### PR TITLE
Bake reflection into the experiment loop

### DIFF
--- a/program.md
+++ b/program.md
@@ -14,7 +14,8 @@ To set up a new experiment, work with the user to:
    - `train.py` — the file you modify. Model architecture, optimizer, training loop.
 4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
-6. **Confirm and go**: Confirm setup looks good.
+6. **Initialize musings.md**: Create an empty `musings.md`. You will be writing to it before each idea you try
+7. **Confirm and go**: Confirm setup looks good.
 
 Once you get confirmation, kick off the experimentation.
 
@@ -94,14 +95,16 @@ The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autorese
 LOOP FOREVER:
 
 1. Look at the git state: the current branch/commit we're on
-2. Tune `train.py` with an experimental idea by directly hacking the code.
-3. git commit
-4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
-5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
-6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
-7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
-8. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
-9. If val_bpb is equal or worse, you git reset back to where you started
+2. Think of an idea you would like to try, and summarize it in a new section in musings.md: explain the rationale behind it, ground it in ML theory and anything else that is relevant to understand why you think this idea is worth trying
+3. Tune `train.py` with an experimental idea by directly hacking the code.
+4. git commit
+5. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
+6. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
+7. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
+8. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
+9. Update musings.md with whether the current attempt succeeded or not, and what you make of that.
+10. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
+11. If val_bpb is equal or worse, you git reset back to where you started
 
 The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
 


### PR DESCRIPTION
## Summary

This updates `program.md` to add a lightweight reflection step before and after each experiment.

The workflow now asks the agent to:
- initialize a `musings.md` file during setup
- write down a short rationale for the proposed idea, including the underlying intuition and any relevant ML grounding, before changing `train.py`
- record a brief post-mortem after the run, capturing whether the attempt succeeded and what was learned.

The resulting `musings.md` leaves behind a useful learning trail for humans (at least this human) interested in the nuances of ML theory and their application.
It may also improve the agent's idea generation quality by making the loop more systematic, though that would need more deliberate validation.

## Changes

- add `musings.md` initialization to the experiment setup checklist
- require a short pre-execution writeup for each proposed idea
- require a short post-run reflection on whether the attempt worked and what was learned

## Testing

- docs/process change only