### PR TITLE
feat: Turing GPU (T4/RTX) compat via capability-aware FA3 fallback, fp16+GradScaler

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,9 +21,10 @@ from kernels import get_kernel
 cap = torch.cuda.get_device_capability()
 # varunneal's FA3 is Hopper only, use kernels-community on non-Hopper GPUs
 repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
-fa3 = get_kernel(repo).flash_attn_interface
+fa3 = get_kernel(repo).flash_attn_interface if cap >= (8, 0) else None
 
-from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
+from prepare import MAX_SEQ_LEN as _MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
+MAX_SEQ_LEN = _MAX_SEQ_LEN if cap >= (8, 0) else 512
 
 # ---------------------------------------------------------------------------
 # GPT Model
@@ -90,7 +91,12 @@ class CausalSelfAttention(nn.Module):
         q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
         q, k = norm(q), norm(k)
 
-        y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        if fa3 is not None:
+            y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+        else:
+            q2, k2, v2 = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+            y = F.scaled_dot_product_attention(q2, k2, v2, is_causal=True)
+            y = y.transpose(1, 2)
         y = y.contiguous().view(B, T, -1)
         y = self.c_proj(y)
         return y
@@ -176,9 +182,10 @@ class GPT(nn.Module):
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.cos, self.sin = cos, sin
         # Cast embeddings to bf16
-        self.transformer.wte.to(dtype=torch.bfloat16)
+        embed_dtype = torch.bfloat16 if torch.cuda.get_device_capability() >= (8, 0) else torch.float32
+        self.transformer.wte.to(dtype=embed_dtype)
         for ve in self.value_embeds.values():
-            ve.to(dtype=torch.bfloat16)
+            ve.to(dtype=embed_dtype)
 
     def _precompute_rotary_embeddings(self, seq_len, head_dim, base=10000, device=None):
         if device is None:
@@ -188,7 +195,8 @@ class GPT(nn.Module):
         t = torch.arange(seq_len, dtype=torch.float32, device=device)
         freqs = torch.outer(t, inv_freq)
         cos, sin = freqs.cos(), freqs.sin()
-        cos, sin = cos.bfloat16(), sin.bfloat16()
+        cos_dtype = torch.bfloat16 if torch.cuda.get_device_capability() >= (8, 0) else torch.float32
+        cos, sin = cos.to(cos_dtype), sin.to(cos_dtype)
         cos, sin = cos[None, :, None, :], sin[None, :, None, :]
         return cos, sin
 
@@ -321,7 +329,7 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     momentum_buffer.lerp_(stacked_grads, 1 - momentum)
     g = stacked_grads.lerp_(momentum_buffer, momentum)
     # Polar express orthogonalization
-    X = g.bfloat16()
+    X = g.bfloat16() if torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0) else g.half()
     X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
     if g.size(-2) > g.size(-1):
         for a, b, c in polar_express_coeffs[:ns_steps]:
@@ -435,7 +443,7 @@ HEAD_DIM = 128          # target head dimension for attention
 WINDOW_PATTERN = "SSSL" # sliding window pattern: L=full, S=half context
 
 # Optimization
-TOTAL_BATCH_SIZE = 2**19 # ~524K tokens per optimizer step
+TOTAL_BATCH_SIZE = 2**19 if cap >= (8, 0) else 2**16  # ~524K tokens, reduced for pre-Ampere GPUs
 EMBEDDING_LR = 0.6      # learning rate for token embeddings (Adam)
 UNEMBEDDING_LR = 0.004  # learning rate for lm_head (Adam)
 MATRIX_LR = 0.04        # learning rate for matrix parameters (Muon)
@@ -448,7 +456,7 @@ FINAL_LR_FRAC = 0.0     # final LR as fraction of initial
 
 # Model size
 DEPTH = 8               # number of transformer layers
-DEVICE_BATCH_SIZE = 128  # per-device batch size (reduce if OOM)
+DEVICE_BATCH_SIZE = 128 if cap >= (8, 0) else 16  # reduced for pre-Ampere GPUs
 
 # ---------------------------------------------------------------------------
 # Setup: tokenizer, model, optimizer, dataloader
@@ -459,7 +467,9 @@ torch.manual_seed(42)
 torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
 device = torch.device("cuda")
-autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
+amp_dtype = torch.bfloat16 if cap >= (8, 0) else torch.float16
+autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=amp_dtype)
+scaler = torch.amp.GradScaler("cuda") if amp_dtype == torch.float16 else None
 H100_BF16_PEAK_FLOPS = 989.5e12
 
 tokenizer = Tokenizer.from_directory()
@@ -548,7 +558,7 @@ while True:
             loss = model(x, y)
         train_loss = loss.detach()
         loss = loss / grad_accum_steps
-        loss.backward()
+        (scaler.scale(loss) if scaler else loss).backward()
         x, y, epoch = next(train_loader)
 
     # Progress and schedules
