### PR TITLE
Add ANE training backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ dev/
 
 # Results file
 results.tsv
+
+# ANE build artifacts and data
+ane/train_ane
+ane/*.bin
+ane/*.ckpt
+ane/.arch_hash
+ane/TinyStories_tok32000.tar.gz
+run_ane.log

--- a/README.md
+++ b/README.md
@@ -80,6 +80,69 @@ Seeing as there seems to be a lot of interest in tinkering with autoresearch on 
 
 I think these would be the reasonable hyperparameters to play with. Ask your favorite coding agent for help and copy paste them this guide, as well as the full source code.
 
+## ANE Backend (Apple Neural Engine)
+
+This fork adds an **ANE training backend** that runs transformer training directly on the Apple Neural Engine via reverse-engineered private APIs. No GPU required — trains on the 15.8 TFLOPS ANE available in every Apple Silicon Mac.
+
+Based on [maderix/ANE](https://github.com/maderix/ANE) — the first project to train transformers directly on ANE using Objective-C and raw MIL kernel compilation.
+
+### How it works
+
+- Uses TinyStories dataset with Llama2 32K BPE tokenizer (ANE's native data format)
+- Compiles forward and backward ANE kernels with baked weights, recompiles after each Adam update
+- Uses `exec()` restart to work around ANE's ~100 kernel compile limit per process
+- Metric is `val_loss` (cross-entropy), not `val_bpb` — experiments are compared within this framework
+- Agent edits only `ane/experiment_config.h` (architecture + optimizer hyperparameters)
+
+### Setup
+
+```bash
+# 1. Download TinyStories data (~1 GB)
+cd ane && bash download_data.sh
+
+# 2. Compile the training binary
+make -C ane train_ane
+
+# 3. Run a single experiment (5 minutes)
+python harness_ane.py
+
+# 4. Or run with custom wall time
+ANE_WALL_TIME=60 python harness_ane.py
+```
+
+### Running the autonomous agent
+
+Point Claude at `program_ane.md`:
+
+```
+Hi, have a look at program_ane.md and let's kick off a new ANE experiment!
+```
+
+The agent will modify `ane/experiment_config.h`, run experiments via `harness_ane.py`, and iterate autonomously.
+
+### ANE-specific files
+
+```
+ane/                         # ANE training backend
+├── experiment_config.h      # Agent's ONLY editing target
+├── stories_config.h         # Model config (includes experiment_config.h)
+├── stories_io.h             # IOSurface I/O helpers
+├── stories_mil.h            # MIL kernel generators
+├── stories_cpu_ops.h        # CPU ops (RMSNorm, cross-entropy, Adam)
+├── forward.h                # Forward pass helpers
+├── backward.h               # Backward pass helpers
+├── ane_runtime.h            # ANE runtime wrapper
+├── ane_mil_gen.h             # MIL text generation
+├── model.h                  # Model struct + weight loading
+├── train_ane.m              # Training binary (+wall-time, +val, +JSON)
+├── download_data.sh         # TinyStories data download
+└── Makefile                 # Build train_ane binary
+harness_ane.py               # ANE orchestrator
+program_ane.md               # ANE agent instructions
+```
+
+The original CUDA files (`prepare.py`, `train.py`, `program.md`) remain untouched and work as before if you have a GPU.
+
 ## Notable forks
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)

--- a/ane/Makefile
+++ b/ane/Makefile
@@ -1,0 +1,14 @@
+CC = xcrun clang
+CFLAGS = -O2 -Wall -DACCELERATE_NEW_LAPACK -fobjc-arc
+FRAMEWORKS = -framework Foundation -framework CoreML -framework IOSurface -framework Accelerate
+LDFLAGS = $(FRAMEWORKS) -ldl
+
+HEADERS = experiment_config.h stories_config.h stories_io.h stories_mil.h stories_cpu_ops.h
+
+train_ane: train_ane.m $(HEADERS)
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	rm -f train_ane
+
+.PHONY: clean

--- a/ane/ane_mil_gen.h
+++ b/ane/ane_mil_gen.h
@@ -1,0 +1,208 @@
+// ane_mil_gen.h — Generate MIL text for conv-based linear ops + weight blobs
+#pragma once
+#import <Foundation/Foundation.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+// Build an FP16 weight blob with the required header structure.
+// weights_f32: source weights in row-major [out_ch, in_ch]
+// Returns NSData with header + FP16 weights
+static NSData *mil_build_weight_blob(const float *weights_f32, int out_ch, int in_ch) {
+    NSUInteger wsize = (NSUInteger)out_ch * in_ch * 2; // FP16
+    NSUInteger total = 64 + 64 + wsize; // global header + chunk header + data
+    uint8_t *buf = (uint8_t*)calloc(total, 1);
+    buf[0] = 0x01; buf[4] = 0x02;
+    uint8_t *chunk = buf + 64;
+    chunk[0] = 0xEF; chunk[1] = 0xBE; chunk[2] = 0xAD; chunk[3] = 0xDE;
+    chunk[4] = 0x01;
+    *(uint32_t*)(chunk + 8) = (uint32_t)wsize;   // data_size
+    *(uint32_t*)(chunk + 16) = 128;               // data_offset (from file start)
+    // Convert f32 → fp16 (simple truncation via _Float16)
+    _Float16 *fp16 = (_Float16*)(buf + 128);
+    for (NSUInteger i = 0; i < (NSUInteger)out_ch * in_ch; i++)
+        fp16[i] = (_Float16)weights_f32[i];
+    return [NSData dataWithBytesNoCopy:buf length:total freeWhenDone:YES];
+}
+
+// Generate MIL for a single matmul: y = W @ x (using matmul op, weights as input)
+// Input x: [1, in_ch, spatial] fp32
+// Input W: [1, out_ch, in_ch] fp32
+// Output:  [1, out_ch, spatial] fp32
+static NSString *mil_gen_matmul(int in_ch, int out_ch, int spatial) {
+    return [NSString stringWithFormat:
+        @"program(1.3)\n"
+        "[buildInfo = dict<string, string>({{\"coremlc-component-MIL\", \"3510.2.1\"}, "
+        "{\"coremlc-version\", \"3505.4.1\"}, {\"coremltools-component-milinternal\", \"\"}, "
+        "{\"coremltools-version\", \"9.0\"}})]\n"
+        "{\n"
+        "    func main<ios18>(tensor<fp32, [1, %d, %d]> x, tensor<fp32, [1, %d, %d]> W) {\n"
+        "        string to_fp16 = const()[name = string(\"to_fp16\"), val = string(\"fp16\")];\n"
+        "        tensor<fp16, [1, %d, %d]> x16 = cast(dtype = to_fp16, x = x)[name = string(\"cast_x\")];\n"
+        "        tensor<fp16, [1, %d, %d]> W16 = cast(dtype = to_fp16, x = W)[name = string(\"cast_W\")];\n"
+        "        bool tx = const()[name = string(\"tx\"), val = bool(false)];\n"
+        "        bool ty = const()[name = string(\"ty\"), val = bool(false)];\n"
+        "        tensor<fp16, [1, %d, %d]> y16 = matmul(transpose_x = tx, transpose_y = ty, x = W16, y = x16)[name = string(\"mm\")];\n"
+        "        string to_fp32 = const()[name = string(\"to_fp32\"), val = string(\"fp32\")];\n"
+        "        tensor<fp32, [1, %d, %d]> y = cast(dtype = to_fp32, x = y16)[name = string(\"cast_out\")];\n"
+        "    } -> (y);\n"
+        "}\n",
+        in_ch, spatial, out_ch, in_ch,
+        in_ch, spatial, out_ch, in_ch,
+        out_ch, spatial, out_ch, spatial];
+}
+
+// Keep the baked-weight version for reference (used in inference-only scenarios)
+static NSString *mil_gen_conv(int in_ch, int out_ch, int spatial) {
+    return [NSString stringWithFormat:
+        @"program(1.3)\n"
+        "[buildInfo = dict<string, string>({{\"coremlc-component-MIL\", \"3510.2.1\"}, "
+        "{\"coremlc-version\", \"3505.4.1\"}, {\"coremltools-component-milinternal\", \"\"}, "
+        "{\"coremltools-version\", \"9.0\"}})]\n"
+        "{\n"
+        "    func main<ios18>(tensor<fp32, [1, %d, 1, %d]> x) {\n"
+        "        string c_pad_type = const()[name = string(\"c_pad_type\"), val = string(\"valid\")];\n"
+        "        tensor<int32, [2]> c_strides = const()[name = string(\"c_strides\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        tensor<int32, [4]> c_pad = const()[name = string(\"c_pad\"), val = tensor<int32, [4]>([0, 0, 0, 0])];\n"
+        "        tensor<int32, [2]> c_dilations = const()[name = string(\"c_dilations\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        int32 c_groups = const()[name = string(\"c_groups\"), val = int32(1)];\n"
+        "        string to_fp16 = const()[name = string(\"to_fp16\"), val = string(\"fp16\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> x16 = cast(dtype = to_fp16, x = x)[name = string(\"cast_in\")];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> W = const()[name = string(\"W\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(64)))];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> y16 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = W, x = x16)[name = string(\"conv\")];\n"
+        "        string to_fp32 = const()[name = string(\"to_fp32\"), val = string(\"fp32\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> y = cast(dtype = to_fp32, x = y16)[name = string(\"cast_out\")];\n"
+        "    } -> (y);\n"
+        "}\n",
+        in_ch, spatial, in_ch, spatial,
+        out_ch, in_ch, out_ch, in_ch,
+        out_ch, spatial, out_ch, spatial];
+}
+
+// Generate MIL for fused QKV: 3 parallel convs from same input
+// Input:  [1, dim, 1, S]
+// Outputs: Q[1, dim, 1, S], K[1, dim, 1, S], V[1, dim, 1, S]
+// Weight blob layout: Wq[dim,dim] @ offset 64, Wk @ offset 64+cs, Wv @ offset 64+2*cs
+// where cs = 64 + dim*dim*2
+static NSString *mil_gen_qkv(int dim, int spatial) {
+    NSUInteger cs = 64 + (NSUInteger)dim * dim * 2;
+    return [NSString stringWithFormat:
+        @"program(1.3)\n"
+        "[buildInfo = dict<string, string>({{\"coremlc-component-MIL\", \"3510.2.1\"}, "
+        "{\"coremlc-version\", \"3505.4.1\"}, {\"coremltools-component-milinternal\", \"\"}, "
+        "{\"coremltools-version\", \"9.0\"}})]\n"
+        "{\n"
+        "    func main<ios18>(tensor<fp32, [1, %d, 1, %d]> x) {\n"
+        "        string c_pad_type = const()[name = string(\"c_pad_type\"), val = string(\"valid\")];\n"
+        "        tensor<int32, [2]> c_strides = const()[name = string(\"c_strides\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        tensor<int32, [4]> c_pad = const()[name = string(\"c_pad\"), val = tensor<int32, [4]>([0, 0, 0, 0])];\n"
+        "        tensor<int32, [2]> c_dilations = const()[name = string(\"c_dilations\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        int32 c_groups = const()[name = string(\"c_groups\"), val = int32(1)];\n"
+        "        string to_fp16 = const()[name = string(\"to_fp16\"), val = string(\"fp16\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> x16 = cast(dtype = to_fp16, x = x)[name = string(\"cast_in\")];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> Wq = const()[name = string(\"Wq\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(64)))];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> Wk = const()[name = string(\"Wk\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(%lu)))];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> Wv = const()[name = string(\"Wv\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(%lu)))];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> q16 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = Wq, x = x16)[name = string(\"conv_q\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> k16 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = Wk, x = x16)[name = string(\"conv_k\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> v16 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = Wv, x = x16)[name = string(\"conv_v\")];\n"
+        "        string to_fp32 = const()[name = string(\"to_fp32\"), val = string(\"fp32\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> q = cast(dtype = to_fp32, x = q16)[name = string(\"cast_q\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> k = cast(dtype = to_fp32, x = k16)[name = string(\"cast_k\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> v = cast(dtype = to_fp32, x = v16)[name = string(\"cast_v\")];\n"
+        "    } -> (q, k, v);\n"
+        "}\n",
+        dim, spatial, dim, spatial,
+        dim, dim, dim, dim,
+        dim, dim, dim, dim, (unsigned long)(64 + cs),
+        dim, dim, dim, dim, (unsigned long)(64 + 2*cs),
+        dim, spatial, dim, spatial, dim, spatial,
+        dim, spatial, dim, spatial, dim, spatial];
+}
+
+// Build weight blob for fused QKV (3 weight matrices concatenated)
+static NSData *mil_build_qkv_weight_blob(const float *wq, const float *wk, const float *wv, int dim) {
+    NSUInteger wsize = (NSUInteger)dim * dim * 2;
+    NSUInteger cs = 64 + wsize;
+    NSUInteger total = 64 + 3 * cs;
+    uint8_t *buf = (uint8_t*)calloc(total, 1);
+    buf[0] = 0x01; buf[4] = 0x02;
+    const float *ws[3] = {wq, wk, wv};
+    for (int w = 0; w < 3; w++) {
+        uint8_t *chunk = buf + 64 + w * cs;
+        chunk[0]=0xEF; chunk[1]=0xBE; chunk[2]=0xAD; chunk[3]=0xDE;
+        chunk[4]=0x01;
+        *(uint32_t*)(chunk + 8) = (uint32_t)wsize;
+        *(uint32_t*)(chunk + 16) = (uint32_t)(64 + w * cs + 64); // absolute data offset
+        _Float16 *fp16 = (_Float16*)(chunk + 64);
+        for (NSUInteger i = 0; i < (NSUInteger)dim * dim; i++)
+            fp16[i] = (_Float16)ws[w][i];
+    }
+    return [NSData dataWithBytesNoCopy:buf length:total freeWhenDone:YES];
+}
+
+// Build weight blob for fused FFN up (w1 + w3, both [hidden_dim, dim])
+static NSData *mil_build_ffn_up_weight_blob(const float *w1, const float *w3, int hidden_dim, int dim) {
+    NSUInteger wsize = (NSUInteger)hidden_dim * dim * 2;
+    NSUInteger cs = 64 + wsize;
+    NSUInteger total = 64 + 2 * cs;
+    uint8_t *buf = (uint8_t*)calloc(total, 1);
+    buf[0] = 0x01; buf[4] = 0x02;
+    const float *ws[2] = {w1, w3};
+    for (int w = 0; w < 2; w++) {
+        uint8_t *chunk = buf + 64 + w * cs;
+        chunk[0]=0xEF; chunk[1]=0xBE; chunk[2]=0xAD; chunk[3]=0xDE;
+        chunk[4]=0x01;
+        *(uint32_t*)(chunk + 8) = (uint32_t)wsize;
+        *(uint32_t*)(chunk + 16) = (uint32_t)(64 + w * cs + 64); // absolute data offset
+        _Float16 *fp16 = (_Float16*)(chunk + 64);
+        for (NSUInteger i = 0; i < (NSUInteger)hidden_dim * dim; i++)
+            fp16[i] = (_Float16)ws[w][i];
+    }
+    return [NSData dataWithBytesNoCopy:buf length:total freeWhenDone:YES];
+}
+
+// Generate MIL for fused FFN up: w1 + w3 parallel convs
+static NSString *mil_gen_ffn_up(int dim, int hidden_dim, int spatial) {
+    NSUInteger cs = 64 + (NSUInteger)hidden_dim * dim * 2;
+    return [NSString stringWithFormat:
+        @"program(1.3)\n"
+        "[buildInfo = dict<string, string>({{\"coremlc-component-MIL\", \"3510.2.1\"}, "
+        "{\"coremlc-version\", \"3505.4.1\"}, {\"coremltools-component-milinternal\", \"\"}, "
+        "{\"coremltools-version\", \"9.0\"}})]\n"
+        "{\n"
+        "    func main<ios18>(tensor<fp32, [1, %d, 1, %d]> x) {\n"
+        "        string c_pad_type = const()[name = string(\"c_pad_type\"), val = string(\"valid\")];\n"
+        "        tensor<int32, [2]> c_strides = const()[name = string(\"c_strides\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        tensor<int32, [4]> c_pad = const()[name = string(\"c_pad\"), val = tensor<int32, [4]>([0, 0, 0, 0])];\n"
+        "        tensor<int32, [2]> c_dilations = const()[name = string(\"c_dilations\"), val = tensor<int32, [2]>([1, 1])];\n"
+        "        int32 c_groups = const()[name = string(\"c_groups\"), val = int32(1)];\n"
+        "        string to_fp16 = const()[name = string(\"to_fp16\"), val = string(\"fp16\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> x16 = cast(dtype = to_fp16, x = x)[name = string(\"cast_in\")];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> W1 = const()[name = string(\"W1\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(64)))];\n"
+        "        tensor<fp16, [%d, %d, 1, 1]> W3 = const()[name = string(\"W3\"), "
+        "val = tensor<fp16, [%d, %d, 1, 1]>(BLOBFILE(path = string(\"@model_path/weights/weight.bin\"), offset = uint64(%lu)))];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> h1 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = W1, x = x16)[name = string(\"conv_w1\")];\n"
+        "        tensor<fp16, [1, %d, 1, %d]> h3 = conv(dilations = c_dilations, groups = c_groups, "
+        "pad = c_pad, pad_type = c_pad_type, strides = c_strides, weight = W3, x = x16)[name = string(\"conv_w3\")];\n"
+        "        string to_fp32 = const()[name = string(\"to_fp32\"), val = string(\"fp32\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> out1 = cast(dtype = to_fp32, x = h1)[name = string(\"cast_h1\")];\n"
+        "        tensor<fp32, [1, %d, 1, %d]> out3 = cast(dtype = to_fp32, x = h3)[name = string(\"cast_h3\")];\n"
+        "    } -> (out1, out3);\n"
+        "}\n",
+        dim, spatial, dim, spatial,
+        hidden_dim, dim, hidden_dim, dim,
+        hidden_dim, dim, hidden_dim, dim, (unsigned long)(64 + cs),
+        hidden_dim, spatial, hidden_dim, spatial,
+        hidden_dim, spatial, hidden_dim, spatial];
+}

--- a/ane/ane_runtime.h
+++ b/ane/ane_runtime.h
@@ -1,0 +1,165 @@
+// ane_runtime.h — Reusable ANE in-memory compile/load/eval wrapper
+// Uses _ANEInMemoryModel via private AppleNeuralEngine.framework
+#pragma once
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <dlfcn.h>
+#import <IOSurface/IOSurface.h>
+
+typedef struct {
+    id model;               // _ANEInMemoryModel
+    IOSurfaceRef *ioInputs;
+    IOSurfaceRef *ioOutputs;
+    id request;             // _ANERequest
+    NSString *tmpDir;
+    int nInputs, nOutputs;
+    size_t *inputBytes;
+    size_t *outputBytes;
+} ANEKernel;
+
+static Class g_ANEDesc, g_ANEInMem, g_ANEReq, g_ANEIO;
+static bool g_ane_loaded = false;
+
+static void ane_init(void) {
+    if (g_ane_loaded) return;
+    dlopen("/System/Library/PrivateFrameworks/AppleNeuralEngine.framework/AppleNeuralEngine", RTLD_NOW);
+    g_ANEDesc  = NSClassFromString(@"_ANEInMemoryModelDescriptor");
+    g_ANEInMem = NSClassFromString(@"_ANEInMemoryModel");
+    g_ANEReq   = NSClassFromString(@"_ANERequest");
+    g_ANEIO    = NSClassFromString(@"_ANEIOSurfaceObject");
+    g_ane_loaded = true;
+}
+
+static IOSurfaceRef ane_create_surface(size_t bytes) {
+    return IOSurfaceCreate((__bridge CFDictionaryRef)@{
+        (id)kIOSurfaceWidth: @(bytes),
+        (id)kIOSurfaceHeight: @1,
+        (id)kIOSurfaceBytesPerElement: @1,
+        (id)kIOSurfaceBytesPerRow: @(bytes),
+        (id)kIOSurfaceAllocSize: @(bytes),
+        (id)kIOSurfacePixelFormat: @0
+    });
+}
+
+// Compile a MIL graph with weight blob into an ANE kernel.
+// milText: NSData of MIL text
+// weightData: NSData of raw weight blob (can be nil)
+// inputSizes/outputSizes: arrays of byte sizes for each I/O tensor
+static ANEKernel *ane_compile(NSData *milText, NSData *weightData,
+                               int nInputs, size_t *inputSizes,
+                               int nOutputs, size_t *outputSizes) {
+    ane_init();
+    NSError *e = nil;
+
+    NSDictionary *wdict = nil;
+    if (weightData) {
+        wdict = @{@"@model_path/weights/weight.bin": @{@"offset": @0, @"data": weightData}};
+    }
+    id desc = ((id(*)(Class,SEL,id,id,id))objc_msgSend)(
+        g_ANEDesc, @selector(modelWithMILText:weights:optionsPlist:),
+        milText, wdict, nil);
+    if (!desc) return NULL;
+
+    id mdl = ((id(*)(Class,SEL,id))objc_msgSend)(
+        g_ANEInMem, @selector(inMemoryModelWithDescriptor:), desc);
+
+    // Pre-populate temp dir with MIL + weights
+    id hx = ((id(*)(id,SEL))objc_msgSend)(mdl, @selector(hexStringIdentifier));
+    NSString *td = [NSTemporaryDirectory() stringByAppendingPathComponent:hx];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtPath:[td stringByAppendingPathComponent:@"weights"]
+        withIntermediateDirectories:YES attributes:nil error:nil];
+    [milText writeToFile:[td stringByAppendingPathComponent:@"model.mil"] atomically:YES];
+    if (weightData)
+        [weightData writeToFile:[td stringByAppendingPathComponent:@"weights/weight.bin"] atomically:YES];
+
+    if (!((BOOL(*)(id,SEL,unsigned int,id,NSError**))objc_msgSend)(
+            mdl, @selector(compileWithQoS:options:error:), 21, @{}, &e)) {
+        fprintf(stderr, "ANE compile failed: %s\n", [[e description] UTF8String]);
+        [fm removeItemAtPath:td error:nil];
+        return NULL;
+    }
+    if (!((BOOL(*)(id,SEL,unsigned int,id,NSError**))objc_msgSend)(
+            mdl, @selector(loadWithQoS:options:error:), 21, @{}, &e)) {
+        fprintf(stderr, "ANE load failed: %s\n", [[e description] UTF8String]);
+        [fm removeItemAtPath:td error:nil];
+        return NULL;
+    }
+
+    ANEKernel *k = calloc(1, sizeof(ANEKernel));
+    k->model = mdl;
+    k->tmpDir = td;
+    k->nInputs = nInputs;
+    k->nOutputs = nOutputs;
+    k->inputBytes = malloc(nInputs * sizeof(size_t));
+    k->outputBytes = malloc(nOutputs * sizeof(size_t));
+    memcpy(k->inputBytes, inputSizes, nInputs * sizeof(size_t));
+    memcpy(k->outputBytes, outputSizes, nOutputs * sizeof(size_t));
+
+    // Create IOSurfaces
+    k->ioInputs = malloc(nInputs * sizeof(IOSurfaceRef));
+    k->ioOutputs = malloc(nOutputs * sizeof(IOSurfaceRef));
+    for (int i = 0; i < nInputs; i++)
+        k->ioInputs[i] = ane_create_surface(inputSizes[i]);
+    for (int i = 0; i < nOutputs; i++)
+        k->ioOutputs[i] = ane_create_surface(outputSizes[i]);
+
+    // Build request
+    NSMutableArray *wIns = [NSMutableArray arrayWithCapacity:nInputs];
+    NSMutableArray *iIdx = [NSMutableArray arrayWithCapacity:nInputs];
+    for (int i = 0; i < nInputs; i++) {
+        [wIns addObject:((id(*)(Class,SEL,IOSurfaceRef))objc_msgSend)(
+            g_ANEIO, @selector(objectWithIOSurface:), k->ioInputs[i])];
+        [iIdx addObject:@(i)];
+    }
+    NSMutableArray *wOuts = [NSMutableArray arrayWithCapacity:nOutputs];
+    NSMutableArray *oIdx = [NSMutableArray arrayWithCapacity:nOutputs];
+    for (int i = 0; i < nOutputs; i++) {
+        [wOuts addObject:((id(*)(Class,SEL,IOSurfaceRef))objc_msgSend)(
+            g_ANEIO, @selector(objectWithIOSurface:), k->ioOutputs[i])];
+        [oIdx addObject:@(i)];
+    }
+    k->request = ((id(*)(Class,SEL,id,id,id,id,id,id,id))objc_msgSend)(
+        g_ANEReq, @selector(requestWithInputs:inputIndices:outputs:outputIndices:weightsBuffer:perfStats:procedureIndex:),
+        wIns, iIdx, wOuts, oIdx, nil, nil, @0);
+
+    return k;
+}
+
+static void ane_write_input(ANEKernel *k, int idx, const void *data, size_t bytes) {
+    IOSurfaceLock(k->ioInputs[idx], 0, NULL);
+    memcpy(IOSurfaceGetBaseAddress(k->ioInputs[idx]), data, bytes);
+    IOSurfaceUnlock(k->ioInputs[idx], 0, NULL);
+}
+
+static void ane_read_output(ANEKernel *k, int idx, void *data, size_t bytes) {
+    IOSurfaceLock(k->ioOutputs[idx], kIOSurfaceLockReadOnly, NULL);
+    memcpy(data, IOSurfaceGetBaseAddress(k->ioOutputs[idx]), bytes);
+    IOSurfaceUnlock(k->ioOutputs[idx], kIOSurfaceLockReadOnly, NULL);
+}
+
+static bool ane_eval(ANEKernel *k) {
+    NSError *e = nil;
+    BOOL ok = ((BOOL(*)(id,SEL,unsigned int,id,id,NSError**))objc_msgSend)(
+        k->model, @selector(evaluateWithQoS:options:request:error:),
+        21, @{}, k->request, &e);
+    if (!ok) {
+        fprintf(stderr, "ANE eval failed: %s\n",
+                e ? [[e description] UTF8String] : "unknown error");
+    }
+    return ok;
+}
+
+static void ane_free(ANEKernel *k) {
+    if (!k) return;
+    NSError *e = nil;
+    ((BOOL(*)(id,SEL,unsigned int,NSError**))objc_msgSend)(
+        k->model, @selector(unloadWithQoS:error:), 21, &e);
+    for (int i = 0; i < k->nInputs; i++) CFRelease(k->ioInputs[i]);
+    for (int i = 0; i < k->nOutputs; i++) CFRelease(k->ioOutputs[i]);
+    [[NSFileManager defaultManager] removeItemAtPath:k->tmpDir error:nil];
+    free(k->ioInputs); free(k->ioOutputs);
+    free(k->inputBytes); free(k->outputBytes);
+    free(k);
+}

--- a/ane/backward.h
+++ b/ane/backward.h
@@ -1,0 +1,308 @@
+// backward.h — Backward pass using CPU matmul (correct gradients) + ANE optional
+#pragma once
+#include "model.h"
+#include "forward.h"
+#include <math.h>
+#include <string.h>
+
+// dW += dy @ x^T — dy: [S, out_dim], x: [S, in_dim], dW: [out_dim, in_dim]
+static void cpu_accum_dW(float *dW, const float *dy, const float *x, int S, int out_dim, int in_dim) {
+    for (int t = 0; t < S; t++)
+        for (int i = 0; i < out_dim; i++)
+            for (int j = 0; j < in_dim; j++)
+                dW[i*in_dim+j] += dy[t*out_dim+i] * x[t*in_dim+j];
+}
+
+// dx = W^T @ dy — W: [out_dim, in_dim], dy: [S, out_dim] → dx: [S, in_dim]
+static void cpu_matmul_backward_dx(const float *W, const float *dy, float *dx,
+                                    int S, int out_dim, int in_dim) {
+    for (int t = 0; t < S; t++)
+        for (int j = 0; j < in_dim; j++) {
+            float sum = 0;
+            for (int i = 0; i < out_dim; i++)
+                sum += W[i*in_dim+j] * dy[t*out_dim+i];
+            dx[t*in_dim+j] = sum;
+        }
+}
+
+static void cpu_rmsnorm_backward(float *dx, const float *dy, const float *x, const float *w,
+                                  int S, int D) {
+    for (int t = 0; t < S; t++) {
+        float ss = 0;
+        for (int i = 0; i < D; i++) ss += x[t*D+i] * x[t*D+i];
+        float rms = sqrtf(ss / D + 1e-5f);
+        float inv_rms = 1.0f / rms;
+        float dot = 0;
+        for (int i = 0; i < D; i++)
+            dot += dy[t*D+i] * w[i] * x[t*D+i];
+        dot /= (D * rms * rms);
+        for (int i = 0; i < D; i++)
+            dx[t*D+i] = dy[t*D+i] * w[i] * inv_rms - x[t*D+i] * dot;
+    }
+}
+
+static inline float silu_backward(float x) {
+    float s = 1.0f / (1.0f + expf(-x));
+    return s * (1.0f + x * (1.0f - s));
+}
+
+static void cpu_attention_backward(float *dq, float *dk, float *dv,
+                                    const float *d_out, const float *q, const float *k, const float *v,
+                                    int S, int n_heads, int head_dim) {
+    float scale = 1.0f / sqrtf((float)head_dim);
+    int D = n_heads * head_dim;
+    float *scores = (float*)malloc(S * sizeof(float));
+    float *dscores = (float*)malloc(S * sizeof(float));
+
+    memset(dq, 0, S * D * sizeof(float));
+    memset(dk, 0, S * D * sizeof(float));
+    memset(dv, 0, S * D * sizeof(float));
+
+    for (int h = 0; h < n_heads; h++) {
+        for (int t = 0; t < S; t++) {
+            // Recompute softmax for this row
+            float mx = -1e9f;
+            for (int s = 0; s <= t; s++) {
+                float dot = 0;
+                for (int i = 0; i < head_dim; i++)
+                    dot += q[t*D + h*head_dim + i] * k[s*D + h*head_dim + i];
+                scores[s] = dot * scale;
+                if (scores[s] > mx) mx = scores[s];
+            }
+            float sm = 0;
+            for (int s = 0; s <= t; s++) { scores[s] = expf(scores[s] - mx); sm += scores[s]; }
+            for (int s = 0; s <= t; s++) scores[s] /= sm;
+
+            // dscores = d_out · v
+            float ds_sum = 0;
+            for (int s = 0; s <= t; s++) {
+                float dot = 0;
+                for (int i = 0; i < head_dim; i++)
+                    dot += d_out[t*D + h*head_dim + i] * v[s*D + h*head_dim + i];
+                dscores[s] = dot;
+                ds_sum += scores[s] * dot;
+            }
+
+            // Softmax backward + scale
+            for (int s = 0; s <= t; s++) {
+                float ds = scores[s] * (dscores[s] - ds_sum) * scale;
+                // dq[t] += ds * k[s]
+                for (int i = 0; i < head_dim; i++)
+                    dq[t*D + h*head_dim + i] += ds * k[s*D + h*head_dim + i];
+                // dk[s] += ds * q[t]
+                for (int i = 0; i < head_dim; i++)
+                    dk[s*D + h*head_dim + i] += ds * q[t*D + h*head_dim + i];
+                // dv[s] += scores[t,s] * d_out[t]
+                for (int i = 0; i < head_dim; i++)
+                    dv[s*D + h*head_dim + i] += scores[s] * d_out[t*D + h*head_dim + i];
+            }
+        }
+    }
+    free(scores); free(dscores);
+}
+
+static void cpu_rope_backward(float *dq, float *dk, int S, int n_heads, int head_dim) {
+    for (int t = 0; t < S; t++)
+        for (int h = 0; h < n_heads; h++)
+            for (int i = 0; i < head_dim; i += 2) {
+                float freq = 1.0f / powf(10000.0f, (float)i / head_dim);
+                float val = t * freq;
+                float cos_v = cosf(val), sin_v = sinf(val);
+                int off = t * n_heads * head_dim + h * head_dim + i;
+                float dq0 = dq[off], dq1 = dq[off+1];
+                dq[off]   = dq0 * cos_v + dq1 * sin_v;
+                dq[off+1] = -dq0 * sin_v + dq1 * cos_v;
+                float dk0 = dk[off], dk1 = dk[off+1];
+                dk[off]   = dk0 * cos_v + dk1 * sin_v;
+                dk[off+1] = -dk0 * sin_v + dk1 * cos_v;
+            }
+}
+
+static void model_clip_gradients(Model *m, float max_norm) {
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, vs = m->cfg.vocab_size;
+    double total_norm_sq = 0;
+    #define ACCUM_NORM(grad, size) do { \
+        for (size_t _i = 0; _i < (size_t)(size); _i++) total_norm_sq += (double)(grad)[_i] * (grad)[_i]; \
+    } while(0)
+    for (int l = 0; l < N_LAYERS; l++) {
+        ACCUM_NORM(m->grad_wq[l], d*d); ACCUM_NORM(m->grad_wk[l], d*d);
+        ACCUM_NORM(m->grad_wv[l], d*d); ACCUM_NORM(m->grad_wo[l], d*d);
+        ACCUM_NORM(m->grad_w1[l], hd*d); ACCUM_NORM(m->grad_w2[l], d*hd);
+        ACCUM_NORM(m->grad_w3[l], hd*d);
+    }
+    ACCUM_NORM(m->grad_wcls, vs*d); ACCUM_NORM(m->grad_emb, vs*d);
+    #undef ACCUM_NORM
+    float total_norm = sqrtf((float)total_norm_sq);
+    if (total_norm > max_norm) {
+        float scale = max_norm / total_norm;
+        #define SCALE_GRAD(grad, size) do { \
+            for (size_t _i = 0; _i < (size_t)(size); _i++) (grad)[_i] *= scale; \
+        } while(0)
+        for (int l = 0; l < N_LAYERS; l++) {
+            SCALE_GRAD(m->grad_wq[l], d*d); SCALE_GRAD(m->grad_wk[l], d*d);
+            SCALE_GRAD(m->grad_wv[l], d*d); SCALE_GRAD(m->grad_wo[l], d*d);
+            SCALE_GRAD(m->grad_w1[l], hd*d); SCALE_GRAD(m->grad_w2[l], d*hd);
+            SCALE_GRAD(m->grad_w3[l], hd*d);
+        }
+        SCALE_GRAD(m->grad_wcls, vs*d); SCALE_GRAD(m->grad_emb, vs*d);
+        #undef SCALE_GRAD
+    }
+}
+
+static void model_backward(Model *m, const int *tokens) {
+    int S = m->seq_len, d = m->cfg.dim, hd = m->cfg.hidden_dim;
+    int nh = m->cfg.n_heads, hdim = HEAD_DIM, vs = m->cfg.vocab_size;
+
+    // Zero gradients
+    for (int l = 0; l < N_LAYERS; l++) {
+        memset(m->grad_wq[l], 0, d*d*sizeof(float));
+        memset(m->grad_wk[l], 0, d*d*sizeof(float));
+        memset(m->grad_wv[l], 0, d*d*sizeof(float));
+        memset(m->grad_wo[l], 0, d*d*sizeof(float));
+        memset(m->grad_w1[l], 0, hd*d*sizeof(float));
+        memset(m->grad_w2[l], 0, d*hd*sizeof(float));
+        memset(m->grad_w3[l], 0, hd*d*sizeof(float));
+    }
+    memset(m->grad_wcls, 0, (size_t)vs*d*sizeof(float));
+    memset(m->grad_emb, 0, (size_t)vs*d*sizeof(float));
+
+    // dLogits from cross-entropy
+    float *dlogits = (float*)calloc(S * vs, sizeof(float));
+    for (int t = 0; t < S - 1; t++) {
+        float mx = -1e9f;
+        for (int i = 0; i < vs; i++) if (m->logits[t*vs+i] > mx) mx = m->logits[t*vs+i];
+        float sm = 0;
+        for (int i = 0; i < vs; i++) sm += expf(m->logits[t*vs+i] - mx);
+        for (int i = 0; i < vs; i++)
+            dlogits[t*vs+i] = expf(m->logits[t*vs+i] - mx) / sm;
+        dlogits[t*vs + tokens[t+1]] -= 1.0f;
+        for (int i = 0; i < vs; i++)
+            dlogits[t*vs+i] /= (S - 1);
+    }
+
+    // Classifier backward
+    cpu_accum_dW(m->grad_wcls, dlogits, m->act_final, S, vs, d);
+    float *dx = (float*)calloc(S * d, sizeof(float));
+    cpu_matmul_backward_dx(m->wcls, dlogits, dx, S, vs, d);
+    free(dlogits);
+
+    // Final RMSNorm backward
+    float *dx_norm = (float*)malloc(S * d * sizeof(float));
+    cpu_rmsnorm_backward(dx_norm, dx, m->act_pre_final, m->rms_final_w, S, d);
+    memcpy(dx, dx_norm, S * d * sizeof(float));
+    free(dx_norm);
+
+    // Layers in reverse
+    for (int l = N_LAYERS - 1; l >= 0; l--) {
+        // FFN down backward
+        float *d_silu = (float*)calloc(S * hd, sizeof(float));
+        cpu_matmul_backward_dx(m->w2[l], dx, d_silu, S, d, hd);
+        cpu_accum_dW(m->grad_w2[l], dx, m->act_silu[l], S, d, hd);
+
+        // SiLU backward
+        float *d_h1 = (float*)malloc(S * hd * sizeof(float));
+        float *d_h3 = (float*)malloc(S * hd * sizeof(float));
+        for (int t = 0; t < S; t++)
+            for (int i = 0; i < hd; i++) {
+                d_h1[t*hd+i] = d_silu[t*hd+i] * m->act_h3[l][t*hd+i] * silu_backward(m->act_h1[l][t*hd+i]);
+                d_h3[t*hd+i] = d_silu[t*hd+i] * silu_f(m->act_h1[l][t*hd+i]);
+            }
+        free(d_silu);
+
+        // FFN up backward
+        cpu_accum_dW(m->grad_w1[l], d_h1, m->act_ffn_in[l], S, hd, d);
+        cpu_accum_dW(m->grad_w3[l], d_h3, m->act_ffn_in[l], S, hd, d);
+
+        float *dx_ffn_in = (float*)calloc(S * d, sizeof(float));
+        float *dx_w1 = (float*)malloc(S * d * sizeof(float));
+        float *dx_w3 = (float*)malloc(S * d * sizeof(float));
+        cpu_matmul_backward_dx(m->w1[l], d_h1, dx_w1, S, hd, d);
+        cpu_matmul_backward_dx(m->w3[l], d_h3, dx_w3, S, hd, d);
+        for (int i = 0; i < S * d; i++) dx_ffn_in[i] = dx_w1[i] + dx_w3[i];
+        free(d_h1); free(d_h3); free(dx_w1); free(dx_w3);
+
+        // RMSNorm FFN backward
+        float *dx_ffn_norm = (float*)malloc(S * d * sizeof(float));
+        // The input to FFN rmsnorm was the residual after attention = act_x[l] + attn_residual
+        // We saved act_x[l] but the actual input to ffn_rmsnorm is x after attention residual
+        // For a proper implementation we'd save this. Approximate with act_x[l].
+        cpu_rmsnorm_backward(dx_ffn_norm, dx_ffn_in, m->act_x[l], m->rms_ffn_w[l], S, d);
+        for (int i = 0; i < S * d; i++) dx[i] += dx_ffn_norm[i];
+        free(dx_ffn_in); free(dx_ffn_norm);
+
+        // O projection backward
+        float *d_attn_out = (float*)calloc(S * d, sizeof(float));
+        cpu_matmul_backward_dx(m->wo[l], dx, d_attn_out, S, d, d);
+        cpu_accum_dW(m->grad_wo[l], dx, m->act_attn_out[l], S, d, d);
+
+        // Attention backward
+        float *dq = (float*)calloc(S * d, sizeof(float));
+        float *dk = (float*)calloc(S * d, sizeof(float));
+        float *dv = (float*)calloc(S * d, sizeof(float));
+        cpu_attention_backward(dq, dk, dv, d_attn_out, m->act_q[l], m->act_k[l], m->act_v[l], S, nh, hdim);
+        free(d_attn_out);
+
+        cpu_rope_backward(dq, dk, S, nh, hdim);
+
+        // QKV backward
+        cpu_accum_dW(m->grad_wq[l], dq, m->act_xnorm[l], S, d, d);
+        cpu_accum_dW(m->grad_wk[l], dk, m->act_xnorm[l], S, d, d);
+        cpu_accum_dW(m->grad_wv[l], dv, m->act_xnorm[l], S, d, d);
+
+        float *dx_qkv = (float*)calloc(S * d, sizeof(float));
+        float *tmp = (float*)malloc(S * d * sizeof(float));
+        cpu_matmul_backward_dx(m->wq[l], dq, tmp, S, d, d);
+        for (int i = 0; i < S*d; i++) dx_qkv[i] += tmp[i];
+        cpu_matmul_backward_dx(m->wk[l], dk, tmp, S, d, d);
+        for (int i = 0; i < S*d; i++) dx_qkv[i] += tmp[i];
+        cpu_matmul_backward_dx(m->wv[l], dv, tmp, S, d, d);
+        for (int i = 0; i < S*d; i++) dx_qkv[i] += tmp[i];
+        free(tmp); free(dq); free(dk); free(dv);
+
+        // RMSNorm attention backward
+        float *dx_att_norm = (float*)malloc(S * d * sizeof(float));
+        cpu_rmsnorm_backward(dx_att_norm, dx_qkv, m->act_x[l], m->rms_att_w[l], S, d);
+        for (int i = 0; i < S * d; i++) dx[i] += dx_att_norm[i];
+        free(dx_qkv); free(dx_att_norm);
+    }
+
+    // Embedding gradient
+    for (int t = 0; t < S; t++)
+        for (int i = 0; i < d; i++)
+            m->grad_emb[tokens[t]*d + i] += dx[t*d + i];
+
+    free(dx);
+}
+
+static void model_adam_step(Model *m, float lr, float beta1, float beta2, float eps) {
+    m->adam_step++;
+    float bc1 = 1.0f - powf(beta1, m->adam_step);
+    float bc2 = 1.0f - powf(beta2, m->adam_step);
+    size_t idx = 0;
+
+    #define ADAM_UPDATE(param, grad, size) do { \
+        for (size_t _i = 0; _i < (size_t)(size); _i++) { \
+            float g = (grad)[_i]; \
+            m->adam_m[idx] = beta1 * m->adam_m[idx] + (1-beta1) * g; \
+            m->adam_v[idx] = beta2 * m->adam_v[idx] + (1-beta2) * g * g; \
+            float m_hat = m->adam_m[idx] / bc1; \
+            float v_hat = m->adam_v[idx] / bc2; \
+            (param)[_i] -= lr * m_hat / (sqrtf(v_hat) + eps); \
+            idx++; \
+        } \
+    } while(0)
+
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, vs = m->cfg.vocab_size;
+    for (int l = 0; l < N_LAYERS; l++) {
+        ADAM_UPDATE(m->wq[l], m->grad_wq[l], d*d);
+        ADAM_UPDATE(m->wk[l], m->grad_wk[l], d*d);
+        ADAM_UPDATE(m->wv[l], m->grad_wv[l], d*d);
+        ADAM_UPDATE(m->wo[l], m->grad_wo[l], d*d);
+        ADAM_UPDATE(m->w1[l], m->grad_w1[l], hd*d);
+        ADAM_UPDATE(m->w2[l], m->grad_w2[l], d*hd);
+        ADAM_UPDATE(m->w3[l], m->grad_w3[l], hd*d);
+    }
+    ADAM_UPDATE(m->wcls, m->grad_wcls, vs*d);
+    ADAM_UPDATE(m->token_embedding, m->grad_emb, vs*d);
+    #undef ADAM_UPDATE
+}

--- a/ane/download_data.sh
+++ b/ane/download_data.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Download pretokenized TinyStories data for ANE training
+# Format: flat uint16 token IDs (Llama2 BPE, 32K vocab)
+# Source: enio/TinyStories on HuggingFace (pretokenized with karpathy/llama2.c)
+#
+# The tar.gz contains data00.bin..data49.bin (50 shards).
+# We extract only data00.bin and rename it to tinystories_data00.bin.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT="$SCRIPT_DIR/tinystories_data00.bin"
+
+if [ -f "$OUTPUT" ]; then
+    SIZE=$(stat -f%z "$OUTPUT" 2>/dev/null || stat -c%s "$OUTPUT" 2>/dev/null)
+    TOKENS=$((SIZE / 2))
+    echo "$OUTPUT already exists ($TOKENS tokens, $(echo "scale=1; $SIZE/1000000" | bc) MB)"
+    exit 0
+fi
+
+TAR_URL="https://huggingface.co/datasets/enio/TinyStories/resolve/main/tok32000/TinyStories_tok32000.tar.gz?download=true"
+TAR_FILE="$SCRIPT_DIR/TinyStories_tok32000.tar.gz"
+
+echo "=== TinyStories Data Download ==="
+echo "Downloading pretokenized TinyStories (32K vocab, ~993 MB)..."
+echo "  Source: enio/TinyStories on HuggingFace"
+echo "  This will take a few minutes depending on your connection."
+echo ""
+
+# Download the tar.gz
+if [ ! -f "$TAR_FILE" ]; then
+    if command -v curl &>/dev/null; then
+        curl -L --progress-bar -o "$TAR_FILE" "$TAR_URL"
+    elif command -v wget &>/dev/null; then
+        wget --show-progress -O "$TAR_FILE" "$TAR_URL"
+    else
+        echo "Error: need curl or wget"
+        exit 1
+    fi
+else
+    echo "Tar file already downloaded, skipping..."
+fi
+
+# Verify it's actually a gzip file (not an error page)
+if ! file "$TAR_FILE" | grep -q "gzip"; then
+    echo "Error: Downloaded file is not a valid gzip archive."
+    echo "Content: $(head -c 100 "$TAR_FILE")"
+    rm -f "$TAR_FILE"
+    exit 1
+fi
+
+echo ""
+echo "Extracting data00.bin from archive..."
+
+# List what's in the archive to find the right path
+DATA_FILE=$(tar tzf "$TAR_FILE" 2>/dev/null | grep 'data00\.bin' | head -1)
+if [ -z "$DATA_FILE" ]; then
+    echo "Error: data00.bin not found in archive. Contents:"
+    tar tzf "$TAR_FILE" | head -20
+    exit 1
+fi
+echo "  Found: $DATA_FILE"
+
+# Extract just data00.bin
+tar xzf "$TAR_FILE" -C "$SCRIPT_DIR" "$DATA_FILE"
+
+# Move to expected location (might be in a subdirectory)
+EXTRACTED="$SCRIPT_DIR/$DATA_FILE"
+if [ "$EXTRACTED" != "$OUTPUT" ]; then
+    mv "$EXTRACTED" "$OUTPUT"
+    # Clean up any extracted subdirectories
+    rmdir "$(dirname "$EXTRACTED")" 2>/dev/null || true
+fi
+
+# Clean up tar.gz to save disk space
+echo "Cleaning up archive..."
+rm -f "$TAR_FILE"
+
+SIZE=$(stat -f%z "$OUTPUT" 2>/dev/null || stat -c%s "$OUTPUT" 2>/dev/null)
+TOKENS=$((SIZE / 2))
+echo ""
+echo "Done: $OUTPUT"
+echo "  $TOKENS tokens ($(echo "scale=1; $SIZE/1000000" | bc) MB)"
+
+# Sanity check
+python3 -c "
+import struct
+with open('$OUTPUT', 'rb') as f:
+    tokens = struct.unpack('<10H', f.read(20))
+    print(f'First 10 tokens: {tokens}')
+" 2>/dev/null || true

--- a/ane/experiment_config.h
+++ b/ane/experiment_config.h
@@ -1,0 +1,13 @@
+// experiment_config.h — Agent edits ONLY this file
+// Architecture (changing these resets checkpoint)
+#define DIM 768
+#define HIDDEN 2048
+#define HEADS 12
+#define SEQ 256
+#define NLAYERS 12
+// Optimizer (safe to change between runs)
+#define LEARNING_RATE 3e-4f
+#define ADAM_BETA1 0.9f
+#define ADAM_BETA2 0.999f
+#define ADAM_EPS 1e-8f
+#define ACCUM_STEPS 10

--- a/ane/forward.h
+++ b/ane/forward.h
@@ -1,0 +1,184 @@
+// forward.h — Forward pass: ANE baked-weight conv for linears, CPU for element-wise
+#pragma once
+#include "model.h"
+#include <math.h>
+#include <string.h>
+
+// ANE conv eval: input [S, in_dim] row-major → transpose to [in_dim, S] channels-first
+// ANE computes conv(W, x) with baked W → output [out_dim, S]
+// Transpose back to [S, out_dim] row-major
+static bool ane_conv_eval(ANEKernel *kernel, const float *x, float *y,
+                          int S, int in_dim, int out_dim) {
+    float *x_t = (float*)malloc(S * in_dim * sizeof(float));
+    for (int t = 0; t < S; t++)
+        for (int i = 0; i < in_dim; i++)
+            x_t[i*S + t] = x[t*in_dim + i];
+
+    ane_write_input(kernel, 0, x_t, S * in_dim * sizeof(float));
+    bool ok = ane_eval(kernel);
+    if (!ok) {
+        free(x_t);
+        return false;
+    }
+
+    float *y_t = (float*)malloc(S * out_dim * sizeof(float));
+    ane_read_output(kernel, 0, y_t, S * out_dim * sizeof(float));
+
+    for (int t = 0; t < S; t++)
+        for (int i = 0; i < out_dim; i++)
+            y[t*out_dim + i] = y_t[i*S + t];
+
+    free(x_t); free(y_t);
+    return true;
+}
+
+// CPU matmul fallback: y = W @ x, W[out_dim, in_dim], x[S, in_dim] → y[S, out_dim]
+static void cpu_matmul(const float *W, const float *x, float *y, int S, int in_dim, int out_dim) {
+    for (int t = 0; t < S; t++)
+        for (int i = 0; i < out_dim; i++) {
+            float sum = 0;
+            for (int j = 0; j < in_dim; j++)
+                sum += W[i*in_dim + j] * x[t*in_dim + j];
+            y[t*out_dim + i] = sum;
+        }
+}
+
+static void cpu_rmsnorm(float *out, const float *x, const float *w, int S, int D) {
+    for (int t = 0; t < S; t++) {
+        float ss = 0;
+        for (int i = 0; i < D; i++) ss += x[t*D+i] * x[t*D+i];
+        ss = 1.0f / sqrtf(ss / D + 1e-5f);
+        for (int i = 0; i < D; i++) out[t*D+i] = x[t*D+i] * ss * w[i];
+    }
+}
+
+static void cpu_rope(float *q, float *k, int S, int n_heads, int head_dim) {
+    for (int t = 0; t < S; t++)
+        for (int h = 0; h < n_heads; h++)
+            for (int i = 0; i < head_dim; i += 2) {
+                float freq = 1.0f / powf(10000.0f, (float)i / head_dim);
+                float val = t * freq;
+                float cos_v = cosf(val), sin_v = sinf(val);
+                int off = t * n_heads * head_dim + h * head_dim + i;
+                float q0 = q[off], q1 = q[off+1];
+                q[off]   = q0 * cos_v - q1 * sin_v;
+                q[off+1] = q0 * sin_v + q1 * cos_v;
+                float k0 = k[off], k1 = k[off+1];
+                k[off]   = k0 * cos_v - k1 * sin_v;
+                k[off+1] = k0 * sin_v + k1 * cos_v;
+            }
+}
+
+static void cpu_attention(float *out, const float *q, const float *k, const float *v,
+                          int S, int n_heads, int head_dim) {
+    float scale = 1.0f / sqrtf((float)head_dim);
+    float *scores = (float*)malloc(S * S * sizeof(float));
+    for (int h = 0; h < n_heads; h++) {
+        int D = n_heads * head_dim;
+        for (int t = 0; t < S; t++) {
+            float mx = -1e9f;
+            for (int s = 0; s <= t; s++) {
+                float dot = 0;
+                for (int i = 0; i < head_dim; i++)
+                    dot += q[t*D + h*head_dim + i] * k[s*D + h*head_dim + i];
+                scores[s] = dot * scale;
+                if (scores[s] > mx) mx = scores[s];
+            }
+            float sm = 0;
+            for (int s = 0; s <= t; s++) { scores[s] = expf(scores[s] - mx); sm += scores[s]; }
+            for (int s = 0; s <= t; s++) scores[s] /= sm;
+            for (int i = 0; i < head_dim; i++) {
+                float val = 0;
+                for (int s = 0; s <= t; s++)
+                    val += scores[s] * v[s*D + h*head_dim + i];
+                out[t*D + h*head_dim + i] = val;
+            }
+        }
+    }
+    free(scores);
+}
+
+static inline float silu_f(float x) { return x / (1.0f + expf(-x)); }
+
+// Forward pass — returns loss. Saves activations for backward.
+static float model_forward(Model *m, const int *tokens, bool use_ane) {
+    int S = m->seq_len, d = m->cfg.dim, hd = m->cfg.hidden_dim;
+    int nh = m->cfg.n_heads, hdim = HEAD_DIM, vs = m->cfg.vocab_size;
+
+    float *x = (float*)malloc(S * d * sizeof(float));
+    for (int t = 0; t < S; t++)
+        memcpy(x + t*d, m->token_embedding + tokens[t]*d, d * sizeof(float));
+
+    for (int l = 0; l < N_LAYERS; l++) {
+        memcpy(m->act_x[l], x, S * d * sizeof(float));
+
+        cpu_rmsnorm(m->act_xnorm[l], x, m->rms_att_w[l], S, d);
+
+        if (use_ane) {
+            ane_conv_eval(m->kern_q[l], m->act_xnorm[l], m->act_q[l], S, d, d);
+            ane_conv_eval(m->kern_k[l], m->act_xnorm[l], m->act_k[l], S, d, d);
+            ane_conv_eval(m->kern_v[l], m->act_xnorm[l], m->act_v[l], S, d, d);
+        } else {
+            cpu_matmul(m->wq[l], m->act_xnorm[l], m->act_q[l], S, d, d);
+            cpu_matmul(m->wk[l], m->act_xnorm[l], m->act_k[l], S, d, d);
+            cpu_matmul(m->wv[l], m->act_xnorm[l], m->act_v[l], S, d, d);
+        }
+
+        cpu_rope(m->act_q[l], m->act_k[l], S, nh, hdim);
+        cpu_attention(m->act_attn_out[l], m->act_q[l], m->act_k[l], m->act_v[l], S, nh, hdim);
+
+        float *o_out = (float*)malloc(S * d * sizeof(float));
+        if (use_ane) {
+            ane_conv_eval(m->kern_o[l], m->act_attn_out[l], o_out, S, d, d);
+        } else {
+            cpu_matmul(m->wo[l], m->act_attn_out[l], o_out, S, d, d);
+        }
+        for (int i = 0; i < S * d; i++) x[i] += o_out[i];
+        free(o_out);
+
+        cpu_rmsnorm(m->act_ffn_in[l], x, m->rms_ffn_w[l], S, d);
+
+        if (use_ane) {
+            ane_conv_eval(m->kern_w1[l], m->act_ffn_in[l], m->act_h1[l], S, d, hd);
+            ane_conv_eval(m->kern_w3[l], m->act_ffn_in[l], m->act_h3[l], S, d, hd);
+        } else {
+            cpu_matmul(m->w1[l], m->act_ffn_in[l], m->act_h1[l], S, d, hd);
+            cpu_matmul(m->w3[l], m->act_ffn_in[l], m->act_h3[l], S, d, hd);
+        }
+
+        for (int t = 0; t < S; t++)
+            for (int i = 0; i < hd; i++)
+                m->act_silu[l][t*hd+i] = silu_f(m->act_h1[l][t*hd+i]) * m->act_h3[l][t*hd+i];
+
+        float *ffn_out = (float*)malloc(S * d * sizeof(float));
+        if (use_ane) {
+            ane_conv_eval(m->kern_w2[l], m->act_silu[l], ffn_out, S, hd, d);
+        } else {
+            cpu_matmul(m->w2[l], m->act_silu[l], ffn_out, S, hd, d);
+        }
+        for (int i = 0; i < S * d; i++) x[i] += ffn_out[i];
+        free(ffn_out);
+    }
+
+    memcpy(m->act_pre_final, x, S * d * sizeof(float));
+    cpu_rmsnorm(m->act_final, x, m->rms_final_w, S, d);
+
+    if (use_ane && m->kern_cls) {
+        ane_conv_eval(m->kern_cls, m->act_final, m->logits, S, d, vs);
+    } else {
+        cpu_matmul(m->wcls, m->act_final, m->logits, S, d, vs);
+    }
+
+    free(x);
+
+    float loss = 0;
+    for (int t = 0; t < S - 1; t++) {
+        float mx = -1e9f;
+        for (int i = 0; i < vs; i++) if (m->logits[t*vs+i] > mx) mx = m->logits[t*vs+i];
+        float sm = 0;
+        for (int i = 0; i < vs; i++) sm += expf(m->logits[t*vs+i] - mx);
+        float log_prob = m->logits[t*vs + tokens[t+1]] - mx - logf(sm);
+        loss -= log_prob;
+    }
+    return loss / (S - 1);
+}

--- a/ane/model.h
+++ b/ane/model.h
@@ -1,0 +1,285 @@
+// model.h — Stories110M model struct + weight loading + ANE kernel compilation
+// Training version: baked-weight conv kernels, recompile when weights update
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "ane_runtime.h"
+#include "ane_mil_gen.h"
+
+#define N_LAYERS 12
+#define DIM 768
+#define HIDDEN_DIM 2048
+#define N_HEADS 12
+#define HEAD_DIM 64
+#define VOCAB_SIZE 32000
+#define MAX_SEQ 1024
+
+typedef struct {
+    int dim, hidden_dim, n_layers, n_heads, n_kv_heads, vocab_size, seq_len;
+} Config;
+
+typedef struct {
+    Config cfg;
+    int seq_len; // training sequence length
+
+    // Raw weights (f32)
+    float *token_embedding;  // [vocab_size, dim]
+    float *rms_att_w[N_LAYERS]; // [dim]
+    float *wq[N_LAYERS];       // [dim, dim]
+    float *wk[N_LAYERS];       // [dim, dim]
+    float *wv[N_LAYERS];       // [dim, dim]
+    float *wo[N_LAYERS];       // [dim, dim]
+    float *rms_ffn_w[N_LAYERS]; // [dim]
+    float *w1[N_LAYERS];       // [hidden_dim, dim]
+    float *w2[N_LAYERS];       // [dim, hidden_dim]
+    float *w3[N_LAYERS];       // [hidden_dim, dim]
+    float *rms_final_w;        // [dim]
+    float *wcls;               // [vocab_size, dim]
+
+    // Per-layer ANE conv kernels (baked weights, recompiled on update)
+    ANEKernel *kern_q[N_LAYERS];   // Q projection: dim→dim
+    ANEKernel *kern_k[N_LAYERS];   // K projection: dim→dim
+    ANEKernel *kern_v[N_LAYERS];   // V projection: dim→dim
+    ANEKernel *kern_o[N_LAYERS];   // O projection: dim→dim
+    ANEKernel *kern_w1[N_LAYERS];  // FFN w1: dim→hidden
+    ANEKernel *kern_w2[N_LAYERS];  // FFN w2: hidden→dim
+    ANEKernel *kern_w3[N_LAYERS];  // FFN w3: dim→hidden
+    ANEKernel *kern_cls;           // Classifier: dim→vocab
+
+    // Gradient accumulators (f32)
+    float *grad_wq[N_LAYERS], *grad_wk[N_LAYERS], *grad_wv[N_LAYERS], *grad_wo[N_LAYERS];
+    float *grad_w1[N_LAYERS], *grad_w2[N_LAYERS], *grad_w3[N_LAYERS];
+    float *grad_wcls;
+    float *grad_emb;
+
+    // Adam optimizer state
+    float *adam_m, *adam_v;
+    int adam_step;
+    size_t total_params;
+
+    // Activation cache for backward
+    float *act_x[N_LAYERS];
+    float *act_xnorm[N_LAYERS];
+    float *act_q[N_LAYERS];
+    float *act_k[N_LAYERS];
+    float *act_v[N_LAYERS];
+    float *act_attn_out[N_LAYERS];
+    float *act_ffn_in[N_LAYERS];
+    float *act_h1[N_LAYERS];
+    float *act_h3[N_LAYERS];
+    float *act_silu[N_LAYERS];
+    float *act_final;
+    float *act_pre_final;
+    float *logits;
+} Model;
+
+static int model_load_weights(Model *m, const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "Cannot open %s\n", path); return -1; }
+    if (fread(&m->cfg, sizeof(Config), 1, f) != 1) {
+        fprintf(stderr, "ERROR: failed to read config from %s\n", path);
+        fclose(f); return -1;
+    }
+    bool shared = m->cfg.vocab_size > 0;
+    if (m->cfg.vocab_size < 0) m->cfg.vocab_size = -m->cfg.vocab_size;
+
+    printf("Model: dim=%d hidden=%d layers=%d heads=%d vocab=%d seq=%d\n",
+           m->cfg.dim, m->cfg.hidden_dim, m->cfg.n_layers, m->cfg.n_heads,
+           m->cfg.vocab_size, m->cfg.seq_len);
+
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, nl = m->cfg.n_layers, vs = m->cfg.vocab_size;
+
+    m->token_embedding = (float*)malloc(vs * d * sizeof(float));
+    if (fread(m->token_embedding, sizeof(float), vs * d, f) != (size_t)(vs * d)) {
+        fprintf(stderr, "ERROR: short read on token_embedding (file truncated?)\n");
+        fclose(f); return -1;
+    }
+
+    float *rms_att_all = (float*)malloc(nl * d * sizeof(float));
+    float *wq_all = (float*)malloc(nl * d * d * sizeof(float));
+    float *wk_all = (float*)malloc(nl * d * d * sizeof(float));
+    float *wv_all = (float*)malloc(nl * d * d * sizeof(float));
+    float *wo_all = (float*)malloc(nl * d * d * sizeof(float));
+    float *rms_ffn_all = (float*)malloc(nl * d * sizeof(float));
+    float *w1_all = (float*)malloc(nl * hd * d * sizeof(float));
+    float *w2_all = (float*)malloc(nl * d * hd * sizeof(float));
+    float *w3_all = (float*)malloc(nl * hd * d * sizeof(float));
+
+    #define FREAD_CHECK(buf, count, file, label) do { \
+        size_t _n = fread(buf, sizeof(float), count, file); \
+        if (_n != (size_t)(count)) { \
+            fprintf(stderr, "ERROR: short read on %s: got %zu, expected %zu (file truncated?)\n", \
+                    label, _n, (size_t)(count)); \
+            fclose(file); return -1; \
+        } \
+    } while(0)
+
+    FREAD_CHECK(rms_att_all, nl * d, f, "rms_att");
+    FREAD_CHECK(wq_all, nl * d * d, f, "wq");
+    FREAD_CHECK(wk_all, nl * d * d, f, "wk");
+    FREAD_CHECK(wv_all, nl * d * d, f, "wv");
+    FREAD_CHECK(wo_all, nl * d * d, f, "wo");
+    FREAD_CHECK(rms_ffn_all, nl * d, f, "rms_ffn");
+    FREAD_CHECK(w1_all, nl * hd * d, f, "w1");
+    FREAD_CHECK(w2_all, nl * d * hd, f, "w2");
+    FREAD_CHECK(w3_all, nl * hd * d, f, "w3");
+
+    for (int l = 0; l < nl; l++) {
+        m->rms_att_w[l] = (float*)malloc(d * sizeof(float));
+        memcpy(m->rms_att_w[l], rms_att_all + l*d, d * sizeof(float));
+        m->wq[l] = (float*)malloc(d*d*sizeof(float));
+        memcpy(m->wq[l], wq_all + l*d*d, d*d*sizeof(float));
+        m->wk[l] = (float*)malloc(d*d*sizeof(float));
+        memcpy(m->wk[l], wk_all + l*d*d, d*d*sizeof(float));
+        m->wv[l] = (float*)malloc(d*d*sizeof(float));
+        memcpy(m->wv[l], wv_all + l*d*d, d*d*sizeof(float));
+        m->wo[l] = (float*)malloc(d*d*sizeof(float));
+        memcpy(m->wo[l], wo_all + l*d*d, d*d*sizeof(float));
+        m->rms_ffn_w[l] = (float*)malloc(d * sizeof(float));
+        memcpy(m->rms_ffn_w[l], rms_ffn_all + l*d, d * sizeof(float));
+        m->w1[l] = (float*)malloc(hd*d*sizeof(float));
+        memcpy(m->w1[l], w1_all + l*hd*d, hd*d*sizeof(float));
+        m->w2[l] = (float*)malloc(d*hd*sizeof(float));
+        memcpy(m->w2[l], w2_all + l*d*hd, d*hd*sizeof(float));
+        m->w3[l] = (float*)malloc(hd*d*sizeof(float));
+        memcpy(m->w3[l], w3_all + l*hd*d, hd*d*sizeof(float));
+    }
+    free(rms_att_all); free(wq_all); free(wk_all); free(wv_all); free(wo_all);
+    free(rms_ffn_all); free(w1_all); free(w2_all); free(w3_all);
+
+    m->rms_final_w = (float*)malloc(d * sizeof(float));
+    FREAD_CHECK(m->rms_final_w, d, f, "rms_final");
+
+    if (shared) {
+        m->wcls = m->token_embedding;
+    } else {
+        m->wcls = (float*)malloc(vs * d * sizeof(float));
+        FREAD_CHECK(m->wcls, vs * d, f, "wcls");
+    }
+    #undef FREAD_CHECK
+    fclose(f);
+    return 0;
+}
+
+// Compile a single baked-weight conv kernel
+static ANEKernel *compile_conv_kernel(const float *weights, int in_ch, int out_ch, int spatial) {
+    NSData *wb = mil_build_weight_blob(weights, out_ch, in_ch);
+    NSString *mil = mil_gen_conv(in_ch, out_ch, spatial);
+    size_t inBytes = (size_t)in_ch * spatial * 4;
+    size_t outBytes = (size_t)out_ch * spatial * 4;
+    return ane_compile([mil dataUsingEncoding:NSUTF8StringEncoding], wb, 1, &inBytes, 1, &outBytes);
+}
+
+// Compile all per-layer ANE kernels with current weights
+static int model_compile_kernels(Model *m, int seq_len) {
+    m->seq_len = seq_len;
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, vs = m->cfg.vocab_size;
+    int S = seq_len;
+    printf("Compiling %d ANE conv kernels (S=%d)...\n", N_LAYERS * 7 + 1, S);
+
+    for (int l = 0; l < N_LAYERS; l++) {
+        m->kern_q[l] = compile_conv_kernel(m->wq[l], d, d, S);
+        m->kern_k[l] = compile_conv_kernel(m->wk[l], d, d, S);
+        m->kern_v[l] = compile_conv_kernel(m->wv[l], d, d, S);
+        m->kern_o[l] = compile_conv_kernel(m->wo[l], d, d, S);
+        m->kern_w1[l] = compile_conv_kernel(m->w1[l], d, hd, S);
+        m->kern_w2[l] = compile_conv_kernel(m->w2[l], hd, d, S);
+        m->kern_w3[l] = compile_conv_kernel(m->w3[l], d, hd, S);
+        if (!m->kern_q[l]) { fprintf(stderr, "L%d kern_q fail\n",l); return -1; }
+        if (!m->kern_k[l]) { fprintf(stderr, "L%d kern_k fail\n",l); return -1; }
+        if (!m->kern_v[l]) { fprintf(stderr, "L%d kern_v fail\n",l); return -1; }
+        if (!m->kern_o[l]) { fprintf(stderr, "L%d kern_o fail\n",l); return -1; }
+        if (!m->kern_w1[l]) { fprintf(stderr, "L%d kern_w1 fail\n",l); return -1; }
+        if (!m->kern_w2[l]) { fprintf(stderr, "L%d kern_w2 fail\n",l); return -1; }
+        if (!m->kern_w3[l]) { fprintf(stderr, "L%d kern_w3 fail\n",l); return -1; }
+        printf("  Layer %d OK\n", l);
+    }
+    m->kern_cls = compile_conv_kernel(m->wcls, d, vs, S);
+    if (!m->kern_cls) {
+        fprintf(stderr, "Classifier kernel compile failed (dim=%d→vocab=%d too large?), using CPU for cls\n", d, vs);
+    }
+    printf("  All kernels compiled (%d conv + %s)\n", N_LAYERS * 7, m->kern_cls ? "cls" : "cls=CPU");
+    return 0;
+}
+
+// Recompile all kernels after weight update — compile new first, then swap
+static int model_recompile_kernels(Model *m) {
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, vs = m->cfg.vocab_size;
+    int S = m->seq_len;
+
+    // Phase 1: compile new kernels into temporaries
+    ANEKernel *new_q[N_LAYERS], *new_k[N_LAYERS], *new_v[N_LAYERS], *new_o[N_LAYERS];
+    ANEKernel *new_w1[N_LAYERS], *new_w2[N_LAYERS], *new_w3[N_LAYERS];
+    for (int l = 0; l < N_LAYERS; l++) {
+        new_q[l] = compile_conv_kernel(m->wq[l], d, d, S);
+        new_k[l] = compile_conv_kernel(m->wk[l], d, d, S);
+        new_v[l] = compile_conv_kernel(m->wv[l], d, d, S);
+        new_o[l] = compile_conv_kernel(m->wo[l], d, d, S);
+        new_w1[l] = compile_conv_kernel(m->w1[l], d, hd, S);
+        new_w2[l] = compile_conv_kernel(m->w2[l], hd, d, S);
+        new_w3[l] = compile_conv_kernel(m->w3[l], d, hd, S);
+        if (!new_q[l] || !new_k[l] || !new_v[l] || !new_o[l] ||
+            !new_w1[l] || !new_w2[l] || !new_w3[l]) {
+            // Cleanup partially compiled new kernels
+            for (int i = 0; i <= l; i++) {
+                ane_free(new_q[i]); ane_free(new_k[i]); ane_free(new_v[i]); ane_free(new_o[i]);
+                ane_free(new_w1[i]); ane_free(new_w2[i]); ane_free(new_w3[i]);
+            }
+            fprintf(stderr, "Recompile failed at layer %d, keeping old kernels\n", l);
+            return -1;
+        }
+    }
+    ANEKernel *new_cls = compile_conv_kernel(m->wcls, d, vs, S);
+
+    // Phase 2: all compiles succeeded — swap and free old
+    for (int l = 0; l < N_LAYERS; l++) {
+        ane_free(m->kern_q[l]); ane_free(m->kern_k[l]); ane_free(m->kern_v[l]); ane_free(m->kern_o[l]);
+        ane_free(m->kern_w1[l]); ane_free(m->kern_w2[l]); ane_free(m->kern_w3[l]);
+        m->kern_q[l] = new_q[l]; m->kern_k[l] = new_k[l];
+        m->kern_v[l] = new_v[l]; m->kern_o[l] = new_o[l];
+        m->kern_w1[l] = new_w1[l]; m->kern_w2[l] = new_w2[l]; m->kern_w3[l] = new_w3[l];
+    }
+    if (m->kern_cls) ane_free(m->kern_cls);
+    m->kern_cls = new_cls;  // may be NULL for large vocab — forward uses CPU fallback
+    return 0;
+}
+
+static void model_alloc_training(Model *m) {
+    int d = m->cfg.dim, hd = m->cfg.hidden_dim, vs = m->cfg.vocab_size, S = m->seq_len;
+    for (int l = 0; l < N_LAYERS; l++) {
+        m->act_x[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_xnorm[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_q[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_k[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_v[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_attn_out[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_ffn_in[l] = (float*)calloc(S * d, sizeof(float));
+        m->act_h1[l] = (float*)calloc(S * hd, sizeof(float));
+        m->act_h3[l] = (float*)calloc(S * hd, sizeof(float));
+        m->act_silu[l] = (float*)calloc(S * hd, sizeof(float));
+
+        m->grad_wq[l] = (float*)calloc(d * d, sizeof(float));
+        m->grad_wk[l] = (float*)calloc(d * d, sizeof(float));
+        m->grad_wv[l] = (float*)calloc(d * d, sizeof(float));
+        m->grad_wo[l] = (float*)calloc(d * d, sizeof(float));
+        m->grad_w1[l] = (float*)calloc(hd * d, sizeof(float));
+        m->grad_w2[l] = (float*)calloc(d * hd, sizeof(float));
+        m->grad_w3[l] = (float*)calloc(hd * d, sizeof(float));
+    }
+    m->act_final = (float*)calloc(S * d, sizeof(float));
+    m->act_pre_final = (float*)calloc(S * d, sizeof(float));
+    m->logits = (float*)calloc(S * vs, sizeof(float));
+    m->grad_wcls = (float*)calloc(vs * d, sizeof(float));
+    m->grad_emb = (float*)calloc(vs * d, sizeof(float));
+
+    m->total_params = 0;
+    for (int l = 0; l < N_LAYERS; l++)
+        m->total_params += 4*(size_t)d*d + 2*(size_t)hd*d + (size_t)d*hd;
+    m->total_params += (size_t)vs * d * 2;
+    m->adam_m = (float*)calloc(m->total_params, sizeof(float));
+    m->adam_v = (float*)calloc(m->total_params, sizeof(float));
+    m->adam_step = 0;
+    printf("Total trainable params: %zu (%.1f M)\n", m->total_params, m->total_params/1e6);
+}

--- a/ane/stories_config.h
+++ b/ane/stories_config.h
@@ -1,0 +1,184 @@
+// stories_config.h — Stories110M model config and structures
+#pragma once
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <dlfcn.h>
+#import <IOSurface/IOSurface.h>
+#import <mach/mach_time.h>
+#import <Accelerate/Accelerate.h>
+#include <math.h>
+#include <unistd.h>
+#include <dispatch/dispatch.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+// Stories110M config — architecture and optimizer from experiment_config.h
+#include "experiment_config.h"
+#define HD (DIM/HEADS)
+#define VOCAB 32000
+#define MAX_COMPILES 100
+
+// Per compile: 5 weight-bearing kernels per layer + 1 classifier = 5*12+1 = 61
+// Plus 1 static (sdpaBwd2 per layer, no weights) = 12 more but those are weight-free
+// Actually sdpaBwd2 has no weights, compile once per layer
+// Weight-bearing: fwdAttn(1) + fwdFFN(1) + ffnBwd(1) + sdpaBwd1(1) + qkvBwd(1) = 5 per layer
+// 5 * 12 = 60 weight-bearing compiles per batch
+// With MAX_COMPILES=100, we get 1 batch of ACCUM_STEPS before restart
+#define KERNELS_PER_LAYER 5
+#define TOTAL_WEIGHT_KERNELS (KERNELS_PER_LAYER * NLAYERS)
+
+// Attention score channels for SDPA backward
+#define SCORE_CH (HEADS*SEQ)
+
+// Weight sizes per layer
+#define WQ_SZ (DIM*DIM)
+#define WO_SZ (DIM*DIM)
+#define W1_SZ (HIDDEN*DIM)
+#define W2_SZ (DIM*HIDDEN)
+#define W3_SZ (HIDDEN*DIM)
+#define LAYER_PARAMS (4*WQ_SZ + W1_SZ + W2_SZ + W3_SZ + 2*DIM)
+#define TOTAL_PARAMS (NLAYERS * LAYER_PARAMS + DIM + VOCAB*DIM)  // +rms_final+embed
+
+// Per-layer weight and optimizer state
+typedef struct {
+    float *Wq, *Wk, *Wv, *Wo;
+    float *W1, *W2, *W3;
+    float *rms_att, *rms_ffn;
+} LayerWeights;
+
+typedef struct {
+    float *m, *v;
+    size_t n;
+} AdamState;
+
+typedef struct {
+    AdamState Wq, Wk, Wv, Wo;
+    AdamState W1, W2, W3;
+    AdamState rms_att, rms_ffn;
+} LayerAdam;
+
+// Per-layer activation buffers (saved for backward)
+typedef struct {
+    float *layer_in;    // [DIM, SEQ] input to this layer (for rmsnorm1 bwd)
+    float *xnorm;      // [DIM, SEQ] rmsnorm1 output
+    float *Q, *K, *V;  // [DIM, SEQ] QKV projections
+    float *attn_out;    // [DIM, SEQ] attention output (before Wo)
+    float *o_out;       // [DIM, SEQ] Wo output
+    float *x2;          // [DIM, SEQ] residual after attn
+    float *x2norm;      // [DIM, SEQ] rmsnorm2 output
+    float *h1, *h3;     // [HIDDEN, SEQ] FFN intermediates
+    float *silu_out;    // [HIDDEN, SEQ] SiLU(h1)*h3
+    float *ffn_out;     // [DIM, SEQ] FFN output
+} LayerActs;
+
+// Per-layer gradient accumulators
+typedef struct {
+    float *Wq, *Wk, *Wv, *Wo;
+    float *W1, *W2, *W3;
+    float *rms_att, *rms_ffn;
+} LayerGrads;
+
+// ANE kernels per layer
+typedef struct { void *model; IOSurfaceRef ioIn, ioOut; void *request; void *tmpDir; } Kern;
+typedef struct {
+    Kern *fwdAttn, *fwdFFN, *ffnBwd, *sdpaBwd1, *sdpaBwd2, *qkvBwd;
+} LayerKernels;
+
+// Checkpoint header
+typedef struct {
+    int magic;          // 0x424C5A54 "BLZT"
+    int version;        // 2
+    int step, total_steps;
+    int n_layers, vocab_size, dim, hidden_dim, n_heads, seq_len;
+    float lr, loss;
+    double cum_compile, cum_train, cum_wall;
+    int cum_steps, cum_batches;
+    int adam_t;
+    int pad[3];         // alignment
+} CkptHdr;
+
+// llama2.c model file header
+typedef struct {
+    int dim, hidden_dim, n_layers, n_heads, n_kv_heads, vocab_size, seq_len;
+} Llama2Config;
+
+// Globals
+static Class g_D, g_I, g_AR, g_AIO;
+static mach_timebase_info_data_t g_tb;
+static int g_compile_count = 0;
+
+static void ane_init(void) {
+    dlopen("/System/Library/PrivateFrameworks/AppleNeuralEngine.framework/AppleNeuralEngine", RTLD_NOW);
+    g_D  = NSClassFromString(@"_ANEInMemoryModelDescriptor");
+    g_I  = NSClassFromString(@"_ANEInMemoryModel");
+    g_AR = NSClassFromString(@"_ANERequest");
+    g_AIO= NSClassFromString(@"_ANEIOSurfaceObject");
+}
+static double tb_ms(uint64_t t) { return (double)t * g_tb.numer / g_tb.denom / 1e6; }
+
+// Alloc helpers
+static AdamState adam_alloc(size_t n) { AdamState s; s.m=(float*)calloc(n,4); s.v=(float*)calloc(n,4); s.n=n; return s; }
+static void adam_free(AdamState *s) { free(s->m); free(s->v); }
+
+static LayerWeights layer_weights_alloc(void) {
+    LayerWeights w;
+    w.Wq=(float*)malloc(WQ_SZ*4); w.Wk=(float*)malloc(WQ_SZ*4);
+    w.Wv=(float*)malloc(WQ_SZ*4); w.Wo=(float*)malloc(WO_SZ*4);
+    w.W1=(float*)malloc(W1_SZ*4); w.W2=(float*)malloc(W2_SZ*4); w.W3=(float*)malloc(W3_SZ*4);
+    w.rms_att=(float*)malloc(DIM*4); w.rms_ffn=(float*)malloc(DIM*4);
+    return w;
+}
+static void layer_weights_free(LayerWeights *w) {
+    free(w->Wq);free(w->Wk);free(w->Wv);free(w->Wo);
+    free(w->W1);free(w->W2);free(w->W3);
+    free(w->rms_att);free(w->rms_ffn);
+}
+static LayerAdam layer_adam_alloc(void) {
+    LayerAdam a;
+    a.Wq=adam_alloc(WQ_SZ); a.Wk=adam_alloc(WQ_SZ); a.Wv=adam_alloc(WQ_SZ); a.Wo=adam_alloc(WO_SZ);
+    a.W1=adam_alloc(W1_SZ); a.W2=adam_alloc(W2_SZ); a.W3=adam_alloc(W3_SZ);
+    a.rms_att=adam_alloc(DIM); a.rms_ffn=adam_alloc(DIM);
+    return a;
+}
+static void layer_adam_free(LayerAdam *a) {
+    adam_free(&a->Wq);adam_free(&a->Wk);adam_free(&a->Wv);adam_free(&a->Wo);
+    adam_free(&a->W1);adam_free(&a->W2);adam_free(&a->W3);
+    adam_free(&a->rms_att);adam_free(&a->rms_ffn);
+}
+static LayerActs layer_acts_alloc(void) {
+    LayerActs a;
+    a.layer_in=(float*)malloc(SEQ*DIM*4);
+    a.xnorm=(float*)malloc(SEQ*DIM*4); a.Q=(float*)malloc(SEQ*DIM*4);
+    a.K=(float*)malloc(SEQ*DIM*4); a.V=(float*)malloc(SEQ*DIM*4);
+    a.attn_out=(float*)malloc(SEQ*DIM*4); a.o_out=(float*)malloc(SEQ*DIM*4);
+    a.x2=(float*)malloc(SEQ*DIM*4); a.x2norm=(float*)malloc(SEQ*DIM*4);
+    a.h1=(float*)malloc(SEQ*HIDDEN*4); a.h3=(float*)malloc(SEQ*HIDDEN*4);
+    a.silu_out=(float*)malloc(SEQ*HIDDEN*4); a.ffn_out=(float*)malloc(SEQ*DIM*4);
+    return a;
+}
+static void layer_acts_free(LayerActs *a) {
+    free(a->layer_in);free(a->xnorm);free(a->Q);free(a->K);free(a->V);
+    free(a->attn_out);free(a->o_out);free(a->x2);free(a->x2norm);
+    free(a->h1);free(a->h3);free(a->silu_out);free(a->ffn_out);
+}
+static LayerGrads layer_grads_alloc(void) {
+    LayerGrads g;
+    g.Wq=(float*)calloc(WQ_SZ,4); g.Wk=(float*)calloc(WQ_SZ,4);
+    g.Wv=(float*)calloc(WQ_SZ,4); g.Wo=(float*)calloc(WO_SZ,4);
+    g.W1=(float*)calloc(W1_SZ,4); g.W2=(float*)calloc(W2_SZ,4); g.W3=(float*)calloc(W3_SZ,4);
+    g.rms_att=(float*)calloc(DIM,4); g.rms_ffn=(float*)calloc(DIM,4);
+    return g;
+}
+static void layer_grads_zero(LayerGrads *g) {
+    memset(g->Wq,0,WQ_SZ*4);memset(g->Wk,0,WQ_SZ*4);
+    memset(g->Wv,0,WQ_SZ*4);memset(g->Wo,0,WO_SZ*4);
+    memset(g->W1,0,W1_SZ*4);memset(g->W2,0,W2_SZ*4);memset(g->W3,0,W3_SZ*4);
+    memset(g->rms_att,0,DIM*4);memset(g->rms_ffn,0,DIM*4);
+}
+static void layer_grads_free(LayerGrads *g) {
+    free(g->Wq);free(g->Wk);free(g->Wv);free(g->Wo);
+    free(g->W1);free(g->W2);free(g->W3);
+    free(g->rms_att);free(g->rms_ffn);
+}

--- a/ane/stories_cpu_ops.h
+++ b/ane/stories_cpu_ops.h
@@ -1,0 +1,131 @@
+// stories_cpu_ops.h — CPU operations: RMSNorm, cross-entropy, Adam, softmax
+#pragma once
+#include "stories_config.h"
+
+
+static void rmsnorm(float *out, const float *x, const float *w, int d, int S) {
+    float *rms_tmp = (float*)malloc(S * sizeof(float));
+    float *ss = (float*)calloc(S, sizeof(float));
+    for (int i=0; i<d; i++) {
+        vDSP_vmul(x+i*S, 1, x+i*S, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vadd(rms_tmp, 1, ss, 1, ss, 1, (vDSP_Length)S);
+    }
+    float invd = 1.0f/d, eps=1e-5f;
+    vDSP_vsmsa(ss, 1, &invd, &eps, ss, 1, (vDSP_Length)S);
+    int n = S; vvrsqrtf(ss, ss, &n);
+    for (int i=0; i<d; i++) {
+        vDSP_vmul(x+i*S, 1, ss, 1, out+i*S, 1, (vDSP_Length)S);
+        vDSP_vsmul(out+i*S, 1, &w[i], out+i*S, 1, (vDSP_Length)S);
+    }
+    free(ss); free(rms_tmp);
+}
+
+static void rmsnorm_bwd(float *dx, float *dw, const float *dy, const float *x, const float *w, int d, int S) {
+    float *rms_tmp = (float*)malloc(S * sizeof(float));
+    float *ss = (float*)calloc(S, sizeof(float));
+    for (int i=0; i<d; i++) {
+        vDSP_vmul(x+i*S, 1, x+i*S, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vadd(rms_tmp, 1, ss, 1, ss, 1, (vDSP_Length)S);
+    }
+    float invd = 1.0f/d, eps=1e-5f;
+    vDSP_vsmsa(ss, 1, &invd, &eps, ss, 1, (vDSP_Length)S);
+    float *rrms = (float*)malloc(S*4);
+    int n = S; vvrsqrtf(rrms, ss, &n);
+    float *dot = (float*)calloc(S, sizeof(float));
+    for (int i=0; i<d; i++) {
+        vDSP_vmul(dy+i*S, 1, x+i*S, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vsma(rms_tmp, 1, &w[i], dot, 1, dot, 1, (vDSP_Length)S);
+    }
+    vDSP_vmul(rrms, 1, rrms, 1, ss, 1, (vDSP_Length)S);
+    vDSP_vsmul(ss, 1, &invd, ss, 1, (vDSP_Length)S);
+    vDSP_vmul(dot, 1, ss, 1, dot, 1, (vDSP_Length)S);
+    for (int i=0; i<d; i++) {
+        vDSP_vmul(x+i*S, 1, dot, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vsub(rms_tmp, 1, dy+i*S, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vmul(rms_tmp, 1, rrms, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vsmul(rms_tmp, 1, &w[i], dx+i*S, 1, (vDSP_Length)S);
+        vDSP_vmul(dy+i*S, 1, x+i*S, 1, rms_tmp, 1, (vDSP_Length)S);
+        vDSP_vmul(rms_tmp, 1, rrms, 1, rms_tmp, 1, (vDSP_Length)S);
+        float s; vDSP_sve(rms_tmp, 1, &s, (vDSP_Length)S);
+        dw[i] += s;
+    }
+    free(ss); free(rrms); free(dot); free(rms_tmp);
+}
+
+static void adam_update(float *w, const float *g, AdamState *s, int t, float lr, float b1, float b2, float eps) {
+    float bc1 = 1.0f - powf(b1, t), bc2 = 1.0f - powf(b2, t);
+    for (size_t i=0; i<s->n; i++) {
+        s->m[i] = b1*s->m[i] + (1-b1)*g[i];
+        s->v[i] = b2*s->v[i] + (1-b2)*g[i]*g[i];
+        float mh = s->m[i]/bc1, vh = s->v[i]/bc2;
+        w[i] -= lr * mh / (sqrtf(vh) + eps);
+    }
+}
+
+// Cross-entropy loss + gradient for logits (column-major: [VOCAB, SEQ])
+// logits[v*SEQ+t] = logit for vocab v, position t
+// targets[t] = target token id for position t
+// Returns mean CE loss, writes dlogits = softmax(logits) - one_hot(targets)
+// Data is column-major [V, S], but we process per-column (stride=1 within col is v*S+t, stride between v's is S)
+// For vDSP: transpose to row-major scratch [S, V] to vectorize softmax per position
+static float cross_entropy_loss(float *dlogits, const float *logits, const uint16_t *targets, int V, int S) {
+    // Work in transposed layout [S, V] where each row is one position's logits (contiguous)
+    float *buf = (float*)malloc(S * V * 4);
+    // Transpose [V,S] → [S,V]: buf[t*V+v] = logits[v*S+t]
+    vDSP_mtrans(logits, 1, buf, 1, (vDSP_Length)S, (vDSP_Length)V);
+
+    float total_loss = 0;
+    float invS = 1.0f / S;
+    for (int t = 0; t < S; t++) {
+        float *row = buf + t * V;
+        // max
+        float maxv;
+        vDSP_maxv(row, 1, &maxv, (vDSP_Length)V);
+        // row -= maxv
+        float neg_max = -maxv;
+        vDSP_vsadd(row, 1, &neg_max, row, 1, (vDSP_Length)V);
+        // exp in-place
+        int n = V;
+        vvexpf(row, row, &n);
+        // sum
+        float sum;
+        vDSP_sve(row, 1, &sum, (vDSP_Length)V);
+        // normalize
+        float inv_sum = 1.0f / sum;
+        vDSP_vsmul(row, 1, &inv_sum, row, 1, (vDSP_Length)V);
+        // loss
+        int tgt = targets[t];
+        if (tgt < 0 || tgt >= V) { fprintf(stderr, "WARN: target token %d out of vocab range [0,%d), skipping\n", tgt, V); continue; }
+        total_loss -= logf(row[tgt] + 1e-10f);
+        // gradient: softmax - one_hot, then /S
+        row[tgt] -= 1.0f;
+        vDSP_vsmul(row, 1, &invS, row, 1, (vDSP_Length)V);
+    }
+    // Transpose back [S,V] → [V,S]
+    vDSP_mtrans(buf, 1, dlogits, 1, (vDSP_Length)V, (vDSP_Length)S);
+    free(buf);
+    return total_loss / S;
+}
+
+// Embedding lookup: token_ids → x [DIM, SEQ] (channel-first)
+// embed is [VOCAB, DIM] row-major (vocab_size rows, dim cols)
+static void embed_lookup(float *x, const float *embed, const uint16_t *tokens, int dim, int seq) {
+    for (int t = 0; t < seq; t++) {
+        int tok = tokens[t];
+        if (tok < 0 || tok >= VOCAB) { fprintf(stderr, "WARN: token %d out of range [0,%d)\n", tok, VOCAB); continue; }
+        for (int d = 0; d < dim; d++) {
+            x[d*seq + t] = embed[tok*dim + d];
+        }
+    }
+}
+
+// Embedding backward: accumulate dE[tok] += dx[:,t] for each position
+static void embed_backward(float *d_embed, const float *dx, const uint16_t *tokens, int dim, int seq) {
+    for (int t = 0; t < seq; t++) {
+        int tok = tokens[t];
+        if (tok < 0 || tok >= VOCAB) { continue; }
+        for (int d = 0; d < dim; d++) {
+            d_embed[tok*dim + d] += dx[d*seq + t];
+        }
+    }
+}

--- a/ane/stories_io.h
+++ b/ane/stories_io.h
@@ -1,0 +1,134 @@
+// stories_io.h — IOSurface helpers, blob builders, NEON conversion
+#pragma once
+#include "stories_config.h"
+#include <arm_neon.h>
+
+static IOSurfaceRef make_surface(size_t bytes) {
+    return IOSurfaceCreate((__bridge CFDictionaryRef)@{
+        (id)kIOSurfaceWidth:@(bytes), (id)kIOSurfaceHeight:@1,
+        (id)kIOSurfaceBytesPerElement:@1, (id)kIOSurfaceBytesPerRow:@(bytes),
+        (id)kIOSurfaceAllocSize:@(bytes), (id)kIOSurfacePixelFormat:@0});
+}
+
+static NSData *build_blob(const float *w, int rows, int cols) {
+    int ws=rows*cols*2, tot=128+ws;
+    uint8_t *b=(uint8_t*)calloc(tot,1);
+    b[0]=1;b[4]=2;b[64]=0xEF;b[65]=0xBE;b[66]=0xAD;b[67]=0xDE;b[68]=1;
+    *(uint32_t*)(b+72)=ws;*(uint32_t*)(b+80)=128;
+    _Float16 *fp16=(_Float16*)(b+128);
+    for(int i=0;i<rows*cols;i++) fp16[i]=(_Float16)w[i];
+    return [NSData dataWithBytesNoCopy:b length:tot freeWhenDone:YES];
+}
+static NSData *build_blob_t(const float *w, int rows, int cols) {
+    int ws=cols*rows*2, tot=128+ws;
+    uint8_t *b=(uint8_t*)calloc(tot,1);
+    b[0]=1;b[4]=2;b[64]=0xEF;b[65]=0xBE;b[66]=0xAD;b[67]=0xDE;b[68]=1;
+    *(uint32_t*)(b+72)=ws;*(uint32_t*)(b+80)=128;
+    _Float16 *fp16=(_Float16*)(b+128);
+    for(int i=0;i<rows;i++) for(int j=0;j<cols;j++) fp16[j*rows+i]=(_Float16)w[i*cols+j];
+    return [NSData dataWithBytesNoCopy:b length:tot freeWhenDone:YES];
+}
+static NSData *build_blob_fp16(_Float16 *d, int cnt) {
+    int ws=cnt*2, tot=128+ws;
+    uint8_t *b=(uint8_t*)calloc(tot,1);
+    b[0]=1;b[4]=2;b[64]=0xEF;b[65]=0xBE;b[66]=0xAD;b[67]=0xDE;b[68]=1;
+    *(uint32_t*)(b+72)=ws;*(uint32_t*)(b+80)=128;
+    memcpy(b+128,d,ws);
+    return [NSData dataWithBytesNoCopy:b length:tot freeWhenDone:YES];
+}
+
+// NEON vectorized conversion
+static void cvt_f16_f32(float *dst, const _Float16 *src, int n) {
+    int i = 0;
+    for (; i+7 < n; i += 8) {
+        float16x8_t h = vld1q_f16((const __fp16*)(src+i));
+        vst1q_f32(dst+i,   vcvt_f32_f16(vget_low_f16(h)));
+        vst1q_f32(dst+i+4, vcvt_f32_f16(vget_high_f16(h)));
+    }
+    for (; i < n; i++) dst[i] = (float)src[i];
+}
+static void cvt_f32_f16(_Float16 *dst, const float *src, int n) {
+    int i = 0;
+    for (; i+7 < n; i += 8) {
+        float16x8_t h = vcombine_f16(vcvt_f16_f32(vld1q_f32(src+i)),
+                                      vcvt_f16_f32(vld1q_f32(src+i+4)));
+        vst1q_f16((__fp16*)(dst+i), h);
+    }
+    for (; i < n; i++) dst[i] = (_Float16)src[i];
+}
+
+// IOSurface I/O (channel-first [C,S] layout)
+static void io_write_fp16(IOSurfaceRef s, const float *data, int channels, int sp) {
+    IOSurfaceLock(s, 0, NULL);
+    cvt_f32_f16((_Float16*)IOSurfaceGetBaseAddress(s), data, channels * sp);
+    IOSurfaceUnlock(s, 0, NULL);
+}
+static void io_read_fp16(IOSurfaceRef s, float *data, int ch_off, int channels, int sp) {
+    IOSurfaceLock(s, kIOSurfaceLockReadOnly, NULL);
+    cvt_f16_f32(data, (_Float16*)IOSurfaceGetBaseAddress(s) + ch_off * sp, channels * sp);
+    IOSurfaceUnlock(s, kIOSurfaceLockReadOnly, NULL);
+}
+static void io_copy(IOSurfaceRef dst, int dst_ch, IOSurfaceRef src, int src_ch, int channels, int sp) {
+    IOSurfaceLock(dst, 0, NULL);
+    IOSurfaceLock(src, kIOSurfaceLockReadOnly, NULL);
+    memcpy((_Float16*)IOSurfaceGetBaseAddress(dst) + dst_ch*sp,
+           (_Float16*)IOSurfaceGetBaseAddress(src) + src_ch*sp,
+           channels * sp * sizeof(_Float16));
+    IOSurfaceUnlock(src, kIOSurfaceLockReadOnly, NULL);
+    IOSurfaceUnlock(dst, 0, NULL);
+}
+static void io_write_fp16_at(IOSurfaceRef s, int ch_off, const float *data, int channels, int sp) {
+    IOSurfaceLock(s, 0, NULL);
+    cvt_f32_f16((_Float16*)IOSurfaceGetBaseAddress(s) + ch_off * sp, data, channels * sp);
+    IOSurfaceUnlock(s, 0, NULL);
+}
+
+// Kernel compile/eval
+static Kern *compile_kern_mil_w(NSString *mil, NSDictionary *weights, int ic_bytes, int oc_bytes) {
+    @autoreleasepool {
+    NSData *md = [mil dataUsingEncoding:NSUTF8StringEncoding];
+    id desc = ((id(*)(Class,SEL,id,id,id))objc_msgSend)(g_D, @selector(modelWithMILText:weights:optionsPlist:), md, weights, nil);
+    if (!desc) { printf("  [compile] desc=NULL\n"); return NULL; }
+    id mdl = ((id(*)(Class,SEL,id))objc_msgSend)(g_I, @selector(inMemoryModelWithDescriptor:), desc);
+    id hx = ((id(*)(id,SEL))objc_msgSend)(mdl, @selector(hexStringIdentifier));
+    NSString *td = [NSTemporaryDirectory() stringByAppendingPathComponent:hx];
+    [[NSFileManager defaultManager] createDirectoryAtPath:[td stringByAppendingPathComponent:@"weights"] withIntermediateDirectories:YES attributes:nil error:nil];
+    [md writeToFile:[td stringByAppendingPathComponent:@"model.mil"] atomically:YES];
+    for (NSString *path in weights) {
+        NSString *rel = [path stringByReplacingOccurrencesOfString:@"@model_path/" withString:@""];
+        [weights[path][@"data"] writeToFile:[td stringByAppendingPathComponent:rel] atomically:YES];
+    }
+    NSError *e = nil;
+    if (!((BOOL(*)(id,SEL,unsigned int,id,NSError**))objc_msgSend)(mdl, @selector(compileWithQoS:options:error:), 21, @{}, &e)) {
+        printf("  [compile] FAIL: %s\n", e ? [[e description] UTF8String] : "no error"); return NULL;
+    }
+    if (!((BOOL(*)(id,SEL,unsigned int,id,NSError**))objc_msgSend)(mdl, @selector(loadWithQoS:options:error:), 21, @{}, &e)) {
+        printf("  [compile] load FAIL\n"); return NULL;
+    }
+    __sync_fetch_and_add(&g_compile_count, 1);
+    Kern *k = (Kern*)calloc(1, sizeof(Kern));
+    k->model = (void*)CFBridgingRetain(mdl);
+    k->ioIn = make_surface(ic_bytes);
+    k->ioOut = make_surface(oc_bytes);
+    id wI = ((id(*)(Class,SEL,IOSurfaceRef))objc_msgSend)(g_AIO, @selector(objectWithIOSurface:), k->ioIn);
+    id wO = ((id(*)(Class,SEL,IOSurfaceRef))objc_msgSend)(g_AIO, @selector(objectWithIOSurface:), k->ioOut);
+    k->request = (void*)CFBridgingRetain(((id(*)(Class,SEL,id,id,id,id,id,id,id))objc_msgSend)(g_AR,
+        @selector(requestWithInputs:inputIndices:outputs:outputIndices:weightsBuffer:perfStats:procedureIndex:),
+        @[wI], @[@0], @[wO], @[@0], nil, nil, @0));
+    k->tmpDir = (void*)CFBridgingRetain(td);
+    return k;
+    }
+}
+static void free_kern(Kern *k) {
+    if (!k) return;
+    id mdl = (__bridge id)k->model; NSError *e = nil;
+    ((BOOL(*)(id,SEL,unsigned int,NSError**))objc_msgSend)(mdl, @selector(unloadWithQoS:error:), 21, &e);
+    CFRelease(k->ioIn); CFRelease(k->ioOut);
+    [[NSFileManager defaultManager] removeItemAtPath:(__bridge id)k->tmpDir error:nil];
+    CFRelease(k->model); CFRelease(k->request); CFRelease(k->tmpDir);
+    free(k);
+}
+static void ane_eval(Kern *k) {
+    id mdl = (__bridge id)k->model; id req = (__bridge id)k->request; NSError *e = nil;
+    ((BOOL(*)(id,SEL,unsigned int,id,id,NSError**))objc_msgSend)(mdl, @selector(evaluateWithQoS:options:request:error:), 21, @{}, req, &e);
+}

--- a/ane/stories_mil.h
+++ b/ane/stories_mil.h
@@ -1,0 +1,286 @@
+// stories_mil.h — MIL program generators for ANE kernels
+// Same architecture as single-layer train_large.m but parameterized
+#pragma once
+#include "stories_io.h"
+
+#define MIL_HDR \
+    @"program(1.3)\n[buildInfo = dict<string, string>({{\"coremlc-component-MIL\", \"3510.2.1\"}, " \
+    "{\"coremlc-version\", \"3505.4.1\"}, {\"coremltools-component-milinternal\", \"\"}, " \
+    "{\"coremltools-version\", \"9.0\"}})]\n{\n"
+#define CONV_CONST \
+    "        string pt = const()[name=string(\"pt\"), val=string(\"valid\")];\n" \
+    "        tensor<int32, [2]> st = const()[name=string(\"st\"), val=tensor<int32, [2]>([1,1])];\n" \
+    "        tensor<int32, [4]> pd = const()[name=string(\"pd\"), val=tensor<int32, [4]>([0,0,0,0])];\n" \
+    "        tensor<int32, [2]> dl = const()[name=string(\"dl\"), val=tensor<int32, [2]>([1,1])];\n" \
+    "        int32 gr = const()[name=string(\"gr\"), val=int32(1)];\n"
+
+// SDPA forward + taps: x_in → rmsnorm → QKV+SDPA+Wo → concat(o_out, Q, K, V, attn_out, xnorm)
+static NSString *gen_sdpa_fwd_taps(void) {
+    float sc = 1.0f/sqrtf((float)HD);
+    float invd = 1.0f/(float)DIM;
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> sq = mul(x=x,y=x)[name=string(\"sq\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<int32, [1]> rax = const()[name=string(\"rax\"), val=tensor<int32, [1]>([1])];\n"];
+    [m appendFormat:@"        bool kd = const()[name=string(\"kd\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss = reduce_sum(x=sq,axes=rax,keep_dims=kd)[name=string(\"ss\")];\n", SEQ];
+    [m appendFormat:@"        fp16 invd = const()[name=string(\"invd\"), val=fp16(%f)];\n", invd];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss2 = mul(x=ss,y=invd)[name=string(\"ss2\")];\n", SEQ];
+    [m appendFormat:@"        fp16 eps = const()[name=string(\"eps\"), val=fp16(0.00001)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss3 = add(x=ss2,y=eps)[name=string(\"ss3\")];\n", SEQ];
+    [m appendFormat:@"        fp16 nhalf = const()[name=string(\"nhalf\"), val=fp16(-0.5)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> rrms = pow(x=ss3,y=nhalf)[name=string(\"rrms\")];\n", SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> xr = mul(x=x,y=rrms)[name=string(\"xr\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,1]> rw = const()[name=string(\"rw\"), val=tensor<fp16, [1,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/rms1.bin\"), offset=uint64(64)))];\n", DIM, DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> xn = mul(x=xr,y=rw)[name=string(\"xn\")];\n", DIM, SEQ];
+    [m appendString:@CONV_CONST];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wq = const()[name=string(\"Wq\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wq.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wk = const()[name=string(\"Wk\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wk.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wv = const()[name=string(\"Wv\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wv.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wo = const()[name=string(\"Wo\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wo.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> qf = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wq,x=xn)[name=string(\"cq\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> kf = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wk,x=xn)[name=string(\"ck\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> vf = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wv,x=xn)[name=string(\"cv\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> qsh = const()[name=string(\"qsh\"), val=tensor<int32, [4]>([1,%d,%d,%d])];\n", HEADS,HD,SEQ];
+    [m appendString:@"        tensor<int32, [4]> pm = const()[name=string(\"pm\"), val=tensor<int32, [4]>([0,1,3,2])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> q4 = reshape(shape=qsh,x=qf)[name=string(\"rq\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> q = transpose(perm=pm,x=q4)[name=string(\"tq\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> k4 = reshape(shape=qsh,x=kf)[name=string(\"rk\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> k = transpose(perm=pm,x=k4)[name=string(\"tk\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> v4 = reshape(shape=qsh,x=vf)[name=string(\"rv\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> v = transpose(perm=pm,x=v4)[name=string(\"tv\")];\n", HEADS,SEQ,HD];
+    [m appendString:@"        bool tx = const()[name=string(\"tx\"), val=bool(false)];\n"];
+    [m appendString:@"        bool ty = const()[name=string(\"ty\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> sc1 = matmul(transpose_x=tx,transpose_y=ty,x=q,y=k)[name=string(\"mm1\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        fp16 scv = const()[name=string(\"scv\"), val=fp16(%f)];\n", sc];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> sc2 = mul(x=sc1,y=scv)[name=string(\"scl\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,1,%d,%d]> cm = const()[name=string(\"cm\"), val=tensor<fp16, [1,1,%d,%d]>(BLOBFILE(path=string(\"@model_path/weights/mask.bin\"), offset=uint64(64)))];\n", SEQ,SEQ,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> ms = add(x=sc2,y=cm)[name=string(\"msk\")];\n", HEADS,SEQ,SEQ];
+    [m appendString:@"        int32 sax = const()[name=string(\"sax\"), val=int32(-1)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> aw = softmax(axis=sax,x=ms)[name=string(\"sm\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> a4 = matmul(transpose_x=tx,transpose_y=tx,x=aw,y=v)[name=string(\"mm2\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> at = transpose(perm=pm,x=a4)[name=string(\"ta\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> os = const()[name=string(\"os\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> af = reshape(shape=os,x=at)[name=string(\"ra\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> oo = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wo,x=af)[name=string(\"co\")];\n", DIM,SEQ];
+    [m appendString:@"        int32 cax = const()[name=string(\"cax\"), val=int32(1)];\n"];
+    [m appendString:@"        bool cid = const()[name=string(\"cid\"), val=bool(false)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = concat(axis=cax,interleave=cid,values=(oo,qf,kf,vf,af,xn))[name=string(\"cat\")];\n", 6*DIM,SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// FFN forward + taps: x2 → rmsnorm → FFN → concat(ffn_out, h1, h3, silu_out, x2norm)
+static NSString *gen_ffn_fwd_taps(void) {
+    float invd = 1.0f/(float)DIM;
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> sq = mul(x=x,y=x)[name=string(\"sq\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<int32, [1]> rax = const()[name=string(\"rax\"), val=tensor<int32, [1]>([1])];\n"];
+    [m appendFormat:@"        bool kd = const()[name=string(\"kd\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss = reduce_sum(x=sq,axes=rax,keep_dims=kd)[name=string(\"ss\")];\n", SEQ];
+    [m appendFormat:@"        fp16 invd = const()[name=string(\"invd\"), val=fp16(%f)];\n", invd];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss2 = mul(x=ss,y=invd)[name=string(\"ss2\")];\n", SEQ];
+    [m appendFormat:@"        fp16 eps = const()[name=string(\"eps\"), val=fp16(0.00001)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> ss3 = add(x=ss2,y=eps)[name=string(\"ss3\")];\n", SEQ];
+    [m appendFormat:@"        fp16 nhalf = const()[name=string(\"nhalf\"), val=fp16(-0.5)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,1,1,%d]> rrms = pow(x=ss3,y=nhalf)[name=string(\"rrms\")];\n", SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> xr = mul(x=x,y=rrms)[name=string(\"xr\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,1]> rw = const()[name=string(\"rw\"), val=tensor<fp16, [1,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/rms2.bin\"), offset=uint64(64)))];\n", DIM, DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> xn = mul(x=xr,y=rw)[name=string(\"xn\")];\n", DIM, SEQ];
+    [m appendString:@CONV_CONST];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W1 = const()[name=string(\"W1\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w1.bin\"), offset=uint64(64)))];\n", HIDDEN,DIM,HIDDEN,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W3 = const()[name=string(\"W3\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w3.bin\"), offset=uint64(64)))];\n", HIDDEN,DIM,HIDDEN,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W2 = const()[name=string(\"W2\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w2.bin\"), offset=uint64(64)))];\n", DIM,HIDDEN,DIM,HIDDEN];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> h1 = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W1,x=xn)[name=string(\"c1\")];\n", HIDDEN,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> h3 = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W3,x=xn)[name=string(\"c3\")];\n", HIDDEN,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> sig = sigmoid(x=h1)[name=string(\"sg\")];\n", HIDDEN,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> silu = mul(x=h1,y=sig)[name=string(\"si\")];\n", HIDDEN,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> gate = mul(x=silu,y=h3)[name=string(\"gt\")];\n", HIDDEN,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> y = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W2,x=gate)[name=string(\"c2\")];\n", DIM,SEQ];
+    [m appendString:@"        int32 cax = const()[name=string(\"cax\"), val=int32(1)];\n"];
+    [m appendString:@"        bool cid = const()[name=string(\"cid\"), val=bool(false)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = concat(axis=cax,interleave=cid,values=(y,h1,h3,gate,xn))[name=string(\"cat\")];\n", 2*DIM+3*HIDDEN,SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// FFN backward: concat(dffn,h1,h3) → concat(dx,dh1,dh3)
+static NSString *gen_ffn_bwd(void) {
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", DIM+2*HIDDEN, SEQ];
+    [m appendString:@CONV_CONST];
+    [m appendString:@"        tensor<int32, [4]> bd = const()[name=string(\"bd\"), val=tensor<int32, [4]>([0,0,0,0])];\n"];
+    [m appendFormat:@"        tensor<int32, [4]> sd = const()[name=string(\"sd\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dffn = slice_by_size(x=x,begin=bd,size=sd)[name=string(\"s0\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b1 = const()[name=string(\"b1\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", DIM];
+    [m appendFormat:@"        tensor<int32, [4]> s1 = const()[name=string(\"s1\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> h1 = slice_by_size(x=x,begin=b1,size=s1)[name=string(\"s1x\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b3 = const()[name=string(\"b3\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", DIM+HIDDEN];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> h3 = slice_by_size(x=x,begin=b3,size=s1)[name=string(\"s3x\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W2t = const()[name=string(\"W2t\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w2t.bin\"), offset=uint64(64)))];\n", HIDDEN, DIM, HIDDEN, DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dsilu = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W2t,x=dffn)[name=string(\"cw2\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> sig = sigmoid(x=h1)[name=string(\"sg\")];\n", HIDDEN, SEQ];
+    [m appendString:@"        fp16 one = const()[name=string(\"one\"), val=fp16(1.0)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> oms = sub(x=one,y=sig)[name=string(\"oms\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> homs = mul(x=h1,y=oms)[name=string(\"homs\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> brk = add(x=one,y=homs)[name=string(\"brk\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dsd = mul(x=sig,y=brk)[name=string(\"dsd\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> t1 = mul(x=dsilu,y=h3)[name=string(\"t1\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dh1 = mul(x=t1,y=dsd)[name=string(\"dh1\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> slh = mul(x=h1,y=sig)[name=string(\"slh\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dh3 = mul(x=dsilu,y=slh)[name=string(\"dh3\")];\n", HIDDEN, SEQ];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W1t = const()[name=string(\"W1t\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w1t.bin\"), offset=uint64(64)))];\n", DIM, HIDDEN, DIM, HIDDEN];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> W3t = const()[name=string(\"W3t\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/w3t.bin\"), offset=uint64(64)))];\n", DIM, HIDDEN, DIM, HIDDEN];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dx1 = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W1t,x=dh1)[name=string(\"cw1\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dx3 = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=W3t,x=dh3)[name=string(\"cw3\")];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dx = add(x=dx1,y=dx3)[name=string(\"adx\")];\n", DIM, SEQ];
+    [m appendString:@"        int32 cax = const()[name=string(\"cax\"), val=int32(1)];\n"];
+    [m appendString:@"        bool cid = const()[name=string(\"cid\"), val=bool(false)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = concat(axis=cax,interleave=cid,values=(dx,dh1,dh3))[name=string(\"cat\")];\n", DIM+2*HIDDEN, SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// QKV backward: concat(dq,dk,dv) → dx
+static NSString *gen_qkvb(void) {
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", 3*DIM, SEQ];
+    [m appendString:@CONV_CONST];
+    [m appendFormat:@"        tensor<int32, [4]> sz = const()[name=string(\"sz\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM, SEQ];
+    [m appendString:@"        tensor<int32, [4]> b0 = const()[name=string(\"b0\"), val=tensor<int32, [4]>([0,0,0,0])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dq = slice_by_size(x=x,begin=b0,size=sz)[name=string(\"s0\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b1 = const()[name=string(\"b1\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dk = slice_by_size(x=x,begin=b1,size=sz)[name=string(\"s1\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b2 = const()[name=string(\"b2\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", 2*DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dv = slice_by_size(x=x,begin=b2,size=sz)[name=string(\"s2\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wqt = const()[name=string(\"Wqt\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wqt.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wkt = const()[name=string(\"Wkt\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wkt.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wvt = const()[name=string(\"Wvt\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wvt.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dxq = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wqt,x=dq)[name=string(\"cq\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dxk = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wkt,x=dk)[name=string(\"ck\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dxv = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wvt,x=dv)[name=string(\"cv\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dxqk = add(x=dxq,y=dxk)[name=string(\"aqk\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = add(x=dxqk,y=dxv)[name=string(\"out\")];\n", DIM,SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// SDPA backward part 1 + Wo^T
+static NSString *gen_sdpa_bwd1(void) {
+    float sc = 1.0f/sqrtf((float)HD);
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", 4*DIM, SEQ];
+    [m appendString:@CONV_CONST];
+    [m appendFormat:@"        tensor<int32, [4]> sz = const()[name=string(\"sz\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM, SEQ];
+    [m appendString:@"        tensor<int32, [4]> b0 = const()[name=string(\"b0\"), val=tensor<int32, [4]>([0,0,0,0])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> qf = slice_by_size(x=x,begin=b0,size=sz)[name=string(\"s0\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b1 = const()[name=string(\"b1\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> kf = slice_by_size(x=x,begin=b1,size=sz)[name=string(\"s1\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b2 = const()[name=string(\"b2\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", 2*DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> vf = slice_by_size(x=x,begin=b2,size=sz)[name=string(\"s2\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b3 = const()[name=string(\"b3\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", 3*DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dx2f = slice_by_size(x=x,begin=b3,size=sz)[name=string(\"s3\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [%d,%d,1,1]> Wot = const()[name=string(\"Wot\"), val=tensor<fp16, [%d,%d,1,1]>(BLOBFILE(path=string(\"@model_path/weights/wot.bin\"), offset=uint64(64)))];\n", DIM,DIM,DIM,DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> df = conv(dilations=dl,groups=gr,pad=pd,pad_type=pt,strides=st,weight=Wot,x=dx2f)[name=string(\"cwo\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> rsh = const()[name=string(\"rsh\"), val=tensor<int32, [4]>([1,%d,%d,%d])];\n", HEADS,HD,SEQ];
+    [m appendString:@"        tensor<int32, [4]> pm = const()[name=string(\"pm\"), val=tensor<int32, [4]>([0,1,3,2])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> qr = reshape(shape=rsh,x=qf)[name=string(\"rq\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> q = transpose(perm=pm,x=qr)[name=string(\"tq\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> kr = reshape(shape=rsh,x=kf)[name=string(\"rk\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> k = transpose(perm=pm,x=kr)[name=string(\"tk\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> vr = reshape(shape=rsh,x=vf)[name=string(\"rv\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> v = transpose(perm=pm,x=vr)[name=string(\"tv\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dr = reshape(shape=rsh,x=df)[name=string(\"rd\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> da = transpose(perm=pm,x=dr)[name=string(\"td\")];\n", HEADS,SEQ,HD];
+    [m appendString:@"        bool bF = const()[name=string(\"bF\"), val=bool(false)];\n"];
+    [m appendString:@"        bool bT = const()[name=string(\"bT\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> sc1 = matmul(transpose_x=bF,transpose_y=bT,x=q,y=k)[name=string(\"mm1\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        fp16 scv = const()[name=string(\"scv\"), val=fp16(%f)];\n", sc];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> sc2 = mul(x=sc1,y=scv)[name=string(\"scl\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,1,%d,%d]> cm = const()[name=string(\"cm\"), val=tensor<fp16, [1,1,%d,%d]>(BLOBFILE(path=string(\"@model_path/weights/mask.bin\"), offset=uint64(64)))];\n", SEQ,SEQ,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> ms = add(x=sc2,y=cm)[name=string(\"msk\")];\n", HEADS,SEQ,SEQ];
+    [m appendString:@"        int32 sax = const()[name=string(\"sax\"), val=int32(-1)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> probs = softmax(axis=sax,x=ms)[name=string(\"sm\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dv4 = matmul(transpose_x=bT,transpose_y=bF,x=probs,y=da)[name=string(\"dv\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dp4 = matmul(transpose_x=bF,transpose_y=bT,x=da,y=v)[name=string(\"dp\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dvt = transpose(perm=pm,x=dv4)[name=string(\"dvt\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> dvs = const()[name=string(\"dvs\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dvf = reshape(shape=dvs,x=dvt)[name=string(\"dvf\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> scs = const()[name=string(\"scs\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", SCORE_CH,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> pf = reshape(shape=scs,x=probs)[name=string(\"pf\")];\n", SCORE_CH,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dpf = reshape(shape=scs,x=dp4)[name=string(\"dpf\")];\n", SCORE_CH,SEQ];
+    [m appendString:@"        int32 cax = const()[name=string(\"cax\"), val=int32(1)];\n"];
+    [m appendString:@"        bool cid = const()[name=string(\"cid\"), val=bool(false)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = concat(axis=cax,interleave=cid,values=(dvf,pf,dpf))[name=string(\"cat\")];\n", DIM+2*SCORE_CH,SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// SDPA backward part 2: concat(probs,dp,Q,K) → concat(dQ,dK)
+static NSString *gen_sdpa_bwd2(void) {
+    float sc = 1.0f/sqrtf((float)HD);
+    int bwd2_in = 2*SCORE_CH + 2*DIM;
+    NSMutableString *m = [NSMutableString string];
+    [m appendString:MIL_HDR];
+    [m appendFormat:@"    func main<ios18>(tensor<fp16, [1, %d, 1, %d]> x) {\n", bwd2_in, SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> sz_sc = const()[name=string(\"szsc\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", SCORE_CH, SEQ];
+    [m appendString:@"        tensor<int32, [4]> b0 = const()[name=string(\"b0\"), val=tensor<int32, [4]>([0,0,0,0])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> pf = slice_by_size(x=x,begin=b0,size=sz_sc)[name=string(\"s0\")];\n", SCORE_CH,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b1 = const()[name=string(\"b1\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", SCORE_CH];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dpf = slice_by_size(x=x,begin=b1,size=sz_sc)[name=string(\"s1\")];\n", SCORE_CH,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> sz_d = const()[name=string(\"szd\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM, SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b2 = const()[name=string(\"b2\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", 2*SCORE_CH];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> qf = slice_by_size(x=x,begin=b2,size=sz_d)[name=string(\"s2\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> b3 = const()[name=string(\"b3\"), val=tensor<int32, [4]>([0,%d,0,0])];\n", 2*SCORE_CH+DIM];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> kf = slice_by_size(x=x,begin=b3,size=sz_d)[name=string(\"s3\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> ssh = const()[name=string(\"ssh\"), val=tensor<int32, [4]>([1,%d,%d,%d])];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> probs = reshape(shape=ssh,x=pf)[name=string(\"rp\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dp = reshape(shape=ssh,x=dpf)[name=string(\"rdp\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> rsh = const()[name=string(\"rsh\"), val=tensor<int32, [4]>([1,%d,%d,%d])];\n", HEADS,HD,SEQ];
+    [m appendString:@"        tensor<int32, [4]> pm = const()[name=string(\"pm\"), val=tensor<int32, [4]>([0,1,3,2])];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> qr = reshape(shape=rsh,x=qf)[name=string(\"rq\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> q = transpose(perm=pm,x=qr)[name=string(\"tq\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> kr = reshape(shape=rsh,x=kf)[name=string(\"rk\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> k = transpose(perm=pm,x=kr)[name=string(\"tk\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> pdp = mul(x=probs,y=dp)[name=string(\"pdp\")];\n", HEADS,SEQ,SEQ];
+    [m appendString:@"        tensor<int32, [1]> rax = const()[name=string(\"rax\"), val=tensor<int32, [1]>([-1])];\n"];
+    [m appendString:@"        bool kd = const()[name=string(\"kd\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,1]> spdp = reduce_sum(x=pdp,axes=rax,keep_dims=kd)[name=string(\"rs\")];\n", HEADS,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dps = sub(x=dp,y=spdp)[name=string(\"dps\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> ds0 = mul(x=probs,y=dps)[name=string(\"ds0\")];\n", HEADS,SEQ,SEQ];
+    [m appendFormat:@"        fp16 scv = const()[name=string(\"scv\"), val=fp16(%f)];\n", sc];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> ds = mul(x=ds0,y=scv)[name=string(\"ds\")];\n", HEADS,SEQ,SEQ];
+    [m appendString:@"        bool bF = const()[name=string(\"bF\"), val=bool(false)];\n"];
+    [m appendString:@"        bool bT = const()[name=string(\"bT\"), val=bool(true)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dq4 = matmul(transpose_x=bF,transpose_y=bF,x=ds,y=k)[name=string(\"dq\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dk4 = matmul(transpose_x=bT,transpose_y=bF,x=ds,y=q)[name=string(\"dk\")];\n", HEADS,SEQ,HD];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dqt = transpose(perm=pm,x=dq4)[name=string(\"dqt\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,%d,%d]> dkt = transpose(perm=pm,x=dk4)[name=string(\"dkt\")];\n", HEADS,HD,SEQ];
+    [m appendFormat:@"        tensor<int32, [4]> fs = const()[name=string(\"fs\"), val=tensor<int32, [4]>([1,%d,1,%d])];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dqf = reshape(shape=fs,x=dqt)[name=string(\"dqf\")];\n", DIM,SEQ];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> dkf = reshape(shape=fs,x=dkt)[name=string(\"dkf\")];\n", DIM,SEQ];
+    [m appendString:@"        int32 cax = const()[name=string(\"cax\"), val=int32(1)];\n"];
+    [m appendString:@"        bool cid = const()[name=string(\"cid\"), val=bool(false)];\n"];
+    [m appendFormat:@"        tensor<fp16, [1,%d,1,%d]> out = concat(axis=cax,interleave=cid,values=(dqf,dkf))[name=string(\"cat\")];\n", 2*DIM,SEQ];
+    [m appendString:@"    } -> (out);\n}\n"];
+    return m;
+}
+
+// Mask blob (causal mask [SEQ,SEQ])
+static NSData *g_mask_blob = nil;
+static NSData *get_mask_blob(void) {
+    if (!g_mask_blob) {
+        _Float16 *mask = (_Float16*)calloc(SEQ*SEQ, sizeof(_Float16));
+        for(int t=0;t<SEQ;t++) for(int t2=0;t2<SEQ;t2++)
+            mask[t*SEQ+t2] = (t2<=t) ? (_Float16)0.0f : (_Float16)(-65504.0f);
+        g_mask_blob = build_blob_fp16(mask, SEQ*SEQ);
+        free(mask);
+    }
+    return g_mask_blob;
+}

--- a/ane/train_ane.m
+++ b/ane/train_ane.m
@@ -1,0 +1,716 @@
+// train_ane.m — Train transformer on Apple Neural Engine
+// Based on train_large.m from maderix/ANE
+// Modifications: +wall-time budget, +validation split, +forward-only val, +JSON output
+// Uses pretokenized TinyStories data with cross-entropy loss
+// 5 weight-bearing ANE kernels per layer × NLAYERS = 60 per compile batch
+#include "stories_io.h"
+#include "stories_mil.h"
+#include "stories_cpu_ops.h"
+
+#define CKPT_PATH_DEFAULT "ane_stories110M_ckpt.bin"
+#define MODEL_PATH_DEFAULT "stories110M.bin"
+#define DATA_PATH_DEFAULT "tinystories_data00.bin"
+
+#define VAL_WINDOWS 50
+
+// ===== Weight loading from llama2.c format =====
+static bool load_pretrained(LayerWeights *lw, float *rms_final, float *embed, const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) { printf("Cannot open %s\n", path); return false; }
+    Llama2Config cfg;
+    fread(&cfg, sizeof(cfg), 1, f);
+    printf("  Model config: dim=%d hidden=%d layers=%d heads=%d vocab=%d seq=%d\n",
+           cfg.dim, cfg.hidden_dim, cfg.n_layers, cfg.n_heads, abs(cfg.vocab_size), cfg.seq_len);
+    if (cfg.dim != DIM || cfg.hidden_dim != HIDDEN || cfg.n_layers != NLAYERS) {
+        printf("  ERROR: Config mismatch! Expected dim=%d hidden=%d layers=%d\n", DIM, HIDDEN, NLAYERS);
+        fclose(f); return false;
+    }
+    int V = abs(cfg.vocab_size);
+    bool shared = cfg.vocab_size > 0;
+
+    fread(embed, 4, V * DIM, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].rms_att, 4, DIM, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].Wq, 4, WQ_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].Wk, 4, WQ_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].Wv, 4, WQ_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].Wo, 4, WO_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].rms_ffn, 4, DIM, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].W1, 4, W1_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].W2, 4, W2_SZ, f);
+    for (int L = 0; L < NLAYERS; L++) fread(lw[L].W3, 4, W3_SZ, f);
+    fread(rms_final, 4, DIM, f);
+
+    fclose(f);
+    printf("  Loaded pretrained weights (%s)\n", shared ? "shared embed/cls" : "separate cls");
+    return true;
+}
+
+// ===== Compile one layer's kernels =====
+static bool compile_layer_kernels(LayerKernels *lk, LayerWeights *w) {
+    lk->fwdAttn = compile_kern_mil_w(gen_sdpa_fwd_taps(), (@{
+        @"@model_path/weights/rms1.bin": @{@"offset":@0, @"data":build_blob(w->rms_att,1,DIM)},
+        @"@model_path/weights/wq.bin": @{@"offset":@0, @"data":build_blob(w->Wq,DIM,DIM)},
+        @"@model_path/weights/wk.bin": @{@"offset":@0, @"data":build_blob(w->Wk,DIM,DIM)},
+        @"@model_path/weights/wv.bin": @{@"offset":@0, @"data":build_blob(w->Wv,DIM,DIM)},
+        @"@model_path/weights/wo.bin": @{@"offset":@0, @"data":build_blob(w->Wo,DIM,DIM)},
+        @"@model_path/weights/mask.bin": @{@"offset":@0, @"data":get_mask_blob()},
+    }), DIM*SEQ*2, 6*DIM*SEQ*2);
+
+    lk->fwdFFN = compile_kern_mil_w(gen_ffn_fwd_taps(), (@{
+        @"@model_path/weights/rms2.bin": @{@"offset":@0, @"data":build_blob(w->rms_ffn,1,DIM)},
+        @"@model_path/weights/w1.bin": @{@"offset":@0, @"data":build_blob(w->W1,HIDDEN,DIM)},
+        @"@model_path/weights/w3.bin": @{@"offset":@0, @"data":build_blob(w->W3,HIDDEN,DIM)},
+        @"@model_path/weights/w2.bin": @{@"offset":@0, @"data":build_blob(w->W2,DIM,HIDDEN)},
+    }), DIM*SEQ*2, (2*DIM+3*HIDDEN)*SEQ*2);
+
+    lk->ffnBwd = compile_kern_mil_w(gen_ffn_bwd(), (@{
+        @"@model_path/weights/w2t.bin": @{@"offset":@0, @"data":build_blob_t(w->W2,DIM,HIDDEN)},
+        @"@model_path/weights/w1t.bin": @{@"offset":@0, @"data":build_blob_t(w->W1,HIDDEN,DIM)},
+        @"@model_path/weights/w3t.bin": @{@"offset":@0, @"data":build_blob_t(w->W3,HIDDEN,DIM)},
+    }), (DIM+2*HIDDEN)*SEQ*2, (DIM+2*HIDDEN)*SEQ*2);
+
+    lk->sdpaBwd1 = compile_kern_mil_w(gen_sdpa_bwd1(), (@{
+        @"@model_path/weights/mask.bin": @{@"offset":@0, @"data":get_mask_blob()},
+        @"@model_path/weights/wot.bin": @{@"offset":@0, @"data":build_blob_t(w->Wo,DIM,DIM)},
+    }), 4*DIM*SEQ*2, (DIM+2*SCORE_CH)*SEQ*2);
+
+    lk->qkvBwd = compile_kern_mil_w(gen_qkvb(), (@{
+        @"@model_path/weights/wqt.bin": @{@"offset":@0, @"data":build_blob_t(w->Wq,DIM,DIM)},
+        @"@model_path/weights/wkt.bin": @{@"offset":@0, @"data":build_blob_t(w->Wk,DIM,DIM)},
+        @"@model_path/weights/wvt.bin": @{@"offset":@0, @"data":build_blob_t(w->Wv,DIM,DIM)},
+    }), 3*DIM*SEQ*2, DIM*SEQ*2);
+
+    return lk->fwdAttn && lk->fwdFFN && lk->ffnBwd && lk->sdpaBwd1 && lk->qkvBwd;
+}
+
+static Kern *compile_sdpa_bwd2(void) {
+    return compile_kern_mil_w(gen_sdpa_bwd2(), @{},
+        (2*SCORE_CH+2*DIM)*SEQ*2, 2*DIM*SEQ*2);
+}
+
+static void free_layer_kernels(LayerKernels *lk) {
+    free_kern(lk->fwdAttn); free_kern(lk->fwdFFN); free_kern(lk->ffnBwd);
+    free_kern(lk->sdpaBwd1); free_kern(lk->qkvBwd);
+    lk->fwdAttn = lk->fwdFFN = lk->ffnBwd = lk->sdpaBwd1 = lk->qkvBwd = NULL;
+}
+
+// ===== Checkpoint save/load =====
+static void save_checkpoint(const char *path, int step, int total_steps, float lr, float loss,
+                            double cc, double ct, double cw, int cs, int cb, int adam_t,
+                            LayerWeights *lw, LayerAdam *la, float *rms_final, AdamState *arms_final,
+                            float *embed, AdamState *aembed) {
+    FILE *f = fopen(path, "wb");
+    CkptHdr h = {0};
+    h.magic = 0x424C5A54; h.version = 2;
+    h.step = step; h.total_steps = total_steps;
+    h.n_layers = NLAYERS; h.vocab_size = VOCAB; h.dim = DIM;
+    h.hidden_dim = HIDDEN; h.n_heads = HEADS; h.seq_len = SEQ;
+    h.lr = lr; h.loss = loss;
+    h.cum_compile = cc; h.cum_train = ct; h.cum_wall = cw;
+    h.cum_steps = cs; h.cum_batches = cb; h.adam_t = adam_t;
+    fwrite(&h, sizeof(h), 1, f);
+    for (int L = 0; L < NLAYERS; L++) {
+        fwrite(lw[L].Wq,4,WQ_SZ,f); fwrite(lw[L].Wk,4,WQ_SZ,f);
+        fwrite(lw[L].Wv,4,WQ_SZ,f); fwrite(lw[L].Wo,4,WO_SZ,f);
+        fwrite(lw[L].W1,4,W1_SZ,f); fwrite(lw[L].W2,4,W2_SZ,f); fwrite(lw[L].W3,4,W3_SZ,f);
+        fwrite(lw[L].rms_att,4,DIM,f); fwrite(lw[L].rms_ffn,4,DIM,f);
+        fwrite(la[L].Wq.m,4,WQ_SZ,f); fwrite(la[L].Wq.v,4,WQ_SZ,f);
+        fwrite(la[L].Wk.m,4,WQ_SZ,f); fwrite(la[L].Wk.v,4,WQ_SZ,f);
+        fwrite(la[L].Wv.m,4,WQ_SZ,f); fwrite(la[L].Wv.v,4,WQ_SZ,f);
+        fwrite(la[L].Wo.m,4,WO_SZ,f); fwrite(la[L].Wo.v,4,WO_SZ,f);
+        fwrite(la[L].W1.m,4,W1_SZ,f); fwrite(la[L].W1.v,4,W1_SZ,f);
+        fwrite(la[L].W2.m,4,W2_SZ,f); fwrite(la[L].W2.v,4,W2_SZ,f);
+        fwrite(la[L].W3.m,4,W3_SZ,f); fwrite(la[L].W3.v,4,W3_SZ,f);
+        fwrite(la[L].rms_att.m,4,DIM,f); fwrite(la[L].rms_att.v,4,DIM,f);
+        fwrite(la[L].rms_ffn.m,4,DIM,f); fwrite(la[L].rms_ffn.v,4,DIM,f);
+    }
+    fwrite(rms_final,4,DIM,f);
+    fwrite(arms_final->m,4,DIM,f); fwrite(arms_final->v,4,DIM,f);
+    fwrite(embed,4,VOCAB*DIM,f);
+    fwrite(aembed->m,4,VOCAB*DIM,f); fwrite(aembed->v,4,VOCAB*DIM,f);
+    fclose(f);
+}
+
+static bool load_checkpoint(const char *path, int *step, int *total_steps, float *lr, float *loss,
+                             double *cc, double *ct, double *cw, int *cs, int *cb, int *adam_t,
+                             LayerWeights *lw, LayerAdam *la, float *rms_final, AdamState *arms_final,
+                             float *embed, AdamState *aembed) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return false;
+    CkptHdr h;
+    fread(&h, sizeof(h), 1, f);
+    if (h.magic != 0x424C5A54 || h.version != 2) { fclose(f); return false; }
+    *step = h.step; *total_steps = h.total_steps; *lr = h.lr; *loss = h.loss;
+    *cc = h.cum_compile; *ct = h.cum_train; *cw = h.cum_wall;
+    *cs = h.cum_steps; *cb = h.cum_batches; *adam_t = h.adam_t;
+    for (int L = 0; L < NLAYERS; L++) {
+        fread(lw[L].Wq,4,WQ_SZ,f); fread(lw[L].Wk,4,WQ_SZ,f);
+        fread(lw[L].Wv,4,WQ_SZ,f); fread(lw[L].Wo,4,WO_SZ,f);
+        fread(lw[L].W1,4,W1_SZ,f); fread(lw[L].W2,4,W2_SZ,f); fread(lw[L].W3,4,W3_SZ,f);
+        fread(lw[L].rms_att,4,DIM,f); fread(lw[L].rms_ffn,4,DIM,f);
+        fread(la[L].Wq.m,4,WQ_SZ,f); fread(la[L].Wq.v,4,WQ_SZ,f);
+        fread(la[L].Wk.m,4,WQ_SZ,f); fread(la[L].Wk.v,4,WQ_SZ,f);
+        fread(la[L].Wv.m,4,WQ_SZ,f); fread(la[L].Wv.v,4,WQ_SZ,f);
+        fread(la[L].Wo.m,4,WO_SZ,f); fread(la[L].Wo.v,4,WO_SZ,f);
+        fread(la[L].W1.m,4,W1_SZ,f); fread(la[L].W1.v,4,W1_SZ,f);
+        fread(la[L].W2.m,4,W2_SZ,f); fread(la[L].W2.v,4,W2_SZ,f);
+        fread(la[L].W3.m,4,W3_SZ,f); fread(la[L].W3.v,4,W3_SZ,f);
+        fread(la[L].rms_att.m,4,DIM,f); fread(la[L].rms_att.v,4,DIM,f);
+        fread(la[L].rms_ffn.m,4,DIM,f); fread(la[L].rms_ffn.v,4,DIM,f);
+    }
+    fread(rms_final,4,DIM,f);
+    fread(arms_final->m,4,DIM,f); fread(arms_final->v,4,DIM,f);
+    fread(embed,4,VOCAB*DIM,f);
+    fread(aembed->m,4,VOCAB*DIM,f); fread(aembed->v,4,VOCAB*DIM,f);
+    fclose(f);
+    return true;
+}
+
+// ===== Main =====
+int main(int argc, char *argv[]) {
+    @autoreleasepool {
+        setbuf(stdout, NULL);
+        ane_init();
+        mach_timebase_info(&g_tb);
+
+        int total_steps = 10000;
+        float lr = LEARNING_RATE;
+        float adam_b1 = ADAM_BETA1, adam_b2 = ADAM_BETA2, adam_eps = ADAM_EPS;
+        int adam_t = 0, start_step = 0;
+
+        // Parse args
+        const char *ckpt_path = CKPT_PATH_DEFAULT;
+        const char *model_path = MODEL_PATH_DEFAULT;
+        const char *data_path = DATA_PATH_DEFAULT;
+        bool do_resume = false;
+        bool fresh = false;
+        int wall_time_budget = 300;  // default 5 min
+        int pos = 0;
+        for (int i=1; i<argc; i++) {
+            if (strcmp(argv[i], "--resume") == 0) do_resume = true;
+            else if (strcmp(argv[i], "--fresh") == 0) fresh = true;
+            else if (strcmp(argv[i], "--wall-time") == 0 && i+1<argc) wall_time_budget = atoi(argv[++i]);
+            else if (strcmp(argv[i], "--steps") == 0 && i+1<argc) total_steps = atoi(argv[++i]);
+            else if (strcmp(argv[i], "--lr") == 0 && i+1<argc) lr = atof(argv[++i]);
+            else if (strcmp(argv[i], "--ckpt") == 0 && i+1<argc) ckpt_path = argv[++i];
+            else if (strcmp(argv[i], "--model") == 0 && i+1<argc) model_path = argv[++i];
+            else if (strcmp(argv[i], "--data") == 0 && i+1<argc) data_path = argv[++i];
+            else if (argv[i][0] != '-') {
+                if (pos == 0) model_path = argv[i];
+                else if (pos == 1) { /* seq - compile-time constant */ }
+                else if (pos == 2) total_steps = atoi(argv[i]);
+                else if (pos == 3) lr = atof(argv[i]);
+                pos++;
+            }
+        }
+
+        // Allocate per-layer state
+        LayerWeights lw[NLAYERS];
+        LayerAdam la[NLAYERS];
+        LayerActs acts[NLAYERS];
+        LayerGrads grads[NLAYERS];
+        LayerKernels kern[NLAYERS];
+        for (int L=0; L<NLAYERS; L++) {
+            lw[L] = layer_weights_alloc();
+            la[L] = layer_adam_alloc();
+            acts[L] = layer_acts_alloc();
+            grads[L] = layer_grads_alloc();
+            memset(&kern[L], 0, sizeof(LayerKernels));
+        }
+
+        // Final RMSNorm + embedding + classifier
+        float *rms_final = (float*)malloc(DIM*4);
+        float *embed = (float*)malloc(VOCAB*DIM*4);
+        float *grms_final = (float*)calloc(DIM, 4);
+        float *gembed = (float*)calloc(VOCAB*DIM, 4);
+        AdamState arms_final = adam_alloc(DIM);
+        AdamState aembed = adam_alloc((size_t)VOCAB*DIM);
+
+        double cum_compile=0, cum_train=0, cum_wall=0;
+        int cum_steps=0, cum_batches=0;
+
+        float resume_loss = 0;
+        bool resuming = false;
+        if (do_resume) {
+            resuming = load_checkpoint(ckpt_path, &start_step, &total_steps, &lr, &resume_loss,
+                &cum_compile, &cum_train, &cum_wall, &cum_steps, &cum_batches, &adam_t,
+                lw, la, rms_final, &arms_final, embed, &aembed);
+            if (resuming) printf("[RESUMED step %d, loss=%.4f]\n", start_step, resume_loss);
+        }
+        if (!resuming) {
+            printf("=== ANE Training ===\n");
+            printf("dim=%d hidden=%d heads=%d seq=%d vocab=%d layers=%d\n", DIM, HIDDEN, HEADS, SEQ, VOCAB, NLAYERS);
+            printf("wall_time_budget=%ds\n", wall_time_budget);
+            bool loaded = false;
+            if (!fresh) loaded = load_pretrained(lw, rms_final, embed, model_path);
+            if (!loaded) {
+                printf("Using random init\n");
+                srand48(42);
+                float scale_d=1.0f/sqrtf(DIM), scale_h=1.0f/sqrtf(HIDDEN);
+                for (int L=0; L<NLAYERS; L++) {
+                    for(size_t i=0;i<WQ_SZ;i++){lw[L].Wq[i]=scale_d*(2*drand48()-1);lw[L].Wk[i]=scale_d*(2*drand48()-1);}
+                    for(size_t i=0;i<WQ_SZ;i++){lw[L].Wv[i]=scale_d*(2*drand48()-1);lw[L].Wo[i]=scale_d*(2*drand48()-1);}
+                    for(size_t i=0;i<W1_SZ;i++) lw[L].W1[i]=scale_h*(2*drand48()-1);
+                    for(size_t i=0;i<W2_SZ;i++) lw[L].W2[i]=scale_d*(2*drand48()-1);
+                    for(size_t i=0;i<W3_SZ;i++) lw[L].W3[i]=scale_h*(2*drand48()-1);
+                    for(int i=0;i<DIM;i++){lw[L].rms_att[i]=1.0f; lw[L].rms_ffn[i]=1.0f;}
+                }
+                for(int i=0;i<DIM;i++) rms_final[i]=1.0f;
+                float escale = 0.02f;
+                for(size_t i=0;i<(size_t)VOCAB*DIM;i++) embed[i]=escale*(2*drand48()-1);
+            }
+            size_t tp = (size_t)NLAYERS*LAYER_PARAMS + DIM + (size_t)VOCAB*DIM;
+            double xfmr_params = (double)NLAYERS*LAYER_PARAMS;
+            double embed_params = (double)VOCAB*DIM;
+            printf("Params: %.2fM (transformer %.2fM + embed %.2fM)\n", tp/1e6, xfmr_params/1e6, embed_params/1e6);
+            printf("Accum %d steps per recompile | Adam LR=%.1e b1=%.1f b2=%.3f\n", ACCUM_STEPS, lr, adam_b1, adam_b2);
+        }
+
+        // mmap token data
+        int data_fd = open(data_path, O_RDONLY);
+        if (data_fd < 0) {
+            printf("Cannot open token data: %s\n", data_path);
+            printf("Hint: run `bash ane/download_data.sh` or pass --data /path/to/tinystories_data00.bin\n");
+            return 1;
+        }
+        struct stat st; fstat(data_fd, &st);
+        size_t data_len = st.st_size;
+        uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
+        if (token_data == MAP_FAILED) { printf("mmap failed\n"); return 1; }
+        size_t n_tokens = data_len / 2;
+        if (n_tokens <= (size_t)(SEQ + 1)) {
+            printf("Token data too short: need at least %d tokens, got %zu\n", SEQ + 2, n_tokens);
+            munmap(token_data, data_len); close(data_fd); return 1;
+        }
+
+        // 90/10 train/val split
+        size_t val_start = (size_t)(n_tokens * 0.9);
+        size_t train_tokens = val_start;
+        size_t val_tokens = n_tokens - val_start;
+        printf("Token data: %zu tokens (%.1f MB) | train: %zu val: %zu\n",
+               n_tokens, data_len/1e6, train_tokens, val_tokens);
+
+        // Gradient buffers shared across layers
+        float *dy = (float*)malloc(SEQ*DIM*4);
+        float *dffn = (float*)malloc(SEQ*DIM*4);
+        float *dh1 = (float*)malloc(SEQ*HIDDEN*4);
+        float *dh3 = (float*)malloc(SEQ*HIDDEN*4);
+        float *dx_ffn = (float*)malloc(SEQ*DIM*4);
+        float *dx2 = (float*)malloc(SEQ*DIM*4);
+        float *do_out_buf = (float*)malloc(SEQ*DIM*4);
+        float *dq = (float*)malloc(SEQ*DIM*4);
+        float *dk = (float*)malloc(SEQ*DIM*4);
+        float *dv = (float*)malloc(SEQ*DIM*4);
+        float *dx_attn = (float*)malloc(SEQ*DIM*4);
+
+        float *x_cur = (float*)malloc(SEQ*DIM*4);
+        float *x_final = (float*)malloc(SEQ*DIM*4);
+        float *logits = (float*)malloc(SEQ*VOCAB*4);
+        float *dlogits = (float*)malloc(SEQ*VOCAB*4);
+
+        // Compile static sdpaBwd2 kernels
+        Kern *sdpaBwd2[NLAYERS];
+        for (int L=0; L<NLAYERS; L++) {
+            sdpaBwd2[L] = compile_sdpa_bwd2();
+            if (!sdpaBwd2[L]) { printf("sdpaBwd2 compile failed\n"); return 1; }
+        }
+
+        dispatch_queue_t dw_q = dispatch_queue_create("dw_cblas", DISPATCH_QUEUE_SERIAL);
+        dispatch_group_t dw_grp = dispatch_group_create();
+
+        float last_loss = 999.0f;
+        double total_compile_ms=0, total_train_ms=0;
+        int total_steps_done=0, total_batches=0;
+        uint64_t t_wall_start = mach_absolute_time();
+
+        srand48(42 + start_step);
+
+        bool wall_time_exceeded = false;
+        int step = start_step;
+        while (step < total_steps) {
+            // Check compile budget
+            if (g_compile_count + TOTAL_WEIGHT_KERNELS > MAX_COMPILES) {
+                // Check wall-time budget before exec() restart
+                double elapsed_s = (tb_ms(mach_absolute_time() - t_wall_start) + cum_wall) / 1000.0;
+                if (elapsed_s + 30.0 > wall_time_budget) {
+                    printf("[wall-time budget nearly exhausted (%.0fs / %ds), stopping training]\n",
+                           elapsed_s, wall_time_budget);
+                    wall_time_exceeded = true;
+                    break;
+                }
+
+                for (int L=0; L<NLAYERS; L++) { free_layer_kernels(&kern[L]); free_kern(sdpaBwd2[L]); }
+                double wall = tb_ms(mach_absolute_time() - t_wall_start);
+                save_checkpoint(ckpt_path, step, total_steps, lr, last_loss,
+                    total_compile_ms+cum_compile, total_train_ms+cum_train, wall+cum_wall,
+                    total_steps_done+cum_steps, total_batches+cum_batches, adam_t,
+                    lw, la, rms_final, &arms_final, embed, &aembed);
+                printf("[exec() restart step %d, %d compiles, loss=%.4f]\n", step, g_compile_count, last_loss);
+                fflush(stdout);
+                // Pass --wall-time through exec
+                char wt_str[32]; snprintf(wt_str, sizeof(wt_str), "%d", wall_time_budget);
+                execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, "--data", data_path,
+                      "--wall-time", wt_str, NULL);
+                perror("execl"); return 1;
+            }
+
+            // Compile all layers' weight-bearing kernels
+            uint64_t tc = mach_absolute_time();
+            for (int L=0; L<NLAYERS; L++) free_layer_kernels(&kern[L]);
+
+            bool compile_ok = true;
+            for (int L=0; L<NLAYERS; L++) {
+                printf("  Compiling layer %d/%d... (%d compiles)\r", L+1, NLAYERS, g_compile_count);
+                fflush(stdout);
+                if (!compile_layer_kernels(&kern[L], &lw[L])) {
+                    printf("\nCompile failed at layer %d, restart\n", L);
+                    compile_ok = false; break;
+                }
+            }
+            if (!compile_ok) { g_compile_count = MAX_COMPILES; continue; }
+
+            for (int L=0; L<NLAYERS; L++) {
+                if (!sdpaBwd2[L]) {
+                    sdpaBwd2[L] = compile_sdpa_bwd2();
+                    if (!sdpaBwd2[L]) { printf("sdpaBwd2 recompile failed\n"); return 1; }
+                }
+            }
+
+            double cms = tb_ms(mach_absolute_time() - tc);
+            total_compile_ms += cms;
+            printf("  Compiled %d kernels in %.0fms                    \n", TOTAL_WEIGHT_KERNELS, cms);
+
+            // Zero gradient accumulators
+            for (int L=0; L<NLAYERS; L++) layer_grads_zero(&grads[L]);
+            memset(grms_final, 0, DIM*4);
+            memset(gembed, 0, (size_t)VOCAB*DIM*4);
+
+            int steps_batch = 0;
+            uint64_t tt = mach_absolute_time();
+            double t_ane=0,t_io=0,t_elem=0,t_rms=0,t_cblas_wait=0,t_cls=0;
+            (void)t_ane;(void)t_io;(void)t_elem;(void)t_rms;(void)t_cblas_wait;(void)t_cls;
+
+            for (int a=0; a<ACCUM_STEPS && step<total_steps; a++, step++) {
+                // Check wall-time budget per step
+                double elapsed_s = (tb_ms(mach_absolute_time() - t_wall_start) + cum_wall) / 1000.0;
+                if (elapsed_s + 10.0 > wall_time_budget) {
+                    printf("[wall-time budget nearly exhausted (%.0fs / %ds), stopping training]\n",
+                           elapsed_s, wall_time_budget);
+                    wall_time_exceeded = true;
+                    break;
+                }
+
+                uint64_t t0,t1;
+                // Sample random position in TRAINING portion only
+                size_t max_pos = train_tokens - SEQ - 1;
+                size_t rpos = (size_t)(drand48() * max_pos);
+                uint16_t *input_tokens = token_data + rpos;
+                uint16_t *target_tokens = token_data + rpos + 1;
+
+                // Embedding lookup
+                t0=mach_absolute_time();
+                embed_lookup(x_cur, embed, input_tokens, DIM, SEQ);
+                t1=mach_absolute_time(); t_elem+=tb_ms(t1-t0);
+
+                // ===== FORWARD =====
+                for (int L=0; L<NLAYERS; L++) {
+                    LayerActs *ac = &acts[L];
+                    memcpy(ac->layer_in, x_cur, SEQ*DIM*4);
+                    t0=mach_absolute_time();
+                    dispatch_group_wait(dw_grp, DISPATCH_TIME_FOREVER);
+                    t1=mach_absolute_time(); t_cblas_wait+=tb_ms(t1-t0); t0=t1;
+                    io_write_fp16(kern[L].fwdAttn->ioIn, x_cur, DIM, SEQ);
+                    t1=mach_absolute_time(); t_io+=tb_ms(t1-t0); t0=t1;
+                    ane_eval(kern[L].fwdAttn);
+                    t1=mach_absolute_time(); t_ane+=tb_ms(t1-t0); t0=t1;
+                    io_read_fp16(kern[L].fwdAttn->ioOut, ac->o_out,    0,     DIM, SEQ);
+                    io_read_fp16(kern[L].fwdAttn->ioOut, ac->attn_out, 4*DIM, DIM, SEQ);
+                    io_read_fp16(kern[L].fwdAttn->ioOut, ac->xnorm,    5*DIM, DIM, SEQ);
+                    t1=mach_absolute_time(); t_io+=tb_ms(t1-t0); t0=t1;
+                    vDSP_vadd(x_cur, 1, ac->o_out, 1, ac->x2, 1, (vDSP_Length)(SEQ*DIM));
+                    t1=mach_absolute_time(); t_elem+=tb_ms(t1-t0); t0=t1;
+                    io_write_fp16(kern[L].fwdFFN->ioIn, ac->x2, DIM, SEQ);
+                    t1=mach_absolute_time(); t_io+=tb_ms(t1-t0); t0=t1;
+                    ane_eval(kern[L].fwdFFN);
+                    t1=mach_absolute_time(); t_ane+=tb_ms(t1-t0); t0=t1;
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ac->ffn_out,  0,              DIM,    SEQ);
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ac->h1,       DIM,            HIDDEN, SEQ);
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ac->h3,       DIM+HIDDEN,     HIDDEN, SEQ);
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ac->silu_out, DIM+2*HIDDEN,   HIDDEN, SEQ);
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ac->x2norm,   DIM+3*HIDDEN,   DIM,    SEQ);
+                    t1=mach_absolute_time(); t_io+=tb_ms(t1-t0); t0=t1;
+                    vDSP_vadd(ac->x2, 1, ac->ffn_out, 1, x_cur, 1, (vDSP_Length)(SEQ*DIM));
+                    t1=mach_absolute_time(); t_elem+=tb_ms(t1-t0);
+                }
+
+                t0=mach_absolute_time();
+                rmsnorm(x_final, x_cur, rms_final, DIM, SEQ);
+                t1=mach_absolute_time(); t_rms+=tb_ms(t1-t0); t0=t1;
+                cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                            VOCAB, SEQ, DIM, 1.0f,
+                            embed, DIM, x_final, SEQ, 0.0f, logits, SEQ);
+                t1=mach_absolute_time(); t_cls+=tb_ms(t1-t0); t0=t1;
+                float loss = cross_entropy_loss(dlogits, logits, target_tokens, VOCAB, SEQ);
+                last_loss = loss;
+                t1=mach_absolute_time(); t_elem+=tb_ms(t1-t0); t0=t1;
+
+                // ===== BACKWARD =====
+                cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+                            DIM, SEQ, VOCAB, 1.0f,
+                            embed, DIM, dlogits, SEQ, 0.0f, dy, SEQ);
+                dispatch_group_async(dw_grp, dw_q, ^{
+                    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                                VOCAB, DIM, SEQ, 1.0f,
+                                dlogits, SEQ, x_final, SEQ, 1.0f, gembed, DIM);
+                });
+
+                float *dx_rms_final = (float*)calloc(SEQ*DIM, 4);
+                rmsnorm_bwd(dx_rms_final, grms_final, dy, x_cur, rms_final, DIM, SEQ);
+                memcpy(dy, dx_rms_final, SEQ*DIM*4);
+                free(dx_rms_final);
+
+                for (int L=NLAYERS-1; L>=0; L--) {
+                    LayerActs *ac = &acts[L];
+                    LayerGrads *gr = &grads[L];
+                    memcpy(dffn, dy, SEQ*DIM*4);
+
+                    io_write_fp16_at(kern[L].ffnBwd->ioIn, 0, dffn, DIM, SEQ);
+                    io_copy(kern[L].ffnBwd->ioIn, DIM, kern[L].fwdFFN->ioOut, DIM, 2*HIDDEN, SEQ);
+                    ane_eval(kern[L].ffnBwd);
+                    io_read_fp16(kern[L].ffnBwd->ioOut, dx_ffn, 0,           DIM,    SEQ);
+                    io_read_fp16(kern[L].ffnBwd->ioOut, dh1,    DIM,         HIDDEN, SEQ);
+                    io_read_fp16(kern[L].ffnBwd->ioOut, dh3,    DIM+HIDDEN,  HIDDEN, SEQ);
+
+                    float *capt_dffn = (float*)malloc(SEQ*DIM*4); memcpy(capt_dffn, dffn, SEQ*DIM*4);
+                    float *capt_silu = (float*)malloc(SEQ*HIDDEN*4); memcpy(capt_silu, ac->silu_out, SEQ*HIDDEN*4);
+                    float *capt_dh1 = (float*)malloc(SEQ*HIDDEN*4); memcpy(capt_dh1, dh1, SEQ*HIDDEN*4);
+                    float *capt_dh3 = (float*)malloc(SEQ*HIDDEN*4); memcpy(capt_dh3, dh3, SEQ*HIDDEN*4);
+                    float *capt_x2n = (float*)malloc(SEQ*DIM*4); memcpy(capt_x2n, ac->x2norm, SEQ*DIM*4);
+                    dispatch_group_async(dw_grp, dw_q, ^{
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, DIM, HIDDEN, SEQ,
+                                    1.0f, capt_dffn, SEQ, capt_silu, SEQ, 1.0f, gr->W2, HIDDEN);
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, HIDDEN, DIM, SEQ,
+                                    1.0f, capt_dh1, SEQ, capt_x2n, SEQ, 1.0f, gr->W1, DIM);
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, HIDDEN, DIM, SEQ,
+                                    1.0f, capt_dh3, SEQ, capt_x2n, SEQ, 1.0f, gr->W3, DIM);
+                        free(capt_dffn); free(capt_silu); free(capt_dh1); free(capt_dh3); free(capt_x2n);
+                    });
+
+                    memset(dx2, 0, SEQ*DIM*4);
+                    rmsnorm_bwd(dx2, gr->rms_ffn, dx_ffn, ac->x2, lw[L].rms_ffn, DIM, SEQ);
+                    for(int i=0;i<SEQ*DIM;i++) dx2[i] += dy[i];
+
+                    memcpy(do_out_buf, dx2, SEQ*DIM*4);
+                    float *capt_do = (float*)malloc(SEQ*DIM*4); memcpy(capt_do, do_out_buf, SEQ*DIM*4);
+                    float *capt_attn = (float*)malloc(SEQ*DIM*4); memcpy(capt_attn, ac->attn_out, SEQ*DIM*4);
+                    dispatch_group_async(dw_grp, dw_q, ^{
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, DIM, DIM, SEQ,
+                                    1.0f, capt_do, SEQ, capt_attn, SEQ, 1.0f, gr->Wo, DIM);
+                        free(capt_do); free(capt_attn);
+                    });
+
+                    io_copy(kern[L].sdpaBwd1->ioIn, 0, kern[L].fwdAttn->ioOut, DIM, 3*DIM, SEQ);
+                    io_write_fp16_at(kern[L].sdpaBwd1->ioIn, 3*DIM, dx2, DIM, SEQ);
+                    ane_eval(kern[L].sdpaBwd1);
+                    io_copy(sdpaBwd2[L]->ioIn, 0, kern[L].sdpaBwd1->ioOut, DIM, 2*SCORE_CH, SEQ);
+                    io_copy(sdpaBwd2[L]->ioIn, 2*SCORE_CH, kern[L].fwdAttn->ioOut, DIM, 2*DIM, SEQ);
+                    ane_eval(sdpaBwd2[L]);
+
+                    io_read_fp16(sdpaBwd2[L]->ioOut, dq, 0,   DIM, SEQ);
+                    io_read_fp16(sdpaBwd2[L]->ioOut, dk, DIM,  DIM, SEQ);
+                    io_read_fp16(kern[L].sdpaBwd1->ioOut, dv, 0, DIM, SEQ);
+
+                    float *capt_dq = (float*)malloc(SEQ*DIM*4); memcpy(capt_dq, dq, SEQ*DIM*4);
+                    float *capt_dk = (float*)malloc(SEQ*DIM*4); memcpy(capt_dk, dk, SEQ*DIM*4);
+                    float *capt_dv = (float*)malloc(SEQ*DIM*4); memcpy(capt_dv, dv, SEQ*DIM*4);
+                    float *capt_xn = (float*)malloc(SEQ*DIM*4); memcpy(capt_xn, ac->xnorm, SEQ*DIM*4);
+                    dispatch_group_async(dw_grp, dw_q, ^{
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, DIM, DIM, SEQ,
+                                    1.0f, capt_dq, SEQ, capt_xn, SEQ, 1.0f, gr->Wq, DIM);
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, DIM, DIM, SEQ,
+                                    1.0f, capt_dk, SEQ, capt_xn, SEQ, 1.0f, gr->Wk, DIM);
+                        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, DIM, DIM, SEQ,
+                                    1.0f, capt_dv, SEQ, capt_xn, SEQ, 1.0f, gr->Wv, DIM);
+                        free(capt_dq); free(capt_dk); free(capt_dv); free(capt_xn);
+                    });
+
+                    io_copy(kern[L].qkvBwd->ioIn, 0, sdpaBwd2[L]->ioOut, 0, 2*DIM, SEQ);
+                    io_copy(kern[L].qkvBwd->ioIn, 2*DIM, kern[L].sdpaBwd1->ioOut, 0, DIM, SEQ);
+                    ane_eval(kern[L].qkvBwd);
+                    io_read_fp16(kern[L].qkvBwd->ioOut, dx_attn, 0, DIM, SEQ);
+
+                    float *dx_rms1 = (float*)calloc(SEQ*DIM, 4);
+                    rmsnorm_bwd(dx_rms1, gr->rms_att, dx_attn, ac->layer_in, lw[L].rms_att, DIM, SEQ);
+                    for(int i=0;i<SEQ*DIM;i++) dy[i] = dx_rms1[i] + dx2[i];
+                    free(dx_rms1);
+                }
+
+                dispatch_group_wait(dw_grp, DISPATCH_TIME_FOREVER);
+                embed_backward(gembed, dy, input_tokens, DIM, SEQ);
+
+                steps_batch++;
+                if (step % 10 == 0 || step == start_step)
+                    printf("step %-4d loss=%.4f\n", step, loss);
+
+                fprintf(stderr, "{\"type\":\"step\",\"step\":%d,\"loss\":%.6f,\"compiles\":%d}\n",
+                    step, loss, g_compile_count);
+            }
+
+            if (wall_time_exceeded) break;
+
+            double tms = tb_ms(mach_absolute_time() - tt);
+            total_train_ms += tms;
+            total_steps_done += steps_batch;
+            total_batches++;
+
+            dispatch_group_wait(dw_grp, DISPATCH_TIME_FOREVER);
+
+            // Adam update
+            float gsc = 1.0f / steps_batch;
+            adam_t++;
+            for (int L=0; L<NLAYERS; L++) {
+                LayerGrads *g = &grads[L];
+                for(size_t i=0;i<WQ_SZ;i++){g->Wq[i]*=gsc;g->Wk[i]*=gsc;g->Wv[i]*=gsc;g->Wo[i]*=gsc;}
+                for(size_t i=0;i<W1_SZ;i++) g->W1[i]*=gsc;
+                for(size_t i=0;i<W2_SZ;i++) g->W2[i]*=gsc;
+                for(size_t i=0;i<W3_SZ;i++) g->W3[i]*=gsc;
+                for(int i=0;i<DIM;i++){g->rms_att[i]*=gsc; g->rms_ffn[i]*=gsc;}
+
+                adam_update(lw[L].Wq, g->Wq, &la[L].Wq, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].Wk, g->Wk, &la[L].Wk, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].Wv, g->Wv, &la[L].Wv, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].Wo, g->Wo, &la[L].Wo, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].W1, g->W1, &la[L].W1, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].W2, g->W2, &la[L].W2, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].W3, g->W3, &la[L].W3, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].rms_att, g->rms_att, &la[L].rms_att, adam_t, lr, adam_b1, adam_b2, adam_eps);
+                adam_update(lw[L].rms_ffn, g->rms_ffn, &la[L].rms_ffn, adam_t, lr, adam_b1, adam_b2, adam_eps);
+            }
+            for(int i=0;i<DIM;i++) grms_final[i]*=gsc;
+            adam_update(rms_final, grms_final, &arms_final, adam_t, lr, adam_b1, adam_b2, adam_eps);
+            for(size_t i=0;i<(size_t)VOCAB*DIM;i++) gembed[i]*=gsc;
+            adam_update(embed, gembed, &aembed, adam_t, lr, adam_b1, adam_b2, adam_eps);
+
+            printf("  [batch %d: compile=%.0fms train=%.1fms (%.1fms/step) compiles=%d]\n",
+                   steps_batch, cms, tms, tms/steps_batch, g_compile_count);
+        }
+
+        // ===== VALIDATION (forward-only, reuse last-compiled kernels) =====
+        printf("\n=== Validation ===\n");
+        // Need kernels compiled with final weights for forward pass
+        // After the last adam_update, weights changed but kernels still have old weights baked in.
+        // Recompile one final set of forward-only kernels for validation.
+        // Actually, we only need fwdAttn and fwdFFN kernels. But recompiling all is simpler
+        // given the exec() restart mechanism. Instead, do validation on CPU using the
+        // existing rmsnorm + cblas_sgemm for the classifier, and recompile just fwd kernels.
+        //
+        // Simpler approach: recompile forward kernels for layer 0..NLAYERS-1
+        // But we might hit compile limit. Use a fresh compile count approach:
+        // After training, we don't care about compile limits anymore since we won't restart.
+        // Reset compile counter (it's a process-global but we're done training).
+        g_compile_count = 0;
+        for (int L=0; L<NLAYERS; L++) free_layer_kernels(&kern[L]);
+        bool val_compile_ok = true;
+        for (int L=0; L<NLAYERS; L++) {
+            if (!compile_layer_kernels(&kern[L], &lw[L])) {
+                printf("Val recompile failed at layer %d, falling back to train_loss\n", L);
+                val_compile_ok = false; break;
+            }
+        }
+
+        float val_loss = -1.0f;
+        if (val_compile_ok && val_tokens > (size_t)(SEQ + 1)) {
+            // Sequential non-overlapping windows from validation portion
+            size_t val_stride = SEQ + 1;  // non-overlapping
+            int n_windows = 0;
+            float total_val_loss = 0;
+            size_t vpos = val_start;
+
+            for (int w = 0; w < VAL_WINDOWS && vpos + val_stride <= n_tokens; w++, vpos += val_stride) {
+                uint16_t *vinput = token_data + vpos;
+                uint16_t *vtarget = token_data + vpos + 1;
+
+                // Forward only (no backward, no gradient)
+                embed_lookup(x_cur, embed, vinput, DIM, SEQ);
+                for (int L=0; L<NLAYERS; L++) {
+                    io_write_fp16(kern[L].fwdAttn->ioIn, x_cur, DIM, SEQ);
+                    ane_eval(kern[L].fwdAttn);
+                    float *o_tmp = (float*)malloc(SEQ*DIM*4);
+                    io_read_fp16(kern[L].fwdAttn->ioOut, o_tmp, 0, DIM, SEQ);
+                    // x_cur = x_cur + o_out (attention residual)
+                    float *x2_tmp = (float*)malloc(SEQ*DIM*4);
+                    vDSP_vadd(x_cur, 1, o_tmp, 1, x2_tmp, 1, (vDSP_Length)(SEQ*DIM));
+                    // FFN forward
+                    io_write_fp16(kern[L].fwdFFN->ioIn, x2_tmp, DIM, SEQ);
+                    ane_eval(kern[L].fwdFFN);
+                    float *ffn_tmp = (float*)malloc(SEQ*DIM*4);
+                    io_read_fp16(kern[L].fwdFFN->ioOut, ffn_tmp, 0, DIM, SEQ);
+                    // x_cur = x2 + ffn_out
+                    vDSP_vadd(x2_tmp, 1, ffn_tmp, 1, x_cur, 1, (vDSP_Length)(SEQ*DIM));
+                    free(o_tmp); free(x2_tmp); free(ffn_tmp);
+                }
+                rmsnorm(x_final, x_cur, rms_final, DIM, SEQ);
+                cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                            VOCAB, SEQ, DIM, 1.0f,
+                            embed, DIM, x_final, SEQ, 0.0f, logits, SEQ);
+                // cross_entropy_loss writes to dlogits as side effect — we just ignore it
+                float wloss = cross_entropy_loss(dlogits, logits, vtarget, VOCAB, SEQ);
+                total_val_loss += wloss;
+                n_windows++;
+            }
+            if (n_windows > 0) {
+                val_loss = total_val_loss / n_windows;
+                printf("val_loss: %.6f (%d windows)\n", val_loss, n_windows);
+            }
+        } else if (!val_compile_ok) {
+            printf("Skipping validation (compile failed), using last train_loss\n");
+            val_loss = last_loss;
+        }
+
+        // Efficiency report
+        double wall = tb_ms(mach_absolute_time() - t_wall_start);
+        total_compile_ms += cum_compile; total_train_ms += cum_train;
+        wall += cum_wall; total_steps_done += cum_steps; total_batches += cum_batches;
+        double fwd_flops = NLAYERS * (4.0*2*DIM*DIM*SEQ + 2.0*2*DIM*HIDDEN*SEQ + 2.0*HIDDEN*DIM*SEQ);
+        double sdpa_flops = NLAYERS * 2.0*HEADS*5*SEQ*SEQ*HD;
+        double ane_flops = (fwd_flops*2 + sdpa_flops) * total_steps_done;
+        double ane_tflops = (total_train_ms > 0) ? ane_flops / (total_train_ms * 1e9) : 0;
+        double ane_util = (total_train_ms > 0) ? 100.0*ane_tflops/15.8 : 0;
+        double ms_per_step = (total_steps_done > 0) ? total_train_ms/total_steps_done : 0;
+
+        printf("\n=== Efficiency Report ===\n");
+        printf("Total steps:     %d\n", total_steps_done);
+        printf("Wall time:       %.0f ms (%.1f s)\n", wall, wall/1000);
+        printf("Compile time:    %.0f ms (%.1f%%)\n", total_compile_ms, 100*total_compile_ms/wall);
+        printf("Train time:      %.0f ms (%.1f%%)\n", total_train_ms, 100*total_train_ms/wall);
+        printf("Avg train:       %.1f ms/step\n", ms_per_step);
+        printf("ANE TFLOPS:      %.2f sustained\n", ane_tflops);
+        printf("ANE utilization: %.1f%% of 15.8 TFLOPS\n", ane_util);
+
+        // ===== JSON output =====
+        printf("\n###JSON###\n");
+        printf("{\"status\":\"ok\",\"val_loss\":%.6f,\"train_loss\":%.6f,"
+               "\"steps\":%d,\"ms_per_step\":%.2f,\"wall_time_s\":%.1f,"
+               "\"compile_time_s\":%.1f,\"ane_util_pct\":%.2f}\n",
+               val_loss, last_loss, total_steps_done, ms_per_step, wall/1000,
+               total_compile_ms/1000, ane_util);
+
+        // Cleanup
+        for (int L=0; L<NLAYERS; L++) {
+            free_layer_kernels(&kern[L]);
+            free_kern(sdpaBwd2[L]);
+            layer_weights_free(&lw[L]);
+            layer_adam_free(&la[L]);
+            layer_acts_free(&acts[L]);
+            layer_grads_free(&grads[L]);
+        }
+        munmap(token_data, data_len);
+        close(data_fd);
+        free(rms_final); free(embed); free(grms_final); free(gembed);
+        adam_free(&arms_final); adam_free(&aembed);
+        free(dy); free(dffn); free(dh1); free(dh3); free(dx_ffn); free(dx2);
+        free(do_out_buf); free(dq); free(dk); free(dv); free(dx_attn);
+        free(x_cur); free(x_final); free(logits); free(dlogits);
+    }
+    return 0;
+}

