### PR TITLE
write eval results to results.json for structured agent consumption

### DIFF
--- a/program.md
+++ b/program.md
@@ -97,8 +97,8 @@ LOOP FOREVER:
 2. Tune `train.py` with an experimental idea by directly hacking the code.
 3. git commit
 4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
-5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
-6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
+5. Read out the results: `cat results.json` (structured JSON written by train.py). Fallback: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
+6. If results.json doesn't exist and the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
 8. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
 9. If val_bpb is equal or worse, you git reset back to where you started

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
 import gc
+import json
 import time
 from dataclasses import dataclass, asdict
 
@@ -627,3 +628,10 @@ print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
 print(f"num_steps:        {step}")
 print(f"num_params_M:     {num_params / 1e6:.1f}")
 print(f"depth:            {DEPTH}")
+
+# Write structured results for reliable agent consumption
+with open("results.json", "w") as f:
+    json.dump({"val_bpb": val_bpb, "training_seconds": round(total_training_time, 1),
+               "total_seconds": round(t_end - t_start, 1), "peak_vram_mb": round(peak_vram_mb, 1),
+               "mfu_percent": round(steady_state_mfu, 2), "num_steps": step,
+               "num_params_M": round(num_params / 1e6, 1), "depth": DEPTH}, f)


### PR DESCRIPTION
Fixes #64

Adds a `results.json` file written after evaluation with the same metrics already printed to stdout. This gives agents a structured, parseable results channel instead of relying on grepping free-form stdout from `run.log`.

- `train.py`: writes `results.json` after the final summary (5 lines, uses stdlib `json`)
- `program.md`: instructs agent to read `results.json` first, fall back to grep

Existing stdout output is unchanged.

This contribution was developed with AI assistance (Claude Code).