### PR TITLE
Report startup_seconds in final training summary

### DIFF
--- a/train.py
+++ b/train.py
@@ -620,6 +620,7 @@ peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
 print("---")
 print(f"val_bpb:          {val_bpb:.6f}")
+print(f"startup_seconds:  {startup_time:.1f}")
 print(f"training_seconds: {total_training_time:.1f}")
 print(f"total_seconds:    {t_end - t_start:.1f}")
 print(f"peak_vram_mb:     {peak_vram_mb:.1f}")


### PR DESCRIPTION
`train.py` already computes `startup_time`, but it is not included in the final summary. This adds startup_seconds to the printed metrics so the runtime breakdown is clearer and the gap between `training_seconds` and `total_seconds` is easier to interpret.