### PR TITLE
Add optional pre-verification to skip doomed experiments

### DIFF
--- a/program.md
+++ b/program.md
@@ -107,6 +107,8 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 **Timeout**: Each experiment should take ~5 minutes total (+ a few seconds for startup and eval overhead). If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
 
+**Pre-verification (optional)**: Before running training, you can optionally verify your changes won't crash by running `npx -y tryassay assess . --no-publish --no-review -y`. This takes ~60-90 seconds and extracts implicit claims from the code, checking for shape mismatches, missing imports, API violations, and other issues. If the score is below 50 or critical bugs are found, revert and try a different approach instead of wasting 5 minutes of GPU time on a run that will crash. This requires Node.js 20+ and an `ANTHROPIC_API_KEY` in the environment. Skip this step if neither is available.
+
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
 
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.


### PR DESCRIPTION
## What

Adds an optional pre-verification step to `program.md`. Before spending 5 minutes on a training run, the agent can run a ~75-second check that extracts implicit claims from the code (shape expectations, import requirements, API contracts) and flags changes likely to crash.

## Why

Autonomous overnight runs produce ~100 experiments. Some crash immediately (OOM, shape mismatch, missing import). Each crash still burns 5 minutes of GPU time plus agent context window on stack trace diagnosis.

Pre-verification catches these before training starts.

## Evidence

Ran 12 LLM-generated architectural modifications on an A10G GPU. For each, Claude generated a complete modified `train.py`, verification ran, then training ran regardless to compare predictions vs reality.

| Modification | Verification Score | Bugs Found | Predicted Crash | Actually Crashed |
|---|---|---|---|---|
| GELU → SiLU activation | 85 | 6 | Yes | Yes |
| Add dropout p=0.1 | 60 | 16 | Yes | Yes |
| Double MLP width (8x) | 58 | 10 | Yes | Yes |
| Sliding window attention | 47 | 16 | Yes | Yes |
| RMSNorm replace LayerNorm | 55 | 17 | Yes | Yes |
| 4 layers, n_embd=1024 | 71 | 5 | Yes | Yes |
| MoE 4 experts, top-2 | 50 | 17 | Yes | Yes |

**7/7 runs where verification executed correctly predicted the crash.** 5 additional runs errored on code generation (Claude API failures), not verification.

## Limitations (being honest)

- Every modification in this test crashed. We have 7 true positives but 0 true negatives (no cases where verification correctly passed a good modification). The 100% crash rate likely reflects overly aggressive LLM-generated changes.
- Verification uses an LLM internally, so it can also hallucinate. It's a pre-filter, not a guarantee.
- Requires Node.js 20+ and an `ANTHROPIC_API_KEY`, which won't be available in all environments. The step is marked optional for this reason.
- Adds ~75 seconds per experiment. At 12 experiments/hour, this reduces throughput to ~10/hour. Worth it only if crash rate exceeds ~25%.

## The change

One paragraph added to `program.md` under "Crashes", marked as optional. No new files, no changes to `train.py` or `prepare.py`.

```
npx -y tryassay assess . --no-publish --no-review -y
```

Full experiment data: [results TSV](https://github.com/gtsbahamas/hallucination-reversing-system/tree/main/experiments/autoresearch-llm-experiment)