--- a/harness_ane.py
+++ b/harness_ane.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""harness_ane.py — ANE training orchestrator for autoresearch-ane.
+
+Compiles the ANE training binary, runs an experiment with a wall-time budget,
+parses JSON output, and logs results. The agent drives the experiment loop
+via program_ane.md — this script handles a single experiment cycle.
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ANE_DIR = Path(__file__).parent / "ane"
+BINARY = ANE_DIR / "train_ane"
+CONFIG_FILE = ANE_DIR / "experiment_config.h"
+CKPT_FILE = ANE_DIR / "ane_stories110M_ckpt.bin"
+DATA_FILE = ANE_DIR / "tinystories_data00.bin"
+RESULTS_FILE = Path(__file__).parent / "results.tsv"
+
+ARCH_DEFINES = {"DIM", "HIDDEN", "HEADS", "SEQ", "NLAYERS"}
+
+
+def parse_config(path: Path = CONFIG_FILE) -> dict[str, str]:
+    """Parse #define values from experiment_config.h."""
+    defines = {}
+    with open(path) as f:
+        for line in f:
+            m = re.match(r"#define\s+(\w+)\s+(.+?)(?:\s*//.*)?$", line.strip())
+            if m:
+                defines[m.group(1)] = m.group(2).strip()
+    return defines
+
+
+def hash_arch_config(path: Path = CONFIG_FILE) -> str:
+    """Hash architecture defines to detect arch changes."""
+    defines = parse_config(path)
+    arch_vals = sorted((k, defines[k]) for k in ARCH_DEFINES if k in defines)
+    return hashlib.sha256(str(arch_vals).encode()).hexdigest()[:16]
+
+
+def validate_config(path: Path = CONFIG_FILE) -> list[str]:
+    """Validate experiment_config.h for obvious errors."""
+    defines = parse_config(path)
+    errors = []
+    try:
+        dim = int(defines.get("DIM", "0"))
+        hidden = int(defines.get("HIDDEN", "0"))
+        heads = int(defines.get("HEADS", "0"))
+        if dim <= 0:
+            errors.append("DIM must be positive")
+        if hidden <= 0:
+            errors.append("HIDDEN must be positive")
+        if heads <= 0:
+            errors.append("HEADS must be positive")
+        if dim > 0 and heads > 0 and dim % heads != 0:
+            errors.append(f"DIM ({dim}) must be divisible by HEADS ({heads})")
+        if hidden > 0 and dim > 0 and hidden <= dim:
+            errors.append(f"HIDDEN ({hidden}) should be > DIM ({dim})")
+    except ValueError as e:
+        errors.append(f"Invalid numeric value: {e}")
+    return errors
+
+
+def compile_ane() -> tuple[bool, str]:
+    """Compile the ANE training binary. Returns (success, output)."""
+    try:
+        result = subprocess.run(
+            ["make", "-C", str(ANE_DIR), "clean", "train_ane"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        output = result.stdout + result.stderr
+        return result.returncode == 0, output
+    except subprocess.TimeoutExpired:
+        return False, "Compilation timed out (120s)"
+    except Exception as e:
+        return False, str(e)
+
+
+def run_experiment(wall_time: int = 300) -> dict:
+    """Run a single training experiment. Returns parsed metrics dict."""
+    if not BINARY.exists():
+        return {"status": "error", "error": "Binary not found. Run compile first."}
+
+    if not DATA_FILE.exists():
+        return {"status": "error", "error": f"Data not found at {DATA_FILE}. Run: bash ane/download_data.sh"}
+
+    # Check if architecture changed → delete checkpoint
+    arch_hash_file = ANE_DIR / ".arch_hash"
+    current_hash = hash_arch_config()
+    if CKPT_FILE.exists():
+        old_hash = ""
+        if arch_hash_file.exists():
+            old_hash = arch_hash_file.read_text().strip()
+        if old_hash != current_hash:
+            print(f"Architecture changed (hash {old_hash[:8]}→{current_hash[:8]}), deleting checkpoint")
+            CKPT_FILE.unlink()
+
+    arch_hash_file.write_text(current_hash)
+
+    cmd = [
+        str(BINARY),
+        "--wall-time", str(wall_time),
+        "--data", str(DATA_FILE),
+        "--fresh",  # always random init (no pretrained model file needed)
+    ]
+    if CKPT_FILE.exists():
+        cmd = [
+            str(BINARY),
+            "--resume",
+            "--ckpt", str(CKPT_FILE),
+            "--wall-time", str(wall_time),
+            "--data", str(DATA_FILE),
+        ]
+
+    print(f"Running: {' '.join(cmd)}")
+    start = time.time()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=wall_time + 120,  # backstop
+            cwd=str(ANE_DIR),
+        )
+        elapsed = time.time() - start
+        stdout = result.stdout
+        stderr = result.stderr
+
+        # Parse JSON after ###JSON### marker
+        marker = "###JSON###"
+        if marker in stdout:
+            json_str = stdout[stdout.index(marker) + len(marker):].strip()
+            # Take first line (the JSON object)
+            json_line = json_str.split("\n")[0].strip()
+            try:
+                metrics = json.loads(json_line)
+                metrics["raw_stdout"] = stdout
+                metrics["elapsed_s"] = elapsed
+                return metrics
+            except json.JSONDecodeError as e:
+                return {
+                    "status": "error",
+                    "error": f"JSON parse error: {e}",
+                    "raw_stdout": stdout,
+                    "raw_stderr": stderr,
+                }
+        else:
+            return {
+                "status": "crash",
+                "error": "No ###JSON### marker in output",
+                "raw_stdout": stdout[-2000:],
+                "raw_stderr": stderr[-2000:],
+                "returncode": result.returncode,
+            }
+
+    except subprocess.TimeoutExpired:
+        return {"status": "crash", "error": f"Timed out after {wall_time + 120}s"}
+    except Exception as e:
+        return {"status": "crash", "error": str(e)}
+
+
+def log_result(commit: str, metrics: dict, status: str, description: str):
+    """Append result to results.tsv."""
+    header = "commit\tval_loss\tane_util_pct\tstatus\tdescription\n"
+    if not RESULTS_FILE.exists():
+        RESULTS_FILE.write_text(header)
+
+    val_loss = metrics.get("val_loss", 0.0)
+    ane_util = metrics.get("ane_util_pct", 0.0)
+
+    with open(RESULTS_FILE, "a") as f:
+        f.write(f"{commit}\t{val_loss:.6f}\t{ane_util:.1f}\t{status}\t{description}\n")
+
+
+def main():
+    """Run a full experiment cycle: validate config → compile → train → parse → log."""
+    # Validate config
+    errors = validate_config()
+    if errors:
+        print("Config validation errors:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+
+    # Compile
+    print("=== Compiling ANE binary ===")
+    ok, output = compile_ane()
+    if not ok:
+        print(f"Compile failed:\n{output}")
+        sys.exit(1)
+    print("Compile OK")
+
+    # Run experiment
+    wall_time = int(os.environ.get("ANE_WALL_TIME", "300"))
+    print(f"\n=== Running experiment (wall_time={wall_time}s) ===")
+    metrics = run_experiment(wall_time)
+
+    # Print summary in same format as karpathy's train.py
+    print("\n---")
+    if metrics.get("status") == "ok":
+        print(f"val_loss:         {metrics['val_loss']:.6f}")
+        print(f"train_loss:       {metrics['train_loss']:.6f}")
+        print(f"steps:            {metrics['steps']}")
+        print(f"ms_per_step:      {metrics['ms_per_step']:.1f}")
+        print(f"wall_time_s:      {metrics['wall_time_s']:.1f}")
+        print(f"compile_time_s:   {metrics['compile_time_s']:.1f}")
+        print(f"ane_util_pct:     {metrics['ane_util_pct']:.1f}")
+    else:
+        print(f"status:           {metrics.get('status', 'unknown')}")
+        print(f"error:            {metrics.get('error', 'unknown')}")
+
+    return metrics
+
+
+if __name__ == "__main__":
+    metrics = main()
+    sys.exit(0 if metrics.get("status") == "ok" else 1)

--- a/program_ane.md
+++ b/program_ane.md
@@ -1,0 +1,101 @@
+# autoresearch-ane
+
+This is an experiment to have the LLM do its own research, running training on Apple Neural Engine (ANE).
+
+## Setup
+
+To set up a new experiment, work with the user to:
+
+1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar10`). The branch `autoresearch-ane/<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b autoresearch-ane/<tag>` from current `ane-backend`.
+3. **Read the in-scope files**: Read these files for full context:
+   - `program_ane.md` — this file, your instructions.
+   - `ane/experiment_config.h` — the file you modify. Architecture and optimizer hyperparameters.
+   - `harness_ane.py` — the orchestrator. Do not modify.
+4. **Verify data exists**: Check that `ane/tinystories_data00.bin` exists. If not, run `bash ane/download_data.sh`.
+5. **Verify compilation**: Run `make -C ane train_ane` to confirm the binary compiles.
+6. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
+7. **Confirm and go**: Confirm setup looks good.
+
+Once you get confirmation, kick off the experimentation.
+
+## Experimentation
+
+Each experiment runs on the Apple Neural Engine. The training binary runs for a **fixed time budget of 5 minutes** (wall clock). You launch it simply as: `python harness_ane.py`.
+
+**What you CAN do:**
+- Modify `ane/experiment_config.h` — this is the ONLY file you edit. It contains architecture defines (DIM, HIDDEN, HEADS, SEQ, NLAYERS) and optimizer hyperparameters (LEARNING_RATE, ADAM_BETA1, ADAM_BETA2, ADAM_EPS, ACCUM_STEPS).
+
+**What you CANNOT do:**
+- Modify any other file (`train_ane.m`, `stories_config.h`, `harness_ane.py`, etc.). They are read-only.
+- Change VOCAB — it must stay 32000 (Llama2 BPE tokenizer).
+- Install new packages or add dependencies.
+
+**The goal is simple: get the lowest val_loss.** Since the time budget is fixed, you don't need to worry about training time — it's always 5 minutes. Everything in `experiment_config.h` is fair game.
+
+**Architecture vs hyperparameter changes:**
+- **Architecture changes** (DIM, HIDDEN, HEADS, SEQ, NLAYERS): These reset the checkpoint to random initialization. This is "expensive" — you lose all training progress.
+- **Hyperparameter changes** (LEARNING_RATE, ADAM_BETA1, ADAM_BETA2, ADAM_EPS, ACCUM_STEPS): These continue from the existing checkpoint. This is "cheap" — training progress is preserved.
+
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement from a radical architecture change that loses checkpoint progress may not be worth it compared to a hyperparameter tweak.
+
+**The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
+
+## Output format
+
+Once the script finishes it prints a summary like this:
+
+```
+---
+val_loss:         3.456789
+train_loss:       3.234567
+steps:            120
+ms_per_step:      412.3
+wall_time_s:      300.1
+compile_time_s:   45.2
+ane_util_pct:     12.5
+```
+
+You can extract the key metric from the log file:
+
+```
+grep "^val_loss:" run_ane.log
+```
+
+## Logging results
+
+When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated).
+
+The TSV has a header row and 5 columns:
+
+```
+commit	val_loss	ane_util_pct	status	description
+```
+
+1. git commit hash (short, 7 chars)
+2. val_loss achieved (e.g. 3.456789) — use 0.000000 for crashes
+3. ANE utilization % (e.g. 12.5) — use 0.0 for crashes
+4. status: `keep`, `discard`, or `crash`
+5. short text description of what this experiment tried
+
+## The experiment loop
+
+The experiment runs on a dedicated branch (e.g. `autoresearch-ane/mar10`).
+
+LOOP FOREVER:
+
+1. Look at the git state: the current branch/commit we're on
+2. Tune `ane/experiment_config.h` with an experimental idea by directly editing the defines.
+3. git commit
+4. Run the experiment: `python harness_ane.py > run_ane.log 2>&1` (redirect everything)
+5. Read out the results: `grep "^val_loss:\|^ane_util_pct:" run_ane.log`
+6. If the grep output is empty, the run crashed. Run `tail -n 50 run_ane.log` to read the error and attempt a fix.
+7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
+8. If val_loss improved (lower), you "advance" the branch, keeping the git commit
+9. If val_loss is equal or worse, you git reset back to where you started
+
+**Timeout**: Each experiment should take ~5 minutes total (+ overhead for compilation and validation). If a run exceeds 10 minutes, kill it and treat it as a failure.
+
+**Crashes**: If a run crashes, use your judgment. If it's a simple fix (e.g. DIM not divisible by HEADS), fix and re-run. If the idea is fundamentally broken, log "crash" and move on.
+
+**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. The human might be asleep. You are autonomous. If you run out of ideas, think harder — try different learning rates, different accumulation steps, different model sizes, combine previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.


### PR DESCRIPTION
## Summary

- Adds a parallel ANE (Apple Neural Engine) training backend in `ane/` alongside the existing CUDA code — all original files remain untouched
- Training binary (`train_ane.m`) based on [maderix/ANE](https://github.com/maderix/ANE), modified with wall-time budget enforcement, 90/10 train/val split, forward-only validation, and JSON output for harness parsing
- Python harness (`harness_ane.py`) orchestrates compile → train → parse → log cycles, with architecture change detection that auto-resets checkpoints
- Agent instructions (`program_ane.md`) adapted for ANE: agent edits only `ane/experiment_config.h` (architecture + optimizer defines), metric is `val_loss`

## Test plan

- [x] `make -C ane train_ane` compiles without errors or warnings
- [x] `ane/train_ane --wall-time 30 --data ane/tinystories_data00.bin --fresh` runs ~30s, prints JSON with val_loss
- [x] `python harness_ane.py` completes full experiment cycle (compile → train → parse → summary output)
- [ ] Changing LEARNING_RATE in experiment_config.h → harness keeps checkpoint
- [ ] Changing DIM → harness detects architecture change, deletes checkpoint
- [ ] 5-minute full experiment cycle
- [ ] Agent can follow program_ane.md to run autonomous loop
- [ ] Original `uv run train.py` still works unchanged (if CUDA available)