### PR TITLE
save checkpoint before eval to survive crashes

### DIFF
--- a/train.py
+++ b/train.py
@@ -606,6 +606,9 @@ print()  # newline after \r training log
 
 total_tokens = step * TOTAL_BATCH_SIZE
 
+# Save checkpoint before eval so training isn't lost if eval crashes
+torch.save(model.state_dict(), "checkpoint.pt")
+
 # Final eval
 model.eval()
 with autocast_ctx:


### PR DESCRIPTION
if evaluate_bpb() OOMs or hits a CUDA error, the entire training run is lost. save model state_dict before eval so the agent can recover.

closes #7