### PR TITLE
Add anti-overfitting policy and ideas scratchpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dev/
 
 # Results file
 results.tsv
+ideas.md

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ The idea: give an AI agent a small but real LLM training setup and let it experi
 
 ## How it works
 
-The repo is deliberately kept small and only really has three files that matter:
+The repo is deliberately kept small and only really has a few files that matter:
 
 - **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
 - **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc. **This file is edited and iterated on by the agent**.
 - **`program.md`** — baseline instructions for one agent. Point your agent here and let it go. **This file is edited and iterated on by the human**.
+- **`overfit.md`** — anti-overfitting policy. Keeps the agent focused on real improvements instead of one-run flukes.
+- **`ideas.md`** — lightweight research notebook. Tracks promising directions, failures, near misses, and future ideas. Keep it untracked.
 
 By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of the details of your compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
 
@@ -47,7 +49,7 @@ Simply spin up your Claude/Codex or whatever you want in this repo (and disable 
 Hi have a look at program.md and let's kick off a new experiment! let's do the setup first.
 ```
 
-The `program.md` file is essentially a super lightweight "skill".
+The `program.md` file is essentially a super lightweight "skill". `overfit.md` and `ideas.md` extend it with a validation policy and a small memory system.
 
 ## Project structure
 
@@ -55,6 +57,8 @@ The `program.md` file is essentially a super lightweight "skill".
 prepare.py      — constants, data prep + runtime utilities (do not modify)
 train.py        — model, optimizer, training loop (agent modifies this)
 program.md      — agent instructions
+overfit.md      — anti-overfitting policy
+ideas.md        — lightweight research notebook (leave untracked)
 pyproject.toml  — dependencies
 ```
 
@@ -63,6 +67,7 @@ pyproject.toml  — dependencies
 - **Single file to modify.** The agent only touches `train.py`. This keeps the scope manageable and diffs reviewable.
 - **Fixed time budget.** Training always runs for exactly 5 minutes, regardless of your specific platform. This means you can expect approx 12 experiments/hour and approx 100 experiments while you sleep. There are two upsides of this design decision. First, this makes experiments directly comparable regardless of what the agent changes (model size, batch size, architecture, etc). Second, this means that autoresearch will find the most optimal model for your platform in that time budget. The downside is that your runs (and results) become not comparable to other people running on other compute platforms.
 - **Self-contained.** No external dependencies beyond PyTorch and a few small packages. No distributed training, no complex configs. One GPU, one file, one metric.
+- **Small memory stack.** `program.md` defines the loop, `overfit.md` discourages fake progress, `ideas.md` preserves local research memory, and `results.tsv` keeps the numeric record.
 
 ## Platform support
 

--- a/overfit.md
+++ b/overfit.md
@@ -1,0 +1,95 @@
+# overfit
+
+Prevent fake progress.
+
+The goal is real improvements, not benchmark tricks.
+
+## Core rule
+
+Do not trust a single run.
+
+A lower metric is evidence, not proof.
+
+## General behavior
+
+Prefer robust gains over fragile gains.
+
+Prefer simple changes over complex hacks.
+
+Prefer changes with a clear mechanism.
+
+Be skeptical of surprising improvements.
+
+## Suspicious signals
+
+Treat results as suspicious if:
+
+- a large improvement appears from a tiny opaque change
+- a gain disappears when rerun
+- the improvement is extremely small
+- code complexity increases significantly
+- the change has no clear explanation
+- the change resembles a benchmark-specific trick
+
+## Validation rule
+
+If a change looks promising:
+
+Rerun the experiment once.
+
+If the improvement disappears, discard it.
+
+If the improvement holds, treat it as stronger evidence.
+
+## Noise rule
+
+Tiny gains are often noise.
+
+If the improvement is extremely small:
+
+Prefer simpler code.
+
+Or rerun the experiment before accepting it.
+
+## Complexity rule
+
+Complexity is a cost.
+
+Prefer:
+
+- fewer lines
+- simpler logic
+- fewer special cases
+
+A small gain from deleting code is very strong.
+
+A small gain that adds messy code is weak.
+
+## Mechanism rule
+
+Before committing a meaningful change, ask:
+
+Why should this help?
+
+If the result contradicts the hypothesis, be cautious.
+
+## Forbidden behaviors
+
+Do not:
+
+- exploit evaluation quirks
+- hardcode dataset assumptions
+- add benchmark-specific logic
+- indirectly modify evaluation behavior
+
+## Exploration rule
+
+If improvements stop appearing:
+
+Change direction.
+
+Do not endlessly tune tiny hyperparameters.
+
+## Final rule
+
+Optimize for improvements that are likely to generalize, not just improvements that win one run.

--- a/program.md
+++ b/program.md
@@ -12,9 +12,12 @@ To set up a new experiment, work with the user to:
    - `README.md` — repository context.
    - `prepare.py` — fixed constants, data prep, tokenizer, dataloader, evaluation. Do not modify.
    - `train.py` — the file you modify. Model architecture, optimizer, training loop.
+   - `overfit.md` — anti-overfitting policy. Follow it.
+   - `ideas.md` — if present, use it as a scratchpad for ideas, failures, and observations. Update it continuously.
 4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
-6. **Confirm and go**: Confirm setup looks good.
+6. **Initialize ideas.md**: If it does not exist, create it with sections for Promising directions, Failed directions, Near misses, Observations, and Future ideas.
+7. **Confirm and go**: Confirm setup looks good.
 
 Once you get confirmation, kick off the experimentation.
 
@@ -35,6 +38,8 @@ Each experiment runs on a single GPU. The training script runs for a **fixed tim
 **VRAM** is a soft constraint. Some increase is acceptable for meaningful val_bpb gains, but it should not blow up dramatically.
 
 **Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 val_bpb improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep.
+
+**Anti-overfitting criterion**: Follow `overfit.md`. Do not trust a single run. A lower metric is evidence, not proof. Prefer robust gains, simple changes, and changes with a clear mechanism.
 
 **The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
 
@@ -87,6 +92,22 @@ c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
 d4e5f6g	0.000000	0.0	crash	double model width (OOM)
 ```
 
+## Research memory
+
+Maintain `ideas.md` continuously.
+
+It is a lightweight research notebook and is not committed to git.
+
+Use short notes only.
+
+Update it with:
+
+- promising directions
+- failed directions
+- near misses
+- observations
+- future ideas
+
 ## The experiment loop
 
 The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autoresearch/mar5-gpu0`).
