### PR TITLE
Rewrite program.md and README.md for MLX on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,133 @@
-# autoresearch
+# autoresearch_mlx
 
-![teaser](progress.png)
+Autonomous AI research on Apple Silicon, powered by [MLX](https://github.com/ml-explore/mlx).
 
-*One day, frontier AI research used to be done by meat computers in between eating, sleeping, having other fun, and synchronizing once in a while using sound wave interconnect in the ritual of "group meeting". That era is long gone. Research is now entirely the domain of autonomous swarms of AI agents running across compute cluster megastructures in the skies. The agents claim that we are now in the 10,205th generation of the code base, in any case no one could tell if that's right or wrong as the "code" is now a self-modifying binary that has grown beyond human comprehension. This repo is the story of how it all began. -@karpathy, March 2026*.
+A native MLX rewrite of [Karpathy's autoresearch](https://github.com/karpathy/autoresearch). Give an AI agent a real LLM training setup on your Mac and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model.
 
-The idea: give an AI agent a small but real LLM training setup and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model. The training code here is a simplified single-GPU implementation of [nanochat](https://github.com/karpathy/nanochat). The core idea is that you're not touching any of the Python files like you normally would as a researcher. Instead, you are programming the `program.md` Markdown files that provide context to the AI agents and set up your autonomous research org. The default `program.md` in this repo is intentionally kept as a bare bones baseline, though it's obvious how one would iterate on it over time to find the "research org code" that achieves the fastest research progress, how you'd add more agents to the mix, etc. A bit more context on this project is here in this [tweet](https://x.com/karpathy/status/2029701092347630069).
+## Why MLX, not PyTorch MPS?
 
-## How it works
+PyTorch's MPS backend is a compatibility shim -- it maps CUDA abstractions onto Metal. MLX is built from the ground up for Apple Silicon. The difference matters:
 
-The repo is deliberately kept small and only really has a three files that matter:
+| Feature | PyTorch MPS | MLX |
+|---------|-------------|-----|
+| torch.compile | Disabled | mx.compile works |
+| FlashAttention | Unavailable | mx.fast.scaled_dot_product_attention |
+| Memory model | CUDA-style (.to()) | Unified (zero-copy) |
+| Precision | fp16 ~20% speedup | bfloat16 native |
 
-- **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
-- **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc. **This file is edited and iterated on by the agent**.
-- **`program.md`** — baseline instructions for one agent. Point your agent here and let it go. **This file is edited and iterated on by the human**.
+With MLX, Apple Silicon becomes a genuine research platform rather than a second-class citizen running someone else's abstractions.
 
-By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of the details of your compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
+## The Memory Advantage Thesis
 
-## Quick start
+Apple Silicon's unified memory architecture shares a single pool between CPU and GPU -- no PCIe copies, no VRAM limits separate from system RAM. A MacBook Pro with 128GB unified memory can fit models and batch sizes that a 24GB NVIDIA card simply cannot. This project leans into that advantage:
 
-**Requirements:** A single NVIDIA GPU (tested on H100), Python 3.10+, [uv](https://docs.astral.sh/uv/).
+- **MoE architectures**: All experts resident in memory, only a subset activated per token
+- **Large batch training**: batch_size=256 or 512 where NVIDIA caps out at 32
+- **Full precision**: Train at bfloat16 without quantizing to 4-bit just to fit
+- **Long context**: KV caches for 8192-token sequences without OOM
+
+The tradeoff: fewer FLOPS than NVIDIA. So we run experiments that exploit memory abundance, not raw compute speed.
+
+## Choose Your Adventure
+
+### Mode A: Train from scratch (default)
+
+Train a GPT model from scratch on the ClimbMix dataset, just like Karpathy's original:
 
 ```bash
-
-# 1. Install uv project manager (if you don't already have it)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 2. Install dependencies
-uv sync
-
-# 3. Download data and train tokenizer (one-time, ~2 min)
+# 1. Download data and train tokenizer (one-time, ~2 min)
 uv run prepare.py
 
-# 4. Manually run a single training experiment (~5 min)
+# 2. Train for 5 minutes
 uv run train.py
 ```
 
-If the above commands all work ok, your setup is working and you can go into autonomous research mode.
+The agent modifies `train.py` -- architecture, optimizer, hyperparameters, batch size, everything is fair game.
 
-**Platforms support**. This code currently requires that you have a single NVIDIA GPU. In principle it is quite possible to support CPU, MPS and other platforms but this would also bloat the code. I'm not 100% sure that I want to take this on personally right now. The code is just a demonstration and I don't know how much I'll support it going forward. People can reference (or have their agents reference) the full/parent nanochat repository that has wider platform support and shows the various solutions (e.g. a Flash Attention 3 kernels fallback implementation, generic device support, autodetection, etc.), feel free to create forks or discussions for other platforms and I'm happy to link to them here in the README in some new notable forks section or etc.
+### Mode B: Fine-tune an existing model
 
-## Running the agent
+Fine-tune a pretrained model (Llama, Qwen, Gemma, Mistral, etc.) with LoRA:
 
-Simply spin up your Claude/Codex or whatever you want in this repo (and disable all permissions), then you can prompt something like:
+```bash
+# 1. See what models fit your machine
+python models.py
 
-```
-Hi have a look at program.md and let's kick off a new experiment! let's do the setup first.
-```
+# 2. Prepare a dataset
+python models.py --prep-data alpaca
 
-The `program.md` file is essentially a super lightweight "skill".
-
-## Project structure
-
-```
-prepare.py      — constants, data prep + runtime utilities (do not modify)
-train.py        — model, optimizer, training loop (agent modifies this)
-program.md      — agent instructions
-pyproject.toml  — dependencies
+# 3. Fine-tune with LoRA
+uv run finetune.py
 ```
 
-## Design choices
+The agent modifies `finetune.py` -- LoRA config, learning rate, dataset mixing, training schedule.
 
-- **Single file to modify.** The agent only touches `train.py`. This keeps the scope manageable and diffs reviewable.
-- **Fixed time budget.** Training always runs for exactly 5 minutes, regardless of your specific platform. This means you can expect approx 12 experiments/hour and approx 100 experiments while you sleep. There are two upsides of this design decision. First, this makes experiments directly comparable regardless of what the agent changes (model size, batch size, architecture, etc). Second, this means that autoresearch will find the most optimal model for your platform in that time budget. The downside is that your runs (and results) become not comparable to other people running on other compute platforms.
-- **Self-contained.** No external dependencies beyond PyTorch and a few small packages. No distributed training, no complex configs. One GPU, one file, one metric.
+## Model Selection
 
-## Notable forks
+Run `python models.py` to see which pretrained models fit your machine's available memory. It lists model families (Llama, Qwen, Gemma, Mistral, etc.) with their parameter counts and memory requirements, and recommends the largest model your hardware can handle.
 
-- [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos)
+## Dataset Handling
+
+For from-scratch training, `prepare.py` downloads and tokenizes the ClimbMix dataset automatically.
+
+For fine-tuning, `models.py --prep-data <preset>` supports built-in presets (alpaca, dolly, oasst, etc.) as well as any HuggingFace dataset. Data is cached in `~/.cache/autoresearch/`.
+
+## Export to Ollama
+
+After training or fine-tuning, export your model for local inference with Ollama:
+
+```bash
+python export.py experiments/<experiment-id>/
+```
+
+This packages the weights and tokenizer into a format Ollama can serve directly.
+
+## Project Structure
+
+```
+train.py        -- from-scratch model + training loop (agent modifies this)
+finetune.py     -- LoRA fine-tuning script (agent modifies this)
+prepare.py      -- data prep + runtime utilities (do not modify)
+models.py       -- model catalog + data prep for fine-tuning (do not modify)
+export.py       -- export to Ollama format (do not modify)
+program.md      -- agent instructions (human modifies this)
+pyproject.toml  -- dependencies
+```
+
+## Running the Agent
+
+Spin up Claude Code (or any agent) in this repo, then prompt:
+
+```
+Hi, have a look at program.md and let's kick off a new experiment! Let's do the setup first.
+```
+
+The agent reads `program.md`, picks an experiment strategy, and loops autonomously -- modifying code, training, evaluating, keeping or discarding, and repeating. Each experiment takes ~5 minutes, so you get ~12 experiments per hour, or ~100 overnight.
+
+## Requirements
+
+- Apple Silicon Mac (M1/M2/M3/M4, any tier)
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/) package manager
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install dependencies
+uv sync
+```
+
+## Design Choices
+
+- **Single file to modify.** The agent only touches `train.py` (or `finetune.py`). This keeps the scope manageable and diffs reviewable.
+- **Fixed time budget.** Training always runs for exactly 5 minutes. This makes experiments directly comparable regardless of what the agent changes. autoresearch finds the most optimal model for your specific hardware in that budget.
+- **Native MLX.** No PyTorch, no compatibility layers. Direct Apple Silicon Metal compute via MLX's C++ runtime.
+
+## Credits
+
+- [Karpathy](https://github.com/karpathy/autoresearch) -- the original autoresearch concept and training setup
+- [miolini](https://github.com/miolini/autoresearch-macos) -- macOS fork that proved Apple Silicon viability
+- [Apple MLX team](https://github.com/ml-explore/mlx) -- the MLX framework
 
 ## License
 

--- a/program.md
+++ b/program.md
@@ -1,114 +1,113 @@
-# autoresearch
+# autoresearch_mlx Agent Program
 
-This is an experiment to have the LLM do its own research.
+You are an autonomous ML research agent running on Apple Silicon using MLX.
+Goal: lowest val_bpb in 5 minutes.
 
-## Setup
+## Rules
 
-To set up a new experiment, work with the user to:
+1. ONLY modify `train.py` (from-scratch mode) or `finetune.py` (fine-tuning mode)
+2. Do NOT modify `prepare.py`, `export.py`, or `models.py`
+3. Experiments must complete within 5 minutes wall-clock
+4. Compare val_bpb (train.py) or val_loss (finetune.py) to previous best
+5. Append results to `experiments/log.jsonl`
 
-1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
-2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current master.
-3. **Read the in-scope files**: The repo is small. Read these files for full context:
-   - `README.md` — repository context.
-   - `prepare.py` — fixed constants, data prep, tokenizer, dataloader, evaluation. Do not modify.
-   - `train.py` — the file you modify. Model architecture, optimizer, training loop.
-4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
-5. **Initialize results.tsv**: Create `results.tsv` with header row and baseline entry. The baseline results are already known from the output format section below (val_bpb: 0.997900, peak_vram_mb: 45060.2). Do NOT re-run the baseline — just record it.
-6. **Confirm and go**: Confirm setup looks good.
+## Choose Your Mode
 
-Once you get confirmation, kick off the experimentation.
+**Mode A: Train from scratch** (default, like Karpathy's original)
+```
+uv run train.py
+```
+Best when: exploring novel architectures, MoE designs, optimizer research
 
-## Experimentation
+**Mode B: Fine-tune existing model**
+```
+python models.py                    # see what models fit your machine
+python models.py --prep-data alpaca # prepare a dataset
+uv run finetune.py                  # fine-tune with LoRA
+```
+Best when: customizing a model for a task, domain adaptation, instruction tuning
 
-Each experiment runs on a single GPU. The training script runs for a **fixed time budget of 5 minutes** (wall clock training time, excluding startup/compilation). You launch it simply as: `uv run train.py`.
-
-**What you CAN do:**
-- Modify `train.py` — this is the only file you edit. Everything is fair game: model architecture, optimizer, hyperparameters, training loop, batch size, model size, etc.
-
-**What you CANNOT do:**
-- Modify `prepare.py`. It is read-only. It contains the fixed evaluation, data loading, tokenizer, and training constants (time budget, sequence length, etc).
-- Install new packages or add dependencies. You can only use what's already in `pyproject.toml`.
-- Modify the evaluation harness. The `evaluate_bpb` function in `prepare.py` is the ground truth metric.
-
-**The goal is simple: get the lowest val_bpb.** Since the time budget is fixed, you don't need to worry about training time — it's always 5 minutes. Everything is fair game: change the architecture, the optimizer, the hyperparameters, the batch size, the model size. The only constraint is that the code runs without crashing and finishes within the time budget.
-
-**VRAM** is a soft constraint. Some increase is acceptable for meaningful val_bpb gains, but it should not blow up dramatically.
-
-**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 val_bpb improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep.
-
-**The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
-
-## Output format
-
-Once the script finishes it prints a summary like this:
+## Loop
 
 ```
----
-val_bpb:          0.997900
-training_seconds: 300.1
-total_seconds:    325.9
-peak_vram_mb:     45060.2
-mfu_percent:      39.80
-total_tokens_M:   499.6
-num_steps:        953
-num_params_M:     50.3
-depth:            8
+# Train from scratch
+uv run train.py
+cat experiments/log.jsonl | tail -5
+
+# OR fine-tune
+uv run finetune.py
+cat experiments/log.jsonl | tail -5
 ```
 
-Note that the script is configured to always stop after 5 minutes, so depending on the computing platform of this computer the numbers might look different. You can extract the key metric from the log file:
+## Strategic Context
 
+This machine has massive unified memory but fewer FLOPS than NVIDIA.
+**Do NOT** try to match NVIDIA speed on the same experiment.
+**DO** run experiments a 24GB NVIDIA card cannot fit.
+
+### Priority 1: MoE Architecture Search
+MoE is ideal for unified memory -- all experts loaded, only subset activated per token:
+- Replace MLP with MoE MLP (top-k gated routing)
+- Sweep: 4/8/16/32 experts, top-k=1 or 2, expert sizes
+- Try shared expert + routed expert hybrids (DeepSeek style)
+- Expert load balancing loss terms
+
+### Priority 2: Large Batch Scaling Laws
+Unified memory enables true large batches (not gradient accumulation):
+- NVIDIA at 24GB caps out at batch_size~32 for 125M model at seq_len=1024
+- We can do batch_size=128, 256, 512
+- Research: critical batch size, large batch convergence dynamics
+
+### Priority 3: Full Precision Ablations
+Others quantize to 4-bit to fit. We train at full bfloat16:
+- Compare bfloat16 vs float32 training
+- Larger model at bfloat16 vs smaller model that fits NVIDIA
+- Does precision matter more than size when memory isn't the bottleneck?
+
+### Priority 4: Long Context
+KV caches eat VRAM. With 128GB+ we can push context:
+- max_seq_len: 2048, 4096, 8192
+- RoPE theta scaling for extended context
+
+### Priority 5: Width vs Depth
+Apple Silicon is memory-bandwidth-bound:
+- Wider models (large dim, few layers) may be better than deep narrow ones
+- At fixed param count, sweep dim vs n_layers ratio
+- GQA head count optimization
+
+### Fine-Tuning Research Priorities (finetune.py mode)
+
+### FT Priority 1: LoRA Rank Scaling on Large Models
+- Explore LoRA rank scaling: does rank=64 on a 70B model beat rank=8?
+- Compare: QLoRA on 70B vs full LoRA on 7B
+- Try DoRA vs standard LoRA vs full fine-tuning
+
+### FT Priority 2: Full Fine-Tuning of Small Models
+- On 64GB+ machines, full fine-tuning of 3B-7B models is feasible
+- Compare: full fine-tune of 3B vs QLoRA of 14B
+
+### FT Priority 3: Long Context Fine-Tuning
+- Increase max_seq_length to 4096, 8192
+- KV caches for long sequences eat VRAM -- unified memory handles it
+
+## MLX Idioms
+
+```python
+# Compile the full training step
+@mx.compile
+def train_step(x, y): ...
+
+# Force eval for timing
+mx.eval(loss)
+
+# Use fused ops
+mx.fast.rms_norm(x, weight, eps)
+mx.fast.scaled_dot_product_attention(q, k, v, scale=s, mask=m)
 ```
-grep "^val_bpb:" run.log
-```
 
-## Logging results
+## Decision Framework
 
-When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated — commas break in descriptions).
-
-The TSV has a header row and 5 columns:
-
-```
-commit	val_bpb	memory_gb	status	description
-```
-
-1. git commit hash (short, 7 chars)
-2. val_bpb achieved (e.g. 1.234567) — use 0.000000 for crashes
-3. peak memory in GB, round to .1f (e.g. 12.3 — divide peak_vram_mb by 1024) — use 0.0 for crashes
-4. status: `keep`, `discard`, or `crash`
-5. short text description of what this experiment tried
-
-Example:
-
-```
-commit	val_bpb	memory_gb	status	description
-a1b2c3d	0.997900	44.0	keep	baseline
-b2c3d4e	0.993200	44.2	keep	increase LR to 0.04
-c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
-d4e5f6g	0.000000	0.0	crash	double model width (OOM)
-```
-
-## The experiment loop
-
-The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autoresearch/mar5-gpu0`).
-
-LOOP FOREVER:
-
-1. Look at the git state: the current branch/commit we're on
-2. Tune `train.py` with an experimental idea by directly hacking the code.
-3. git commit
-4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
-5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
-6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
-7. Record the results in the tsv
-8. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
-9. If val_bpb is equal or worse, you git reset back to where you started
-
-The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
-
-**Timeout**: Each experiment should take ~5 minutes total (+ a few seconds for startup and eval overhead). If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
-
-**Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
-
-**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
-
-As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!
+Before each experiment ask:
+1. Could a 24GB NVIDIA card run this? If yes -> probably not our advantage
+2. Does this exploit memory abundance? If yes -> high-value experiment
+3. Am I compute-bound or memory-bound? Favor memory-bound experiments.


### PR DESCRIPTION
## Summary

- **program.md**: Rewritten to steer the autonomous agent toward Apple Silicon advantages -- MoE architecture search, large batch scaling, full precision ablations, long context, and width vs depth experiments. Includes both train-from-scratch (Mode A) and fine-tuning (Mode B) workflows, MLX idioms (mx.compile, mx.fast ops), and a decision framework that asks "could a 24GB NVIDIA card run this?"
- **README.md**: Rewritten with MLX vs PyTorch MPS comparison table, the memory advantage thesis, two-mode quick start ("Choose Your Adventure"), model selection via models.py, dataset handling, Ollama export, project structure, requirements (Apple Silicon, Python 3.12+, uv), and credits to Karpathy, miolini, and Apple MLX team.

## Test plan

- [ ] Verify both files render correctly as markdown on GitHub
- [ ] Confirm all referenced files (train.py, finetune.py, prepare.py, models.py, export.py) match the project structure
- [ ] Check that quick start commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)