### PR TITLE
Propose adding matt-langston/autoresearch to notable forks (DGX Spark support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you're going to be using autoresearch on Apple Macbooks in particular, I'd re
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx)
+- [matt-langston/autoresearch](https://github.com/matt-langston/autoresearch)
 
 ## License
 


### PR DESCRIPTION
fork: https://github.com/matt-langston/autoresearch
associated write up: https://github.com/matt-langston/autoresearch/discussions/1

It supports one or more DGX Sparks working together.