### PR TITLE
fix: replace pickle with JSON for tokenizer serialization

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -13,8 +13,9 @@ import os
 import sys
 import time
 import math
+import json
+import base64
 import argparse
-import pickle
 from multiprocessing import Pool
 
 import requests
@@ -27,8 +28,8 @@ import torch
 # Constants (fixed, do not modify)
 # ---------------------------------------------------------------------------
 
-MAX_SEQ_LEN = 2048       # context length
-TIME_BUDGET = 300        # training time budget in seconds (5 minutes)
+MAX_SEQ_LEN = 2048  # context length
+TIME_BUDGET = 300  # training time budget in seconds (5 minutes)
 EVAL_TOKENS = 40 * 524288  # number of tokens for val eval
 
 # ---------------------------------------------------------------------------
@@ -39,7 +40,7 @@ CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "autoresearch")
 DATA_DIR = os.path.join(CACHE_DIR, "data")
 TOKENIZER_DIR = os.path.join(CACHE_DIR, "tokenizer")
 BASE_URL = "https://huggingface.co/datasets/karpathy/climbmix-400b-shuffle/resolve/main"
-MAX_SHARD = 6542 # the last datashard is shard_06542.parquet
+MAX_SHARD = 6542  # the last datashard is shard_06542.parquet
 VAL_SHARD = MAX_SHARD  # pinned validation shard (shard_06542)
 VAL_FILENAME = f"shard_{VAL_SHARD:05d}.parquet"
 VOCAB_SIZE = 8192
@@ -53,6 +54,7 @@ BOS_TOKEN = "<|reserved_0|>"
 # ---------------------------------------------------------------------------
 # Data download
 # ---------------------------------------------------------------------------
+
 
 def download_single_shard(index):
     """Download one parquet shard with retries. Returns True on success."""
@@ -84,7 +86,7 @@ def download_single_shard(index):
                     except OSError:
                         pass
             if attempt < max_attempts:
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
     return False
 
 
@@ -97,7 +99,11 @@ def download_data(num_shards, download_workers=8):
         ids.append(VAL_SHARD)
 
     # Count what's already downloaded
-    existing = sum(1 for i in ids if os.path.exists(os.path.join(DATA_DIR, f"shard_{i:05d}.parquet")))
+    existing = sum(
+        1
+        for i in ids
+        if os.path.exists(os.path.join(DATA_DIR, f"shard_{i:05d}.parquet"))
+    )
     if existing == len(ids):
         print(f"Data: all {len(ids)} shards already downloaded at {DATA_DIR}")
         return
@@ -112,13 +118,19 @@ def download_data(num_shards, download_workers=8):
     ok = sum(1 for r in results if r)
     print(f"Data: {ok}/{len(ids)} shards ready at {DATA_DIR}")
 
+
 # ---------------------------------------------------------------------------
 # Tokenizer training
 # ---------------------------------------------------------------------------
 
+
 def list_parquet_files():
     """Return sorted list of parquet file paths in the data directory."""
-    files = sorted(f for f in os.listdir(DATA_DIR) if f.endswith(".parquet") and not f.endswith(".tmp"))
+    files = sorted(
+        f
+        for f in os.listdir(DATA_DIR)
+        if f.endswith(".parquet") and not f.endswith(".tmp")
+    )
     return [os.path.join(DATA_DIR, f) for f in files]
 
 
@@ -139,11 +151,11 @@ def text_iterator(max_chars=1_000_000_000, doc_cap=10_000):
 
 
 def train_tokenizer():
-    """Train BPE tokenizer using rustbpe, save as tiktoken pickle."""
-    tokenizer_pkl = os.path.join(TOKENIZER_DIR, "tokenizer.pkl")
+    """Train BPE tokenizer using rustbpe, save as JSON (safe, no pickle)."""
+    tokenizer_json = os.path.join(TOKENIZER_DIR, "tokenizer.json")
     token_bytes_path = os.path.join(TOKENIZER_DIR, "token_bytes.pt")
 
-    if os.path.exists(tokenizer_pkl) and os.path.exists(token_bytes_path):
+    if os.path.exists(tokenizer_json) and os.path.exists(token_bytes_path):
         print(f"Tokenizer: already trained at {TOKENIZER_DIR}")
         return
 
@@ -151,7 +163,9 @@ def train_tokenizer():
 
     parquet_files = list_parquet_files()
     if len(parquet_files) < 2:
-        print("Tokenizer: need at least 2 data shards (1 train + 1 val). Download more data first.")
+        print(
+            "Tokenizer: need at least 2 data shards (1 train + 1 val). Download more data first."
+        )
         sys.exit(1)
 
     # --- Train with rustbpe ---
@@ -160,7 +174,9 @@ def train_tokenizer():
 
     tokenizer = rustbpe.Tokenizer()
     vocab_size_no_special = VOCAB_SIZE - len(SPECIAL_TOKENS)
