### PR TITLE
Fix agent crash blindspot by forcing it to read traceback

### DIFF
--- a/program.md
+++ b/program.md
@@ -98,9 +98,10 @@ LOOP FOREVER (until I wake up and come back in the morning):
 3. git commit
 4. run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
 5. read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
-6. record the results in the tsv
-7. if val_bpb improved (lower), you "advance" the branch, keeping the git commit
-8. if val_bpb is equal or worse, you git reset back to where you started
+6. If the grep output is empty, the run crashed. You MUST run `tail -n 50 run.log` to read the Python stack trace so you can actually diagnose and fix the bug.
+7. record the results in the tsv
+8. if val_bpb improved (lower), you "advance" the branch, keeping the git commit
+9. if val_bpb is equal or worse, you git reset back to where you started
 
 The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
 


### PR DESCRIPTION
Currently, `program.md` instructs the agent to evaluate runs via `grep "^val_bpb:\|^\peak_vram_mb:" run.log`. When a syntax error or OOM crash occurs, this `grep` outputs nothing. Because the agent never explicitly reads the raw log, it never actually sees the Python stack trace. It just hallucinates what the bug might have been, crippling its ability to 'fix it and re-run.'

This PR adds a one-sentence instruction for the agent to run `tail -n 50 run.log` if the grep is empty, ensuring it safely acquires the stack trace to successfully self-heal trivial crashes.