### PR TITLE
feat: add CUDA availability check with helpful error message

### DIFF
--- a/train.py
+++ b/train.py
@@ -17,6 +17,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+# Verify CUDA is available before proceeding
+if not torch.cuda.is_available():
+    print("Error: No CUDA GPU detected. This script requires an NVIDIA GPU.")
+    print("If you're on Mac, see the MLX forks listed in README.md")
+    print("If you're on Windows/Linux, ensure CUDA drivers are installed.")
+    exit(1)
+
 from kernels import get_kernel
 cap = torch.cuda.get_device_capability()
 # varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs


### PR DESCRIPTION
## Problem
Currently `train.py` assumes CUDA is available and will crash with a cryptic error if no GPU is detected:
- `torch.cuda.get_device_capability()` throws an exception
- Users on Mac or without NVIDIA GPUs get confusing error messages

## Solution
Add an early check for CUDA availability before any CUDA operations, with a helpful error message that:
1. Clearly states an NVIDIA GPU is required
2. Points Mac users to the MLX forks listed in README
3. Suggests checking CUDA drivers on Windows/Linux

## Code Change
```python
# Verify CUDA is available before proceeding
if not torch.cuda.is_available():
    print("Error: No CUDA GPU detected. This script requires an NVIDIA GPU.")
    print("If you're on Mac, see the MLX forks listed in README.md")
    print("If you're on Windows/Linux, ensure CUDA drivers are installed.")
    exit(1)
```

## Benefits
- Better user experience for people trying the repo on unsupported hardware
- Faster path to the correct solution (forks for Mac, driver installation for Windows/Linux)