### PR TITLE
docs: add val_bpb explanation paragraph in How it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The repo is deliberately kept small and only really has three files that matter:
 
 By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of the details of your compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
 
+**What is val_bpb?** Bits per byte measures how well the model compresses unseen text — specifically, how many bits the model needs on average to predict each byte of the validation set. A perfect model that always predicts the next byte correctly would score 0; a model that guesses randomly over 256 possible bytes scores 8. Real language models land somewhere in between, typically between 0.9 and 1.2 on this setup. Lower means the model has learned better statistical patterns in the data. Unlike cross-entropy loss, bits per byte is independent of tokenizer vocabulary size, so you can fairly compare a model using a 4096-token vocabulary against one using a 32768-token vocabulary — both are measured against raw bytes, not tokens.
+
 If you are new to neural networks, this ["Dummy's Guide"](https://x.com/hooeem/status/2030720614752039185) looks pretty good for a lot more context.
 
 ## Quick start


### PR DESCRIPTION
What

>Added a short explanation of `val_bpb` (validation bits per byte) in the "How it works" section, right after the existing one-line mention of the metric.

Why

>The metric is referenced throughout the repo in `program.md`, in the output summary, and in the experiment loop — but never explained. A newcomer unfamiliar with information-theoretic metrics won't know what a "good" score looks like, why lower is better, or why this metric is used instead of plain cross-entropy loss.

The added paragraph covers:
>What bits per byte actually measure
>The practical range (0 = perfect, 8 = random, real models ~0.9–1.2)
>Why it is vocab-size-independent, which is the key reason it was chosen for this project

No code was changed; documentation only.