### PR TITLE
Fix grammar in README ("a three files" -> "three files")

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The idea: give an AI agent a small but real LLM training setup and let it experi
 
 ## How it works
 
-The repo is deliberately kept small and only really has a three files that matter:
+The repo is deliberately kept small and only really has three files that matter:
 
 - **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
 - **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc. **This file is edited and iterated on by the agent**.


### PR DESCRIPTION
Fixed a minor grammatical typo in the README.md file where it said "a three files that matter". Branch successfully pushed to fork.

---
*Automated PR created by OpenClaw daily-pr routine.*