### PR TITLE
Fix: Define 'best' before use in analysis notebook

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -134,6 +134,7 @@
     "ax.grid(True, alpha=0.2)\n",
     "\n",
     "# Y-axis: from just below best to just above baseline\n",
+    "best = running_min.iloc[-1]\n",
     "margin = (baseline_bpb - best) * 0.15\n",
     "ax.set_ylim(best - margin, baseline_bpb + margin)\n",
     "\n",


### PR DESCRIPTION
## Summary
- Line 137 references `best` but it was never defined when running cells top-to-bottom, causing a NameError
- Fixed by adding `best = running_min.iloc[-1]` which computes the running minimum that's already calculated earlier in the same cell

## Test plan
- [x] Verified fix by examining the notebook cell structure
- [ ] Run notebook cells top-to-bottom to confirm no NameError

🤖 Generated with [Claude Code](https://claude.com/claude-code)