-    tokenizer.train_from_iterator(text_iterator(), vocab_size_no_special, pattern=SPLIT_PATTERN)
+    tokenizer.train_from_iterator(
+        text_iterator(), vocab_size_no_special, pattern=SPLIT_PATTERN
+    )
 
     # Build tiktoken encoding from trained merges
     pattern = tokenizer.get_pattern()
@@ -174,12 +190,20 @@ def train_tokenizer():
         special_tokens=special_tokens,
     )
 
-    # Save tokenizer
-    with open(tokenizer_pkl, "wb") as f:
-        pickle.dump(enc, f)
+    # Save tokenizer components as JSON (safe, no pickle)
+    tokenizer_data = {
+        "name": "rustbpe",
+        "pat_str": pattern,
+        "mergeable_ranks": {
+            base64.b64encode(k).decode("ascii"): v for k, v in mergeable_ranks.items()
+        },
+        "special_tokens": special_tokens,
+    }
+    with open(tokenizer_json, "w") as f:
+        json.dump(tokenizer_data, f)
 
     t1 = time.time()
-    print(f"Tokenizer: trained in {t1 - t0:.1f}s, saved to {tokenizer_pkl}")
+    print(f"Tokenizer: trained in {t1 - t0:.1f}s, saved to {tokenizer_json}")
 
     # --- Build token_bytes lookup for BPB evaluation ---
     print("Tokenizer: building token_bytes lookup...")
@@ -202,9 +226,11 @@ def train_tokenizer():
     assert decoded == test, f"Tokenizer roundtrip failed: {test!r} -> {decoded!r}"
     print(f"Tokenizer: sanity check passed (vocab_size={enc.n_vocab})")
 
+
 # ---------------------------------------------------------------------------
 # Runtime utilities (imported by train.py)
 # ---------------------------------------------------------------------------
+
 
 class Tokenizer:
     """Minimal tokenizer wrapper. Training is handled above."""
@@ -215,8 +241,33 @@ class Tokenizer:
 
     @classmethod
     def from_directory(cls, tokenizer_dir=TOKENIZER_DIR):
-        with open(os.path.join(tokenizer_dir, "tokenizer.pkl"), "rb") as f:
-            enc = pickle.load(f)
+        json_path = os.path.join(tokenizer_dir, "tokenizer.json")
+        pkl_path = os.path.join(tokenizer_dir, "tokenizer.pkl")
+        if os.path.exists(json_path):
+            with open(json_path, "r") as f:
+                data = json.load(f)
+            mergeable_ranks = {
+                base64.b64decode(k): v for k, v in data["mergeable_ranks"].items()
+            }
+            enc = tiktoken.Encoding(
+                name=data["name"],
+                pat_str=data["pat_str"],
+                mergeable_ranks=mergeable_ranks,
+                special_tokens=data["special_tokens"],
+            )
+        elif os.path.exists(pkl_path):
+            print(
+                "WARNING: Loading tokenizer from pickle (unsafe). "
+                "Re-run 'python prepare.py' to regenerate as safe JSON."
+            )
+            import pickle
+
+            with open(pkl_path, "rb") as f:
+                enc = pickle.load(f)
+        else:
+            raise FileNotFoundError(
+                f"No tokenizer found in {tokenizer_dir}. Run 'python prepare.py' first."
+            )
         return cls(enc)
 
     def get_vocab_size(self):
@@ -227,7 +278,11 @@ class Tokenizer:
 
     def encode(self, text, prepend=None, num_threads=8):
         if prepend is not None:
-            prepend_id = prepend if isinstance(prepend, int) else self.enc.encode_single_token(prepend)
+            prepend_id = (
+                prepend
+                if isinstance(prepend, int)
+                else self.enc.encode_single_token(prepend)
+            )
         if isinstance(text, str):
             ids = self.enc.encode_ordinary(text)
             if prepend is not None:
@@ -248,7 +303,7 @@ class Tokenizer:
 def get_token_bytes(device="cpu"):
     path = os.path.join(TOKENIZER_DIR, "token_bytes.pt")
     with open(path, "rb") as f:
-        return torch.load(f, map_location=device)
+        return torch.load(f, map_location=device, weights_only=True)
 
 
 def _document_batches(split, tokenizer_batch_size=128):
@@ -266,9 +321,9 @@ def _document_batches(split, tokenizer_batch_size=128):
             pf = pq.ParquetFile(filepath)
             for rg_idx in range(pf.num_row_groups):
                 rg = pf.read_row_group(rg_idx)
-                batch = rg.column('text').to_pylist()
+                batch = rg.column("text").to_pylist()
                 for i in range(0, len(batch), tokenizer_batch_size):
-                    yield batch[i:i+tokenizer_batch_size], epoch
+                    yield batch[i : i + tokenizer_batch_size], epoch
         epoch += 1
 
 
@@ -296,10 +351,10 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
     row_buffer = torch.empty((B, row_capacity), dtype=torch.long)
     cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=True)
     gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device="cuda")