@@ -94,20 +115,30 @@ The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autorese
 LOOP FOREVER:
 
 1. Look at the git state: the current branch/commit we're on
-2. Tune `train.py` with an experimental idea by directly hacking the code.
-3. git commit
-4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
-5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
-6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
-7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
-8. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
-9. If val_bpb is equal or worse, you git reset back to where you started
+2. Review `ideas.md` and avoid repeating failed directions unless you have a new angle.
+3. Tune `train.py` with an experimental idea by directly hacking the code.
+4. Write down the expected mechanism in your own reasoning before you commit.
+5. git commit
+6. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
+7. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
+8. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
+9. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
+10. Update `ideas.md` with the outcome, including failures and near misses.
+11. If the result looks promising, rerun it once.
+12. If the improvement disappears on rerun, discard it.
+13. If the improvement holds, treat it as stronger evidence.
+14. If val_bpb improved and the result looks real, you "advance" the branch, keeping the git commit
+15. If val_bpb is equal or worse, suspicious, or disappears on rerun, you git reset back to where you started
 
 The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
 
 **Timeout**: Each experiment should take ~5 minutes total (+ a few seconds for startup and eval overhead). If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
 
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
+
+**Suspicious gains**: If a large improvement appears from a tiny opaque change, if the gain is extremely small, if complexity jumps, or if the mechanism is unclear, be skeptical. Prefer simple code and rerun before accepting it.
+
+**Exploration**: If improvements stop appearing, change direction. Do not endlessly tune tiny hyperparameters.
 
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
 


### PR DESCRIPTION
Adds two small files to improve the autonomous research loop.

 overfit.md adds a simple anti-overfitting policy: do not trust a single run, rerun promising changes, prefer
  simple mechanisms, and avoid benchmark-specific tricks.

 ideas.md adds lightweight local memory for failed directions, near misses, observations, and future ideas. This
  helps the agent avoid repeating itself and change direction when progress stalls.

 program.md now tells the agent to actually use both files in the loop, and README.md documents the stack. ideas.md
  is left untracked because it is per-run scratch space.

 This is necessary because the current setup has git for the best trajectory and results.tsv for numeric logging,
  but no explicit policy against fake progress and no lightweight memory for research reasoning.

 It also promotes agentic driving: the agent can keep moving on its own, validate wins before trusting them,
 remember what it learned, and make better decisions without constant human steering.