### PR TITLE
add optional gradient norm clipping for training stability

### DIFF
--- a/train.py
+++ b/train.py
@@ -446,6 +446,7 @@ ADAM_BETAS = (0.8, 0.95) # Adam beta1, beta2
 WARMUP_RATIO = 0.0      # fraction of time budget for LR warmup
 WARMDOWN_RATIO = 0.5    # fraction of time budget for LR warmdown
 FINAL_LR_FRAC = 0.0     # final LR as fraction of initial
+GRAD_CLIP_NORM = 1.0    # max gradient norm (0.0 = disabled)
 
 # Model size
 DEPTH = 8               # number of transformer layers
@@ -562,6 +563,8 @@ while True:
         if group['kind'] == 'muon':
             group["momentum"] = muon_momentum
             group["weight_decay"] = muon_weight_decay
+    if GRAD_CLIP_NORM > 0:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), GRAD_CLIP_NORM)
     optimizer.step()
     model.zero_grad(set_to_none=True)
 


### PR DESCRIPTION
## Problem

The training loop has no gradient clipping. The only stability guard is a hard exit when \	rain_loss > 100\:

\\\python
if train_loss_f > 100:
    print('FAIL')
    exit(1)
\\\

When the autonomous agent experiments with aggressive hyperparameters (high LR, unusual architectures), a single gradient spike can push the loss past 100 in one step, wasting the entire 5-minute experiment. Gradient clipping would let the training recover from transient spikes instead of immediately diverging.

## Fix

Add a \GRAD_CLIP_NORM\ hyperparameter (default \1.0\) in the optimization section:

\\\python
GRAD_CLIP_NORM = 1.0  # max gradient norm (0.0 = disabled)
\\\

Applied before \optimizer.step()\:

\\\python
if GRAD_CLIP_NORM > 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), GRAD_CLIP_NORM)
\\\

The agent can tune or disable this parameter (\