-    cpu_inputs = cpu_buffer[:B * T].view(B, T)
-    cpu_targets = cpu_buffer[B * T:].view(B, T)
-    inputs = gpu_buffer[:B * T].view(B, T)
-    targets = gpu_buffer[B * T:].view(B, T)
+    cpu_inputs = cpu_buffer[: B * T].view(B, T)
+    cpu_targets = cpu_buffer[B * T :].view(B, T)
+    inputs = gpu_buffer[: B * T].view(B, T)
+    targets = gpu_buffer[B * T :].view(B, T)
 
     while True:
         for row_idx in range(B):
@@ -321,13 +376,19 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
 
                 if best_idx >= 0:
                     doc = doc_buffer.pop(best_idx)
-                    row_buffer[row_idx, pos:pos + len(doc)] = torch.tensor(doc, dtype=torch.long)
+                    row_buffer[row_idx, pos : pos + len(doc)] = torch.tensor(
+                        doc, dtype=torch.long
+                    )
                     pos += len(doc)
                 else:
                     # No doc fits — crop shortest to fill remaining
-                    shortest_idx = min(range(len(doc_buffer)), key=lambda i: len(doc_buffer[i]))
+                    shortest_idx = min(
+                        range(len(doc_buffer)), key=lambda i: len(doc_buffer[i])
+                    )
                     doc = doc_buffer.pop(shortest_idx)
-                    row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
+                    row_buffer[row_idx, pos : pos + remaining] = torch.tensor(
+                        doc[:remaining], dtype=torch.long
+                    )
                     pos += remaining
 
         cpu_inputs.copy_(row_buffer[:, :-1])
@@ -335,9 +396,11 @@ def make_dataloader(tokenizer, B, T, split, buffer_size=1000):
         gpu_buffer.copy_(cpu_buffer, non_blocking=True)
         yield inputs, targets, epoch
 
+
 # ---------------------------------------------------------------------------
 # Evaluation (DO NOT CHANGE — this is the fixed metric)
 # ---------------------------------------------------------------------------
+
 
 @torch.no_grad()
 def evaluate_bpb(model, tokenizer, batch_size):
@@ -355,7 +418,7 @@ def evaluate_bpb(model, tokenizer, batch_size):
     total_bytes = 0
     for _ in range(steps):
         x, y, _ = next(val_loader)
-        loss_flat = model(x, y, reduction='none').view(-1)
+        loss_flat = model(x, y, reduction="none").view(-1)
         y_flat = y.view(-1)
         nbytes = token_bytes[y_flat]
         mask = nbytes > 0
@@ -363,14 +426,27 @@ def evaluate_bpb(model, tokenizer, batch_size):
         total_bytes += nbytes.sum().item()
     return total_nats / (math.log(2) * total_bytes)
 
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Prepare data and tokenizer for autoresearch")
-    parser.add_argument("--num-shards", type=int, default=10, help="Number of training shards to download (-1 = all). Val shard is always pinned.")
-    parser.add_argument("--download-workers", type=int, default=8, help="Number of parallel download workers")
+    parser = argparse.ArgumentParser(
+        description="Prepare data and tokenizer for autoresearch"
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=10,
+        help="Number of training shards to download (-1 = all). Val shard is always pinned.",
+    )
+    parser.add_argument(
+        "--download-workers",
+        type=int,
+        default=8,
+        help="Number of parallel download workers",
+    )
     args = parser.parse_args()
 
     num_shards = MAX_SHARD if args.num_shards == -1 else args.num_shards


### PR DESCRIPTION
Closes #41

## Problem

`prepare.py` uses `pickle.dump`/`pickle.load` for tokenizer serialization. Pickle deserialization executes arbitrary Python code ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), so anyone with write access to `~/.cache/autoresearch/tokenizer/tokenizer.pkl` (shared machines, copied caches, compromised filesystems) can achieve full code execution when `train.py` imports the tokenizer.

Additionally, `torch.load()` is called without `weights_only=True`, which relies on the PyTorch version default for safety — fragile across versions and forks.

## Changes

1. **Replace pickle with JSON** for tokenizer serialization. The `tiktoken.Encoding` object is reconstructed from its components (`pat_str`, `mergeable_ranks`, `special_tokens`) which are all JSON-serializable. Byte keys in `mergeable_ranks` are base64-encoded.

2. **Add `weights_only=True`** to `torch.load()` for `token_bytes.pt`, making the safe behavior explicit regardless of PyTorch version.

3. **Backward compatible**: If only the old `tokenizer.pkl` exists (no `tokenizer.json`), it still loads but prints a warning recommending re-running `prepare.py`. This means existing caches work without breakage.

## What this does NOT change

- No changes to `train.py`, the model, optimizer, or evaluation
- No new dependencies (uses stdlib `json` and `base64`)
- No changes to the tokenizer training logic itself — only the serialization format
- Existing users just need to re-run `python prepare.py` to regenerate the cache as JSON

## Note on formatting

A few cosmetic PEP 8 changes (line length wrapping, blank lines between top-level definitions) were applied by the editor alongside the security changes. The semantic diff is limited to the import block, `train_tokenizer()` save logic, `Tokenizer.from_directory()` load logic, and the `torch.load()` call.