### PR TITLE
Fix: Save pre-eval checkpoint to recover from crashes (Fixes #7)

### DIFF
--- a/train.py
+++ b/train.py
@@ -620,10 +620,18 @@ print()  # newline after \r training log
 
 total_tokens = step * TOTAL_BATCH_SIZE
 
+# Save pre-eval checkpoint in case eval crashes
+ckpt_path = "pre_eval_checkpoint.pt"
+torch.save(model.state_dict(), ckpt_path)
+
 # Final eval
 model.eval()
 with autocast_ctx:
     val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+
+# Clean up checkpoint on successful eval
+if os.path.exists(ckpt_path):
+    os.remove(ckpt_path)
 
 # Final summary
 t_end = time.time()


### PR DESCRIPTION
Fixes #7 by saving a lightweight `pre_eval_checkpoint.pt` immediately after the training loop finishes. If the evaluation step crashes, the checkpoint survives for inspection. If the evaluation succeeds, the checkpoint is cleaned up to avoid clutter. 

### Changes:
- Added `torch.save(model.state_dict(), ckpt_path)` before `evaluate_bpb`.
- Added cleanup via `os.remove(ckpt_path)` after.

Tested via `python -m py_compile train.py` and visual verification.