### PR TITLE
save checkpoint before evaluation to prevent training loss on eval crash

### DIFF
--- a/train.py
+++ b/train.py
@@ -608,10 +608,20 @@ print()  # newline after \r training log
 
 total_tokens = step * TOTAL_BATCH_SIZE
 
+# Save checkpoint before eval (in case eval OOMs or crashes)
+checkpoint_path = "checkpoint_pre_eval.pt"
+raw_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+torch.save(raw_model.state_dict(), checkpoint_path)
+print(f"Checkpoint saved to {checkpoint_path}")
+
 # Final eval
 model.eval()
 with autocast_ctx:
     val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+
+# Clean up checkpoint after successful eval
+if os.path.exists(checkpoint_path):
+    os.remove(checkpoint_path)
 
 # Final summary
 t_end = time.time()


### PR DESCRIPTION
## Problem

The training loop runs for the full 5-minute budget, then calls \evaluate_bpb()\. If evaluation crashes (e.g. OOM when the agent has experimented with larger models, or a CUDA error), the entire training run and trained weights are lost with no recovery path.

In the autonomous agent loop where experiments run overnight, this wastes a full experiment cycle per crash.

## Fix

Save a lightweight checkpoint (model \state_dict\ only) immediately after the training loop ends, before evaluation begins:

\\\python
raw_model = model._orig_mod if hasattr(model, '_orig_mod') else model
torch.save(raw_model.state_dict(), 'checkpoint_pre_eval.pt')
\\\

- If evaluation succeeds: checkpoint is cleaned up automatically
- If evaluation crashes: \checkpoint_pre_eval.pt\ survives for weight inspection or metric recovery
- Handles \	orch.compile\'d models by unwrapping via \_orig_mod\

## Scope

+10 lines. No changes to the training loop, model, or evaluation logic.

Fixes #7