### PR TITLE
reduce rotary embedding buffer to actual sequence length

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,7 +140,7 @@ class GPT(nn.Module):
             for i in range(config.n_layer) if has_ve(i, config.n_layer)
         })
         # Rotary embeddings
-        self.rotary_seq_len = config.sequence_len * 10
+        self.rotary_seq_len = config.sequence_len
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.register_buffer("cos", cos, persistent=False)
         self.register_buffer("sin", sin, persistent=False)


### PR DESCRIPTION
Fixes #6

The rotary cos/sin buffers are pre-computed for `config.sequence_len * 10` (20480 positions), but training and eval never exceed `MAX_SEQ_LEN` (2048). This one-line change removes the 10x factor, reducing the rotary buffer memory by 90%.

This contribution was developed with AI assistance (Claude Code).