### PR TITLE
Harden input validation in prepare.py

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -90,6 +90,10 @@ def download_single_shard(index):
 
 def download_data(num_shards, download_workers=8):
     """Download training shards + pinned validation shard."""
+    if num_shards < 0:
+        raise ValueError("num_shards must be >= 0")
+    if download_workers < 1:
+        raise ValueError("download_workers must be >= 1")
     os.makedirs(DATA_DIR, exist_ok=True)
     num_train = min(num_shards, MAX_SHARD)
     ids = list(range(num_train))
@@ -372,6 +376,11 @@ if __name__ == "__main__":
     parser.add_argument("--num-shards", type=int, default=10, help="Number of training shards to download (-1 = all). Val shard is always pinned.")
     parser.add_argument("--download-workers", type=int, default=8, help="Number of parallel download workers")
     args = parser.parse_args()
+
+    if args.num_shards < -1:
+        parser.error("num_shards must be -1 (all) or >= 0")
+    if args.download_workers < 1:
+        parser.error("download_workers must be >= 1")
 
     num_shards = MAX_SHARD if args.num_shards == -1 else args.num_shards
 


### PR DESCRIPTION

## Summary
Adds defensive validation for `prepare.py` so invalid CLI and function arguments fail fast with clear errors instead of causing confusing downstream behavior. No change to training or model logic.

## Changes

### 1. Validation in `download_data()`
- Require `num_shards >= 0`; raise `ValueError("num_shards must be >= 0")` otherwise.
- Require `download_workers >= 1`; raise `ValueError("download_workers must be >= 1")` otherwise.

### 2. CLI validation after `parse_args()`
- Reject `--num-shards` when < -1 (e.g. `-2`); allow `-1` for "all shards".
- Reject `--download-workers` when < 1 (e.g. `0`).

Invalid flags now produce immediate, clear `argparse` errors instead of obscure downstream failures.

## Why
- Improves reliability for humans and automation (e.g. scripts/agents).
- Keeps the change small and low-risk: data/tokenizer entrypoint only, no training or model code touched.

## Testing
- `python -m py_compile prepare.py` passes.
- Invalid usage: `python prepare.py --num-shards -2` and `python prepare.py --download-workers 0` both exit with clear error messages.