### PR TITLE
reduce rotary embedding buffer from 10x to 1x sequence length

### DIFF
--- a/train.py
+++ b/train.py
@@ -142,7 +142,7 @@ class GPT(nn.Module):
             for i in range(config.n_layer) if has_ve(i, config.n_layer)
         })
         # Rotary embeddings
-        self.rotary_seq_len = config.sequence_len * 10
+        self.rotary_seq_len = config.sequence_len
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.register_buffer("cos", cos, persistent=False)
         self.register_buffer("sin", sin, persistent=False)


### PR DESCRIPTION
## Problem

Rotary cos/sin buffers are pre-allocated for \sequence_len * 10 = 20480\ positions:

\\\python
self.rotary_seq_len = config.sequence_len * 10
\\\

Both training and evaluation are bounded by \MAX_SEQ_LEN = 2048\, so the extra 9x buffer entries are never accessed, wasting GPU memory.

## Fix

One-line change: set \self.rotary_seq_len = config.sequence_len\.

This reduces the rotary buffer footprint by ~90% with zero impact on training or evaluation behavior (the \orward()\ method already asserts \T <= self.cos.size(1)\).

Fixes #6