### PR TITLE
Add autoresearch-mac-mini to Notable Forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
+- [Venkateshwar-PortoAI/autoresearch-mac-mini](https://github.com/Venkateshwar-PortoAI/autoresearch-mac-mini) (Mac Mini, PyTorch MPS/CPU, no CUDA required)
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds [autoresearch-mac-mini](https://github.com/Venkateshwar-PortoAI/autoresearch-mac-mini) to the Notable Forks section.

**How it differs from autoresearch-macos:**

| | autoresearch-macos | autoresearch-mac-mini (ours) |
|---|---|---|
| Platforms | macOS only (crashes on Linux/Windows) | CUDA, MPS, CPU — auto-detects |
| CUDA support | No | Yes (FA3 + torch.compile if available) |
| Optimizer on MPS | Moves CPU tensors to device each step | Dual path: Python scalars (MPS/CPU), compiled tensors (CUDA) |
| Progress chart | Manual via notebook | Auto-updating `plot_progress.py` |

**Key changes from upstream:**
- FA3 → PyTorch SDPA with sliding window mask support
- Auto device detection: CUDA → MPS → CPU
- Smaller defaults for Mac (DEPTH=4, BATCH=8) per your README recommendations
- `plot_progress.py` auto-generates progress.png after each experiment

**Baseline result:** val_bpb 1.723 on Mac Mini M4 (MPS, float32, 11.5M params, 96 steps in 5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)