### PR TITLE
Save pre-eval checkpoint to prevent training loss on eval crash

### DIFF
--- a/train.py
+++ b/train.py
@@ -606,10 +606,18 @@ print()  # newline after \r training log
 
 total_tokens = step * TOTAL_BATCH_SIZE
 
+# Save pre-eval checkpoint so training isn't lost if evaluation crashes (e.g. OOM)
+checkpoint_path = "pre_eval_checkpoint.pt"
+torch.save(model.state_dict(), checkpoint_path)
+
 # Final eval
 model.eval()
 with autocast_ctx:
     val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+
+# Eval succeeded — remove the safety checkpoint
+if os.path.exists(checkpoint_path):
+    os.remove(checkpoint_path)
 
 # Final summary
 t_end = time.time()


### PR DESCRIPTION
## Summary

Saves a lightweight checkpoint (model state dict) after the training loop completes and before `evaluate_bpb()` runs. If evaluation crashes (OOM, CUDA error), the trained weights survive for inspection or metric recovery. On successful eval, the checkpoint is cleaned up automatically.

- **What**: `torch.save(model.state_dict(), "pre_eval_checkpoint.pt")` between training and eval
- **Why**: The agent loop runs experiments overnight — a crash during eval wastes a full 5-minute training cycle with no recovery path
- **Impact**: +5 lines, no change to training loop or eval logic

Fixes #7
