### PR TITLE
Fix: Dynamically calculate MFU based on detected GPU (Fixes #5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -459,7 +459,31 @@ torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
 device = torch.device("cuda")
 autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
-H100_BF16_PEAK_FLOPS = 989.5e12
+
+def get_peak_flops():
+    if not torch.cuda.is_available():
+        return 989.5e12
+    device_name = torch.cuda.get_device_name().lower()
+    # Approx BF16/FP16 peak FLOPS
+    if "h100" in device_name:
+        return 989.5e12
+    elif "a100" in device_name:
+        return 312.0e12
+    elif "a10" in device_name and "a100" not in device_name:
+        return 125.0e12
+    elif "rtx 4090" in device_name:
+        return 165.2e12
+    elif "rtx 4080" in device_name:
+        return 97.5e12
+    elif "rtx 3090" in device_name:
+        return 71.0e12
+    elif "l40" in device_name:
+        return 181.0e12
+    else:
+        # Fallback to H100
+        return 989.5e12
+
+PEAK_FLOPS = get_peak_flops()
 
 tokenizer = Tokenizer.from_directory()
 vocab_size = tokenizer.get_vocab_size()
@@ -583,7 +607,7 @@ while True:
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
     pct_done = 100 * progress
     tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
-    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
+    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / PEAK_FLOPS
     remaining = max(0, TIME_BUDGET - total_training_time)
 
     print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
@@ -614,7 +638,7 @@ with autocast_ctx:
 # Final summary
 t_end = time.time()
 startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / PEAK_FLOPS if total_training_time > 0 else 0
 peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
 print("---")


### PR DESCRIPTION
Fixes #5. MFU calculations were previously hardcoded against the H100 theoretical peak FLOPS, resulting in misleading utilization percentages on other hardware like A100s, 3090s, and 4090s.

### Changes:
- Added a `get_peak_flops()` helper string-matching the running device via `torch.cuda.get_device_name()`.
- Added support mappings for H100, A100, A10, RTX 4090, RTX 4080, RTX 3090, and L40/L40s.
- Falls back to existing H100 FLOPS baseline for unknown GPUs to prevent regressions.

Verified using 100% confidence approach.