### PR TITLE
fix(notebook): define 'best' before use in plotting cell

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -125,6 +125,7 @@
     "                color=\"#1a7a3a\", alpha=0.9,\n",
     "                rotation=30, ha=\"left\", va=\"bottom\")\n",
     "\n",
+    "best = running_min.iloc[-1] if len(running_min) > 0 else baseline_bpb\n",
     "n_total = len(df)\n",
     "n_kept = len(df[df[\"status\"] == \"KEEP\"])\n",
     "ax.set_xlabel(\"Experiment #\", fontsize=12)\n",


### PR DESCRIPTION
## Problem
The plotting cell in `analysis.ipynb` references the variable `best` on lines 137-138:
```python
margin = (baseline_bpb - best) * 0.15
ax.set_ylim(best - margin, baseline_bpb + margin)
```

However, `best` is not defined until the "Summary Statistics" cell which comes later in the notebook. This causes a `NameError` when running the notebook.

## Solution
Add `best = running_min.iloc[-1]` before the Y-axis limits are set, with a fallback to `baseline_bpb` for the edge case where no experiments have been kept yet.

## Related
- Similar to #166 and #171