### PR TITLE
Add MLX port for MacOS (optimized for 16GB RAM) to notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
+- [matt-k-wong/autoresearch_mlx_mkw](https://github.com/matt-k-wong/autoresearch_mlx_mkw) (MacOS / Optimized for 16GB RAM with Linear Attention & Muon)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 
 ## License


### PR DESCRIPTION
Added a native MLX port specifically re-engineered for Apple Silicon edge hardware. Unlike other 'naive' ports, this version includes O(N) Chunkwise Linear Attention, memory-safe Gradient Accumulation, and a pure MLX Muon optimizer port, making it stable on 16GB MacBook Airs.