### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+This is a small experimental repository. Security fixes, if any, are expected to land on the latest version of the default branch. Older commits, branches, and forks should be treated as unsupported unless a maintainer states otherwise.
+
+## Reporting a Vulnerability
+
+Please do not report security issues in public GitHub issues, discussions, or pull requests.
+
+If GitHub private vulnerability reporting is enabled for this repository, use that channel. Otherwise, use the maintainer's preferred private contact method if one is available. Please avoid public disclosure until the issue has been reviewed and a fix or mitigation has been discussed.
+
+## What to Include
+
+Please include:
+
+- A clear description of the issue and why you believe it is security-relevant
+- Affected files, functions, commands, or workflows
+- Reproduction steps or a minimal proof of concept
+- Expected impact and any realistic attack prerequisites
+- Any suggested mitigation, if you have one
+
+## Operational Notes
+
+This repository is primarily intended for local experimental use. Reports are most useful when they account for the local trust boundary, including cloned code, downloaded artifacts, local caches, and any agent or tool permissions granted during use.


### PR DESCRIPTION
## Summary
Adds a minimal `SECURITY.md` so the repo has a clear security reporting policy.

## Why
GitHub currently shows no security policy for this repository. This adds a simple, standard place for responsible disclosure guidance without changing any code.

## Scope
- adds `SECURITY.md` only
- no runtime or training changes