### PR TITLE
fix off-by-one in steady-state MFU step count

### DIFF
--- a/train.py
+++ b/train.py
@@ -574,7 +574,7 @@ while True:
     t1 = time.time()
     dt = t1 - t0
 
-    if step > 10:
+    if step >= 10:
         total_training_time += dt
 
     # Logging


### PR DESCRIPTION
Align steady-state timing with the existing MFU step count. The loop adds dt before step += 1, so the old condition if step > 10 was excluding steps 0..10, while the final MFU formula already assumes only the first 10 steps are skipped via step - 10. Changing the timing gate to >= 10 makes the timed window and MFU numerator match, and better reflects the apparent intent to exclude the first 10 startup / compile steps.