### PR TITLE
Add Tenstorrent TT-XLA fork to notable forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
+- [bro4all/autoresearch-tenstorrent](https://github.com/bro4all/autoresearch-tenstorrent) (Tenstorrent)
 
 ## License
 


### PR DESCRIPTION
Adds [autoresearch-tenstorrent](https://github.com/bro4all/autoresearch-tenstorrent) to the Notable Forks section — a single-device TT-XLA port targeting Tenstorrent Wormhole hardware (tested on N300).

**How it differs from upstream:**

| | upstream | autoresearch-tenstorrent |
|---|---|---|
| Backend | CUDA (H100) | TT-XLA on Tenstorrent Wormhole |
| Attention | Flash Attention 3 | Pure PyTorch causal attention |
| Optimizer | Muon + AdamW | AdamW (Muon needs torch.compile, not TT-stable yet) |
| Precision | bfloat16 | float32 (bf16 crashes TT MLIR compiler) |

**Baseline result:** val_bpb 1.968 on N300 (single Wormhole chip, 168 steps in 5 min, 3.7M params)