### PR TITLE
auto-detect GPU for accurate MFU calculation

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,19 @@ torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
 device = torch.device("cuda")
 autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
-H100_BF16_PEAK_FLOPS = 989.5e12
+
+# BF16 peak FLOPS by compute capability (theoretical, per-GPU)
+_GPU_BF16_PEAK_FLOPS = {
+    (9, 0): 989.5e12,  # H100 SXM
+    (8, 9): 165.2e12,  # RTX 4090 / Ada Lovelace
+    (8, 6): 119.5e12,  # RTX 3090 Ti (FP16 tensor)
+    (8, 0): 312e12,    # A100 SXM
+    (7, 5): 65.1e12,   # RTX 2080 Ti (FP16 tensor)
+    (7, 0): 125e12,    # V100 SXM2 (FP16 tensor)
+}
+_cap = torch.cuda.get_device_capability()
+GPU_PEAK_FLOPS = _GPU_BF16_PEAK_FLOPS.get(_cap, 989.5e12)
+print(f"GPU: {torch.cuda.get_device_name()} (sm_{_cap[0]}{_cap[1]}), peak FLOPS: {GPU_PEAK_FLOPS:.1e}")
 
 tokenizer = Tokenizer.from_directory()
 vocab_size = tokenizer.get_vocab_size()
@@ -585,7 +597,7 @@ while True:
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
     pct_done = 100 * progress
     tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
-    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
+    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / GPU_PEAK_FLOPS
     remaining = max(0, TIME_BUDGET - total_training_time)
 
     print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
@@ -616,7 +628,7 @@ with autocast_ctx:
 # Final summary
 t_end = time.time()
 startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / GPU_PEAK_FLOPS if total_training_time > 0 else 0
 peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
 print("---")


### PR DESCRIPTION
## Problem

MFU (Model FLOPS Utilization) is hardcoded against H100 SXM peak FLOPS (989.5 TFLOPS):

\\\python
H100_BF16_PEAK_FLOPS = 989.5e12
\\\

After PR #2 added non-Hopper GPU support, this metric became misleading on other hardware  an A100 would show ~3x inflated MFU, an RTX 4090 ~6x.

## Changes

- Replace the single hardcoded constant with a lookup table keyed by \	orch.cuda.get_device_capability()\
- Covers: H100 (sm_90), A100 (sm_80), RTX 4090/Ada (sm_89), RTX 3090 Ti (sm_86), RTX 2080 Ti (sm_75), V100 (sm_70)
- Falls back to H100 value for unknown GPUs
- Prints detected GPU name and peak FLOPS at startup

## Scope

+15/-3 lines. Only changes the FLOPS constant and its two usage sites; training logic is untouched.

Fixes #5