@@ -561,7 +571,11 @@ while True:
         if group['kind'] == 'muon':
             group["momentum"] = muon_momentum
             group["weight_decay"] = muon_weight_decay
-    optimizer.step()
+    if scaler:
+        scaler.step(optimizer)
+        scaler.update()
+    else:
+        optimizer.step()
     model.zero_grad(set_to_none=True)
 
     train_loss_f = train_loss.item()


### PR DESCRIPTION
## Summary

Adds automatic compatibility for pre-Ampere GPUs (Turing and older: T4, RTX 2000 series, GTX 1600 series) with zero behavior change for Ampere+ users (H100, A100, RTX 3000/4000 series).

This makes autoresearch runnable on **free Google Colab (T4)** out of the box, which is the most accessible GPU compute available to most people wanting to try this project.

## Problem

Three things hard-crash on Turing GPUs:
1. **Flash Attention 3** - requires Ampere+ (SM 8.0+). T4 is SM 7.5. Crashes with `RuntimeError: FlashAttention only supports Ampere GPUs or newer`
2. **bfloat16** - T4 has no native bfloat16 support. PyTorch falls back to float32 emulation, causing silent OOM during `torch.compile` kernel generation
3. **Batch size** - without FA3's memory efficiency, the default `DEVICE_BATCH_SIZE=128` + `seq_len=2048` allocates a `(128, 2048, 2048)` attention matrix = 1GB per layer, immediately OOM on 15GB T4

## Solution

All changes are gated on `cap = torch.cuda.get_device_capability()` which is already computed at the top of the file. Ampere+ (`cap >= (8, 0)`) gets the original code path unchanged.

### Changes

| Location | Ampere+ (unchanged) | Pre-Ampere (new fallback) |
|----------|-------------------|--------------------------|
| FA3 load | `fa3 = get_kernel(repo).flash_attn_interface` | `fa3 = None` |
| Attention | `fa3.flash_attn_func(...)` | `F.scaled_dot_product_attention(...)` |
| Precision | `bfloat16` | `float16` + `GradScaler` |
| Embeddings | cast to `bfloat16` | stay `float32` (GradScaler requires fp32 grads) |
| Rotary emb | cast to `bfloat16` | stay `float32` |
| Muon ortho | `g.bfloat16()` | `g.half()` |
| Seq length | `MAX_SEQ_LEN` (2048) | 512 |
| Batch size | 128 | 16 |
| Total batch | `2**19` (~524K tokens) | `2**16` (~65K tokens) |

### Why SDPA instead of FA2?

`torch.nn.functional.scaled_dot_product_attention` is already available in the installed PyTorch version, requires no extra install, and automatically dispatches to the most efficient kernel available on the current hardware (Flash Attention 2 on supported GPUs, efficient attention otherwise).

### Why fp32 embeddings?

`GradScaler` requires fp32 gradients, it cannot unscale fp16 gradients (`ValueError: Attempting to unscale FP16 gradients`). Since embeddings are looked up and their gradients flow back directly, they must stay fp32. The forward pass still runs in fp16 via `autocast`.

### Why seq_len=512 and smaller batch?

Without FA3's fused kernel, the attention matrix is materialized explicitly in memory. At seq_len=2048 with batch=128, each layer needs 1GB just for the attention matrix. Seq_len=512 reduces this 16x. The T4 has 15GB VRAM but only ~12GB is usable after CUDA context overhead.

## Results

Tested on **Google Colab free tier (Tesla T4, SM 7.5, 15GB VRAM)**:
```
val_bpb:          1.333735
training_seconds: 300.5
total_seconds:    539.7
peak_vram_mb:     2496.9
mfu_percent:      1.18
total_tokens_M:   19.0
num_steps:        290
num_params_M:     50.3
```

For reference, the H100 baseline from the repo is `val_bpb ~0.998` at seq_len=2048 with ~953 steps. The T4 result is expected to be worse due to:
- 4x shorter context (512 vs 2048) - less signal per step
- ~35x lower throughput (1.2% vs ~40% MFU) - fewer total steps
- No FA3 memory efficiency - smaller effective batch

## Limitations & Future Work

- `mfu_percent` is computed against `H100_BF16_PEAK_FLOPS` - on T4 this reads as ~1%, which is misleading but not wrong (it's genuinely much slower)
- seq_len=512 means the T4 baseline is not directly comparable to H100 results
- A future improvement would be to also adjust `H100_BF16_PEAK_FLOPS` to the actual device's peak FLOPS for accurate MFU reporting
- With Colab Pro (A100), all these fallbacks are bypassed automatically and the full H100-comparable config runs as-is

## Testing

- [x] Runs to completion on T4 (300s budget respected)
- [x] No changes to H100/A100 code path (`cap >= (8, 0)` guard)