### PR TITLE
Reject invalid negative values for --num-shards

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -373,6 +373,9 @@ if __name__ == "__main__":
     parser.add_argument("--download-workers", type=int, default=8, help="Number of parallel download workers")
     args = parser.parse_args()
 
+    if args.num_shards != -1 and args.num_shards < 1:
+        parser.error("--num-shards must be -1 or a positive integer")
+
     num_shards = MAX_SHARD if args.num_shards == -1 else args.num_shards
 
     print(f"Cache directory: {CACHE_DIR}")


### PR DESCRIPTION
`prepare.py` documents `--num-shards=-1` as the special case for downloading all training shards, but other negative values were silently accepted. In practice, values like `--num-shards -2` result in no training shards being selected, which later causes tokenizer training to fail with a less clear error. This change validates the argument early and surfaces a direct CLI error instead.