### PR TITLE
Fix: Add SDPA fallback for older GPUs (e.g. Turing/GTX 1660 Ti)

### DIFF
--- a/train.py
+++ b/train.py
@@ -18,9 +18,14 @@ import torch.nn.functional as F
 
 from kernels import get_kernel
 cap = torch.cuda.get_device_capability()
-# varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs
-repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
-fa3 = get_kernel(repo).flash_attn_interface
+USE_FA3 = cap[0] >= 8 # Hopper, Ada, Ampere
+if USE_FA3:
+    # varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs
+    repo = "varunneal/flash-attention-3" if cap[0] >= 9 else "kernels-community/flash-attn3"
+    try:
+        fa3 = get_kernel(repo).flash_attn_interface
+    except Exception:
+        USE_FA3 = False
 
 from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
 
@@ -89,7 +94,16 @@ class CausalSelfAttention(nn.Module):
         q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
         q, k = norm(q), norm(k)
 
-        y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        if USE_FA3:
+            y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        else:
+            # Fallback to SDPA for < Ampere GPUs or if FA3 kernel import failed
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                is_causal=True
+            ).transpose(1, 2)
         y = y.contiguous().view(B, T, -1)
         y = self.c_proj(y)
         return y


### PR DESCRIPTION
Fixes #87.

Older architectures like Turing do not support FlashAttention-3 kernels, causing crashes during initialization or runtime on devices like the GTX 1660 Ti.

This PR adds an SDPA (Scaled Dot-Product Attention) fallback route when `torch.cuda.get_device_capability()` indicates an architecture earlier than Ampere (compute capability < 8.0) or if the FA3 kernel load fails.

This allows the training script to run on a wider range of consumer hardware.