### PR TITLE
docs: add TSV validation tip to program.md

### DIFF
--- a/program.md
+++ b/program.md
@@ -87,6 +87,12 @@ c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
 d4e5f6g	0.000000	0.0	crash	double model width (OOM)
 ```
 
+**Validate your TSV**: Before logging, you can check the format is correct:
+```bash
+head -1 results.tsv  # Should show: commit	val_bpb	memory_gb	status	description
+wc -l results.tsv    # Count experiments
+```
+
 ## The experiment loop
 
 The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autoresearch/mar5-gpu0`).


### PR DESCRIPTION
## Problem
AI agents sometimes write malformed TSV entries (wrong delimiter, missing columns, etc.) which breaks the analysis notebook.

## Solution
Add a quick validation tip showing how to check the TSV format:
```bash
head -1 results.tsv  # Verify header
wc -l results.tsv    # Count experiments
```

Simple addition that helps catch formatting issues early.