### PR TITLE
fix off-by-one in steady-state MFU calculation

### DIFF
--- a/train.py
+++ b/train.py
@@ -614,7 +614,7 @@ with autocast_ctx:
 # Final summary
 t_end = time.time()
 startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 11) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
 peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
 print("---")


### PR DESCRIPTION
steady_state_mfu was counting one more step than total_training_time actually timed. The timing gate uses if step > 10 before step is incremented, so steps 0..10 are excluded and the timed step count is step - 11, not step - 10. This changes only the reported MFU and does not affect training.