### PR TITLE
Fix softcap VRAM leak by doing tanh natively in bfloat16

### DIFF
--- a/train.py
+++ b/train.py
@@ -280,13 +280,12 @@ class GPT(nn.Module):
             x = block(x, ve, cos_sin, self.window_sizes[i])
         x = norm(x)
 
-        softcap = 15
+        softcap = 15.0 # Must be a float for bfloat16 division
         logits = self.lm_head(x)
-        logits = logits.float()
         logits = softcap * torch.tanh(logits / softcap)
 
         if targets is not None:
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1),
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)).float(), targets.view(-1),
                                    ignore_index=-1, reduction=reduction)
             return loss
         return logits


### PR DESCRIPTION
### Bug Description
The softcapping logic in [train.py](cci:7://file:///Users/sidharth/Documents/autoresearch/train.py:0:0-0:0) currently casts the `logits` tensor (which has shape `[128, 2048, 8192]`) to `.float()` right before the `tanh` calculation. Because the script forces `autocast` to `bfloat16`, the `logits` tensor takes up **~4.3GB** of VRAM. 

Calling `.float()` instantly allocates a new 32-bit tensor (**8.6GB**) just for the calculation, creating an unnecessary **~12.8GB VRAM spike** in the forward pass.

### The Fix
Since `bfloat16` has the exact same dynamic range as `float32` (max `3.4 x 10^38`), there is zero risk of numerical overflow when passing the base logits into `tanh`. 

By deleting the `.float()` cast, we:
1. Save **~8.5GB** of peak VRAM.
2. Reduce memory bandwidth pressure during the final layer calculation (increasing MFU).

The mandatory downcast to `float32` now only happens explicitly inside `F.cross_entropy` where PyTorch actually requires it for gradient stability.
