### PR TITLE
add PyTorch SDPA fallback with sliding window support

### DIFF
--- a/train.py
+++ b/train.py
@@ -17,11 +17,17 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from kernels import get_kernel
-cap = torch.cuda.get_device_capability()
-# varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs
-repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
-fa3 = get_kernel(repo).flash_attn_interface
+# Try FA3 (Hopper-native or community fallback), fall back to PyTorch SDPA
+USE_FA3 = True
+try:
+    from kernels import get_kernel
+    cap = torch.cuda.get_device_capability()
+    repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
+    fa3 = get_kernel(repo).flash_attn_interface
+except Exception:
+    USE_FA3 = False
+    fa3 = None
+    print("FA3 not available, using PyTorch SDPA fallback")
 
 from constants import MAX_SEQ_LEN, TIME_BUDGET
 from prepare import Tokenizer, make_dataloader, evaluate_bpb
@@ -91,7 +97,31 @@ class CausalSelfAttention(nn.Module):
         q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
         q, k = norm(q), norm(k)
 
-        y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        if USE_FA3:
+            y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        else:
+            # SDPA expects (B, H, T, D)
+            q = q.transpose(1, 2)
+            k = k.transpose(1, 2)
+            v = v.transpose(1, 2)
+            # GQA head expansion
+            if self.n_kv_head < self.n_head:
+                r = self.n_head // self.n_kv_head
+                k = k.repeat_interleave(r, dim=1)
+                v = v.repeat_interleave(r, dim=1)
+            # Sliding window causal attention
+            ws = window_size[0]
+            if 0 < ws < T:
+                pos = torch.arange(T, device=q.device)
+                mask = (pos.unsqueeze(0) <= pos.unsqueeze(1)) & \
+                       (pos.unsqueeze(0) >= pos.unsqueeze(1) - ws + 1)
+                attn_mask = torch.zeros(T, T, device=q.device, dtype=q.dtype)
+                attn_mask.masked_fill_(~mask, float('-inf'))
+                y = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+            else:
+                y = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+            y = y.transpose(1, 2)
+
         y = y.contiguous().view(B, T, -1)
         y = self.c_proj(y)
         return y


### PR DESCRIPTION
## Summary

Adds a graceful fallback to PyTorch's `scaled_dot_product_attention` when Flash Attention 3 kernels are unavailable (e.g. Turing/Volta GPUs, or when the `kernels` package fails to build).

## Changes

**FA3 import** (module level):
- Wrap the FA3 kernel import in a try/except
- Set `USE_FA3 = False` on failure instead of crashing the script
- Print a warning so the user knows SDPA is being used

**CausalSelfAttention.forward()**:
- When `USE_FA3 = True`: behavior is unchanged (FA3 path)
- When `USE_FA3 = False`: uses `F.scaled_dot_product_attention` with:
  - Correct tensor layout transpose: `(B,T,H,D)`  `(B,H,T,D)`
  - GQA head expansion via `repeat_interleave` when `n_kv_head < n_head`
  - **Sliding window causal mask** construction for the `SSSL` window pattern, so short-window layers still use half-context attention (unlike PR #1 which fell back to full causal masking)

## Key difference from PR #1

PR #1 also added an SDPA fallback but noted: *'The SDPA fallback does not support sliding window attention, so it uses full causal masking.'* This PR constructs a proper sliding window + causal attention mask, preserving the intended attention pattern and keeping results comparable to FA3 runs.

## Testing

- No changes to constants.py or prepare.py
- The FA3 path is completely unchanged when FA3 is available
- The SDPA path handles all cases: full causal (L layers) and windowed causal (S layers)

Closes #3