### PR TITLE
fix: define 'best' variable before use in progress plot

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -134,6 +134,7 @@
     "ax.grid(True, alpha=0.2)\n",
     "\n",
     "# Y-axis: from just below best to just above baseline\n",
+    "best = valid[\"val_bpb\"].min()\n",
     "margin = (baseline_bpb - best) * 0.15\n",
     "ax.set_ylim(best - margin, baseline_bpb + margin)\n",
     "\n",


### PR DESCRIPTION
Fixes #262. \n\nThe variable `best` is used to calculate the margin and set the y-axis limits in the progress plot, but it is not defined in the scope of that cell. It is defined in a later cell. I've added the definition before its use to prevent `UnboundLocalError`.