### PR TITLE
fix: skip torch.compile on Windows

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,6 +25,15 @@ fa3 = get_kernel(repo).flash_attn_interface
 
 from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
 
+
+def maybe_compile(target=None, **kwargs):
+    """Skip torch.compile on Windows where Triton-backed compilation is unavailable."""
+    if target is None:
+        return lambda real_target: maybe_compile(real_target, **kwargs)
+    if os.name == "nt":
+        return target
+    return torch.compile(target, **kwargs)
+
 # ---------------------------------------------------------------------------
 # GPT Model
 # ---------------------------------------------------------------------------
@@ -302,7 +311,7 @@ polar_express_coeffs = [
     (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
 ]
 
-@torch.compile(dynamic=False, fullgraph=True)
+@maybe_compile(dynamic=False, fullgraph=True)
 def adamw_step_fused(p, grad, exp_avg, exp_avg_sq, step_t, lr_t, beta1_t, beta2_t, eps_t, wd_t):
     p.mul_(1 - lr_t * wd_t)
     exp_avg.lerp_(grad, 1 - beta1_t)
@@ -313,7 +322,7 @@ def adamw_step_fused(p, grad, exp_avg, exp_avg_sq, step_t, lr_t, beta1_t, beta2_
     step_size = lr_t / bias1
     p.add_(exp_avg / denom, alpha=-step_size)
 
-@torch.compile(dynamic=False, fullgraph=True)
+@maybe_compile(dynamic=False, fullgraph=True)
 def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momentum_buffer,
                     momentum_t, lr_t, wd_t, beta2_t, ns_steps, red_dim):
     # Nesterov momentum
@@ -505,7 +514,7 @@ optimizer = model.setup_optimizer(
     weight_decay=WEIGHT_DECAY,
 )
 
-model = torch.compile(model, dynamic=False)
+model = maybe_compile(model, dynamic=False)
 
 train_loader = make_dataloader(tokenizer, DEVICE_BATCH_SIZE, MAX_SEQ_LEN, "train")
 x, y, epoch = next(train_loader)  # prefetch first batch


### PR DESCRIPTION
## Summary

Skip `torch.compile` on Windows so `train.py` can run when Triton-backed compilation is unavailable.

This keeps the current behavior on non-Windows platforms, but treats compilation as optional on Windows by routing both the fused optimizer helpers and the model compile call through a small `maybe_compile(...)` wrapper.

## Why

I reproduced this on Windows 11 with a local RTX 3060 using the repo's existing environment:

```text
os.name= nt
torch= 2.9.1+cu128
cuda= True
device= NVIDIA GeForce RTX 3060
compile_fail TritonMissing Cannot find a working triton installation.
```

Right now that prevents `train.py` from starting unless the user manually edits out the compile calls.

## Scope

- leave Linux / non-Windows behavior unchanged
- make the compile path a no-op on Windows
- avoid broad backend / platform changes

## Validation

- `python -m py_compile train.py`
- reproduced `torch.compile(...)` failure in the local Windows env
- verified the same code path succeeds when wrapped with `maybe_compile(...)`
