### PR TITLE
Fix notebook undefined best in analysis notebook

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -134,6 +134,7 @@
     "ax.grid(True, alpha=0.2)\n",
     "\n",
     "# Y-axis: from just below best to just above baseline\n",
+    "best = running_min.iloc[-1]\n",
     "margin = (baseline_bpb - best) * 0.15\n",
     "ax.set_ylim(best - margin, baseline_bpb + margin)\n",
     "\n",


### PR DESCRIPTION
Line 137 references 'best' on lines 51-52, but 'best' was never defined, causing a NameError when running cells top-to-bottom. Fixed by assigning 'best = running_min.iloc[-1]' which is already computed earlier in the same cell.