### PR TITLE
feat: RTX 3090 (9/24GB) support with SDPA fallback and VRAM optimizations

### DIFF
--- a/train.py
+++ b/train.py
@@ -487,8 +487,8 @@ FINAL_LR_FRAC = 0.0     # final LR as fraction of initial
 
 # Model size
 DEPTH = 8               # number of transformer layers
-DEVICE_BATCH_SIZE = 32   # per-device batch size (reduced for RTX 3090)
-EVAL_BATCH_SIZE = 8      # separate eval batch size (lower to avoid OOM during eval)
+DEVICE_BATCH_SIZE = 32   # reverted to Run 1 baseline (optimal for throughput/VRAM)
+EVAL_BATCH_SIZE = 16     # separate eval batch size (low-risk increase)
 
 # ---------------------------------------------------------------------------
 # Setup: tokenizer, model, optimizer, dataloader


### PR DESCRIPTION
﻿## Summary

Adapt train.py to run without CUDA OOM on RTX 3090 (24GB VRAM) and other non-H100 GPUs.

Only train.py is modified. No changes to prepare.py, pyproject.toml, or the eval harness.

## Results (RTX 3090)

| Metric | Value |
|---|---|
| peak_vram_mb | 9,178 (38% of 24GB) |
| val_bpb | 1.586130 |
| training_seconds | 302.2 |
| total_seconds | 441.9 |
| num_steps | 61 |
| depth | 8 (unchanged) |

## Changes

### VRAM Optimizations

1. Softcap logits: removed early logits.float() before tanh. Softcap/tanh now runs in bf16, fp32 cast only at cross_entropy. Eliminates --2GB transient spike.
2. Separate EVAL_BATCH_SIZE=8: eval no longer uses DEVICE_BATCH_SIZE. Includes OOM fallback (8->4->2) with torch.cuda.empty_cache() between retries.
3. Pre-eval checkpoint: saves checkpoint_pre_eval.pt before eval, so trained weights survive if eval OOMs.
4. Rotary preallocation: sequence_len * 10 -> sequence_len. The 10x buffer is unnecessary since MAX_SEQ_LEN is fixed at 2048.
5. Activation checkpointing: wraps each transformer block in torch.utils.checkpoint.checkpoint(..., use_reentrant=False). Trades --10-15% compute overhead for major memory savings (--20+ GB).
6. Microbatch: DEVICE_BATCH_SIZE 128->32. grad_accum_steps adjusts automatically (2->8), preserving the same TOTAL_BATCH_SIZE.
7. Muon optimizer chunking: splits shape-groups into sub-groups of <=8 params to reduce transient VRAM peaks during optimizer.step().

### Correctness Fix

1. MFU GPU lookup: replaced hardcoded H100_BF16_PEAK_FLOPS with auto-detection via torch.cuda.get_device_name(). Supports H100, A100, RTX 3090/3080/3070, RTX 4090/4080. Falls back to H100 for unknown GPUs.

### Platform Compatibility

1. FA3 -> SDPA fallback: when kernels-community/flash-attn3 is unavailable (e.g., Windows, non-Hopper GPUs without builds), falls back to F.scaled_dot_product_attention with proper BTHD->BHDT transpose and GQA head repeat. Sliding window is not used on the SDPA path (full causal attention instead).
2. torch.compile -> eager fallback: when Triton is unavailable (Windows), _maybe_compile() wrapper makes torch.compile a no-op. Affects model compilation and the two @torch.compile decorated optimizer functions.

## What's NOT changed

- prepare.py, pyproject.toml, eval harness -- untouched
- - MAX_SEQ_LEN -- untouched
- - TOTAL_BATCH_SIZE -- untouched
- - DEPTH -- still 8 (no model shrinking needed)
- - No new dependencies

### 🔬 Scaling Experiments (Why B=32 and Checkpointing=ON is optimal here)

We ran an ablation study to see if we could push throughput further by trading our 15GB of free VRAM for speed on the RTX 3090.

1. **Baseline (BS=32, EVAL_BS=16):** Checkpointing ON. `VRAM: 9.2GB`. `val_bpb: 1.586`. `Total Time: 441.9s`. `Speed: ~87k tok/sec`.
2. **Disable Checkpointing:** Checkpointing OFF, BS=32. `VRAM: 22.1GB`. `Speed: ~89k tok/sec` initially, but wildly degraded to ~35k tok/sec at the end (likely system/thermal throttling under sustained 22GB load).
3. **Double Batch:** Checkpointing ON, BS=64. `VRAM: 17.8GB`. `Speed: ~73.6k tok/sec`. Perfectly stable, but slightly *slower* than B=32.

**Conclusion:** Scaling the batch size or dropping checkpointing does not yield better throughput. The ceiling is strictly dictated by the software backend (`torch.compile` is disabled on Windows due to lack of `triton`, and FA3 is unavailable for Ampere/Windows, forcing a fallback to eager PyTorch + SDPA).
Thus, `DEVICE_BATCH_SIZE=32`, `EVAL_BATCH_SIZE=16`, with activation checkpointing ON remains the most optimal and stable baseline to train the 50M parameter model on a 24GB consumer GPU without backend optimizations.
