### PR TITLE
feat: print GPU name and VRAM at startup

### DIFF
--- a/train.py
+++ b/train.py
@@ -458,6 +458,11 @@ t_start = time.time()
 torch.manual_seed(42)
 torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
+
+# Print GPU info for debugging and verification
+gpu_name = torch.cuda.get_device_name(0)
+gpu_vram_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
+print(f"GPU: {gpu_name} ({gpu_vram_gb:.1f} GB)")
 device = torch.device("cuda")
 autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
 H100_BF16_PEAK_FLOPS = 989.5e12


### PR DESCRIPTION
## Problem
When running `train.py`, there's no indication of which GPU is being used or how much VRAM is available. This makes it harder to:
- Verify the script is using the expected GPU (on multi-GPU systems)
- Debug OOM issues
- Compare results across different hardware

## Solution
Print GPU name and VRAM at startup:
```python
gpu_name = torch.cuda.get_device_name(0)
gpu_vram_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
print(f"GPU: {gpu_name} ({gpu_vram_gb:.1f} GB)")
```

## Example Output
```
GPU: NVIDIA H100 80GB HBM3 (79.6 GB)
Vocab size: 8,192
Model config: {...}
```

## Benefits
- Easier debugging and verification
- Useful context when sharing results or reporting issues
- Minimal code change, no new dependencies