### PR TITLE
add darwin-derby to notable forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
+- [kousun12/darwin-derby](https://github.com/kousun12/darwin-derby) (Generalization)
 
 ## License
 


### PR DESCRIPTION
Adding a fork here - the `derby` is a generalization of autoresearch -- still git based but just a thin set of conventions about what is mutable and how a scoring function would be set up

https://robc.substack.com/p/welcome-to-the-darwin-derby