### PR TITLE
docs: guide for evaluating experiment results at scale

### DIFF
--- a/docs/evaluating-results.md
+++ b/docs/evaluating-results.md
@@ -6,7 +6,7 @@ Once you've run 50+ experiments, the results.tsv file becomes hard to read by ha
 
 val_bpb measures validation bits per byte. Lower is better. It tells you how efficiently the model compresses unseen text.
 
-Small deltas matter. A drop from 0.998 to 0.995 looks tiny but represents a meaningful improvement in next token prediction quality. The evaluation in prepare.py is fixed and deterministic, so the only variable across runs is what you changed in train.py. That said, GPU nondeterminism and data ordering still introduce jitter.
+Small deltas matter. A drop from 0.998 to 0.995 looks tiny but represents a meaningful improvement in next token prediction quality. The evaluation in prepare.py is fixed and deterministic, so the only variable across runs is what you changed in train.py. That said, GPU nondeterminism (cuDNN, floating point ordering) still introduces some jitter.
 
 ## The noise floor
 


### PR DESCRIPTION
After running about 100 experiments I kept squinting at results.tsv trying to figure out which improvements were real. Wrote up what I learned about noise floor estimation and Pareto efficiency for the autoresearch metric format.

This doesn't add any tooling or change any code. Just a standalone guide in docs/ for people who have accumulated enough experiments that eyeballing val_bpb deltas stops working.

Happy to adjust scope or placement if you'd prefer this somewhere else.