### PR TITLE
fix: add helpful error messages to asserts

### DIFF
--- a/train.py
+++ b/train.py
@@ -194,7 +194,7 @@ class GPT(nn.Module):
 
     def _compute_window_sizes(self, config):
         pattern = config.window_pattern.upper()
-        assert all(c in "SL" for c in pattern)
+        assert all(c in "SL" for c in pattern), f"WINDOW_PATTERN must only contain S or L, got: {pattern}"
         long_window = config.sequence_len
         short_window = long_window // 2
         char_to_window = {"L": (long_window, 0), "S": (short_window, 0)}
@@ -493,7 +493,7 @@ num_flops_per_token = model.estimate_flops()
 print(f"Estimated FLOPs per token: {num_flops_per_token:e}")
 
 tokens_per_fwdbwd = DEVICE_BATCH_SIZE * MAX_SEQ_LEN
-assert TOTAL_BATCH_SIZE % tokens_per_fwdbwd == 0
+assert TOTAL_BATCH_SIZE % tokens_per_fwdbwd == 0, f"TOTAL_BATCH_SIZE ({TOTAL_BATCH_SIZE}) must be divisible by tokens_per_fwdbwd ({tokens_per_fwdbwd})"
 grad_accum_steps = TOTAL_BATCH_SIZE // tokens_per_fwdbwd
 
 optimizer = model.setup_optimizer(


### PR DESCRIPTION
## Problem
When assertions fail, users see generic `AssertionError` without context, making debugging harder. For example:
```
AssertionError
```

## Solution
Add descriptive error messages to key assertions:
- **TOTAL_BATCH_SIZE check**: Shows actual values when divisibility fails
- **WINDOW_PATTERN check**: Shows the invalid pattern

## Example
Before:
```
AssertionError
```

After:
```
AssertionError: TOTAL_BATCH_SIZE (524288) must be divisible by tokens_per_fwdbwd (262144)
```

Small change, better debugging experience.