### PR TITLE
feat: real-time web dashboard for experiment monitoring

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,1022 @@
+"""
+Autoresearch Dashboard — single-file FastAPI server.
+Reads ~/.hermes/autoresearch (or REPO_DIR env var).
+
+Usage:
+    cd ~/.hermes/autoresearch
+    uv run dashboard.py
+
+Then open http://localhost:7788
+"""
+
+import asyncio
+import csv
+import io
+import json
+import os
+import re
+import signal
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+REPO_DIR = Path(os.environ.get("REPO_DIR", str(Path(__file__).parent)))
+RESULTS_TSV = REPO_DIR / "results.tsv"
+RUN_LOG = REPO_DIR / "run.log"
+TRAIN_PY = REPO_DIR / "train.py"
+PROGRAM_MD = REPO_DIR / "program.md"
+
+app = FastAPI()
+
+# ---------------------------------------------------------------------------
+# API — Results
+# ---------------------------------------------------------------------------
+
+@app.get("/api/results")
+def get_results():
+    if not RESULTS_TSV.exists():
+        return []
+    rows = []
+    with open(RESULTS_TSV) as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for r in reader:
+            try:
+                r["val_bpb"] = float(r.get("val_bpb", 0))
+            except (ValueError, TypeError):
+                pass
+            try:
+                r["memory_gb"] = float(r.get("memory_gb", 0))
+            except (ValueError, TypeError):
+                pass
+            rows.append(r)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# API — Live training data (from run.log)
+# ---------------------------------------------------------------------------
+
+@app.get("/api/live")
+def get_live():
+    if not RUN_LOG.exists():
+        return {"steps": [], "summary": None, "running": False, "raw_tail": ""}
+
+    text = RUN_LOG.read_text(errors="replace")
+
+    # Parse step lines
+    step_pat = re.compile(
+        r"step (\d+) \(([\d.]+)%\) \| loss: ([\d.]+) \| lrm: ([\d.]+) \| "
+        r"dt: (\d+)ms \| tok/sec: ([\d,]+) \| mfu: ([\d.]+)% \| epoch: (\d+) \| remaining: ([\d.]+)s"
+    )
+    steps = []
+    for m in step_pat.finditer(text):
+        steps.append({
+            "step": int(m.group(1)),
+            "progress": float(m.group(2)),
+            "loss": float(m.group(3)),
+            "lrm": float(m.group(4)),
+            "dt_ms": int(m.group(5)),
+            "tok_sec": int(m.group(6).replace(",", "")),
+            "mfu": float(m.group(7)),
+            "epoch": int(m.group(8)),
+            "remaining": float(m.group(9)),
+        })
+
+    # Parse summary block
+    summary = None
+    sum_pat = re.compile(
+        r"^(val_bpb|training_seconds|total_seconds|peak_vram_mb|mfu_percent|"
+        r"total_tokens_M|num_steps|num_params_M|depth):\s+(.+)$",
+        re.MULTILINE,
+    )
+    matches = dict(sum_pat.findall(text))
+    if matches:
+        summary = {k: float(v) for k, v in matches.items()}
+
+    # Check if train.py is actually running
+    try:
+        r = subprocess.run(["pgrep", "-f", "train.py"], capture_output=True, timeout=5)
+        running = r.returncode == 0
+    except Exception:
+        running = False
+
+    # Last 60 lines for raw log stream
+    lines = text.splitlines()
+    raw_tail = "\n".join(lines[-60:]) if lines else ""
+
+    return {
+        "steps": steps[-500:],   # cap for JSON size
+        "summary": summary,
+        "running": running,
+        "raw_tail": raw_tail,
+    }
+
+
+# ---------------------------------------------------------------------------
+# API — SSE log stream (live tail of run.log)
+# ---------------------------------------------------------------------------
+
+@app.get("/api/stream")
+async def stream_log():
+    async def event_gen():
+        offset = 0
+        if RUN_LOG.exists():
+            offset = RUN_LOG.stat().st_size
+        while True:
+            await asyncio.sleep(1)
+            if not RUN_LOG.exists():
+                continue
+            size = RUN_LOG.stat().st_size
+            if size > offset:
+                with open(RUN_LOG, "rb") as f:
+                    f.seek(offset)
+                    chunk = f.read(size - offset).decode("utf-8", errors="replace")
+                offset = size
+                for line in chunk.splitlines():
+                    line = line.strip()
+                    if line:
+                        yield f"data: {json.dumps(line)}\n\n"
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")
+
+
+# ---------------------------------------------------------------------------
+# API — Git log
+# ---------------------------------------------------------------------------
+
+@app.get("/api/git-log")
+def get_git_log():
+    try:
+        r = subprocess.run(
+            ["git", "log", "--oneline", "--no-decorate", "-40"],
+            capture_output=True, text=True, cwd=REPO_DIR, timeout=10,
+        )
+        commits = []
+        for line in r.stdout.strip().splitlines():
+            if line:
+                parts = line.split(" ", 1)
+                commits.append({"hash": parts[0], "message": parts[1] if len(parts) > 1 else ""})
+        return commits
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@app.get("/api/diff/{commit}")
+def get_diff(commit: str):
+    if not re.match(r"^[a-f0-9]{7,40}$", commit):
+        return JSONResponse({"error": "invalid commit"}, status_code=400)
+    try:
+        r = subprocess.run(
+            ["git", "diff", f"{commit}~1", commit, "--", "train.py"],
+            capture_output=True, text=True, cwd=REPO_DIR, timeout=10,
+        )
+        return {"commit": commit, "diff": r.stdout or "(no changes to train.py)"}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+# ---------------------------------------------------------------------------
+# API — GPU / system status
+# ---------------------------------------------------------------------------
+
+@app.get("/api/status")
+def get_status():
+    gpu_info = []
+    try:
+        r = subprocess.run(
+            ["nvidia-smi",
+             "--query-gpu=index,name,utilization.gpu,memory.used,memory.total,temperature.gpu",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        for line in r.stdout.strip().splitlines():
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 6:
+                gpu_info.append({
+                    "index": int(parts[0]),
+                    "name": parts[1],
+                    "util_pct": int(parts[2]),
+                    "mem_used_mb": int(parts[3]),
+                    "mem_total_mb": int(parts[4]),
+                    "temp_c": int(parts[5]),
+                })
+    except Exception:
+        pass
+
+    branch = ""
+    try:
+        r = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, cwd=REPO_DIR, timeout=5,
+        )
+        branch = r.stdout.strip()
+    except Exception:
+        pass
+
+    exp_count = 0
+    best_bpb = None
+    if RESULTS_TSV.exists():
+        with open(RESULTS_TSV) as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for row in reader:
+                exp_count += 1
+                try:
+                    v = float(row.get("val_bpb", 0))
+                    if v > 0 and (best_bpb is None or v < best_bpb):
+                        best_bpb = v
+                except (ValueError, TypeError):
+                    pass
+
+    try:
+        running = subprocess.run(["pgrep", "-f", "train.py"], capture_output=True, timeout=5).returncode == 0
+    except Exception:
+        running = False
+
+    return {
+        "gpus": gpu_info,
+        "branch": branch,
+        "experiment_count": exp_count,
+        "best_bpb": best_bpb,
+        "running": running,
+        "repo_dir": str(REPO_DIR),
+    }
+
+
+# ---------------------------------------------------------------------------
+# API — Hyperparams (parsed from train.py)
+# ---------------------------------------------------------------------------
+
+@app.get("/api/hyperparams")
+def get_hyperparams():
+    if not TRAIN_PY.exists():
+        return {}
+    text = TRAIN_PY.read_text()
+    # Extract UPPER_CASE = value assignments from the hyperparams section
+    params = {}
+    pat = re.compile(r"^([A-Z_]{3,})\s*=\s*(.+?)(?:\s*#.*)?$", re.MULTILINE)
+    for m in pat.finditer(text):
+        name, val = m.group(1), m.group(2).strip()
+        # Skip internal torch/os stuff
+        if name.startswith("os") or name.startswith("torch"):
+            continue
+        try:
+            params[name] = json.loads(val)
+        except Exception:
+            params[name] = val
+    return params
+
+
+# ---------------------------------------------------------------------------
+# API — Launch / stop controls
+# ---------------------------------------------------------------------------
+
+_agent_proc = None
+
+
+@app.post("/api/launch")
+async def launch_agent(req: Request):
+    global _agent_proc
+    if _agent_proc and _agent_proc.poll() is None:
+        return {"status": "already_running", "pid": _agent_proc.pid}
+
+    body = await req.json()
+    run_tag = body.get("run_tag", "")
+    max_experiments = body.get("max_experiments", 0)
+    model = body.get("model", "")
+
+    if not run_tag:
+        return JSONResponse({"error": "run_tag required"}, status_code=400)
+
+    # Build a prompt that tells the agent to set up and start the loop
+    prompt = f"Read program.md and set up the autoresearch run with tag '{run_tag}'. Then start the experiment loop immediately and never stop."
+    if max_experiments:
+        prompt += f" Run at most {max_experiments} experiments."
+    if model:
+        prompt += f" Use model {model}."
+
+    # Launch hermes as a subprocess so this server stays alive
+    env = os.environ.copy()
+    try:
+        _agent_proc = subprocess.Popen(
+            ["hermes", "--no-banner", "--quiet", prompt],
+            cwd=REPO_DIR,
+            env=env,
+            stdout=open(RUN_LOG.parent / "agent.log", "w"),
+            stderr=subprocess.STDOUT,
+        )
+        return {"status": "launched", "pid": _agent_proc.pid}
+    except FileNotFoundError:
+        # Fall back to just running train.py directly for demo
+        _agent_proc = subprocess.Popen(
+            ["uv", "run", "train.py"],
+            cwd=REPO_DIR,
+            env=env,
+            stdout=open(RUN_LOG, "w"),
+            stderr=subprocess.STDOUT,
+        )
+        return {"status": "launched_train_direct", "pid": _agent_proc.pid}
+
+
+@app.post("/api/stop")
+def stop_agent():
+    global _agent_proc
+    killed = []
+    # Kill any running train.py processes
+    try:
+        r = subprocess.run(["pgrep", "-f", "train.py"], capture_output=True, text=True, timeout=5)
+        for pid in r.stdout.strip().splitlines():
+            try:
+                os.kill(int(pid), signal.SIGTERM)
+                killed.append(int(pid))
+            except Exception:
+                pass
+    except Exception:
+        pass
+    if _agent_proc and _agent_proc.poll() is None:
+        _agent_proc.terminate()
+        killed.append(_agent_proc.pid)
+    return {"status": "stopped", "killed": killed}
+
+
+# ---------------------------------------------------------------------------
+# API — Read / write train.py and program.md
+# ---------------------------------------------------------------------------
+
+@app.get("/api/file/{filename}")
+def read_file(filename: str):
+    if filename == "train.py":
+        path = TRAIN_PY
+    elif filename == "program.md":
+        path = PROGRAM_MD
+    else:
+        return JSONResponse({"error": "not allowed"}, status_code=403)
+    if not path.exists():
+        return {"content": ""}
+    return {"content": path.read_text()}
+
+
+@app.post("/api/file/{filename}")
+async def write_file(filename: str, req: Request):
+    if filename not in ("program.md",):
+        return JSONResponse({"error": "only program.md can be edited here"}, status_code=403)
+    body = await req.json()
+    content = body.get("content", "")
+    path = REPO_DIR / filename
+    path.write_text(content)
+    return {"status": "saved"}
+
+
+# ---------------------------------------------------------------------------
+# Dashboard HTML (fully embedded, no CDN required — uses vanilla JS + Chart.js CDN)
+# ---------------------------------------------------------------------------
+
+DASHBOARD_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Autoresearch Dashboard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --border: #30363d;
+    --text: #e6edf3; --dim: #7d8590; --green: #3fb950; --red: #f85149;
+    --amber: #d29922; --cyan: #58a6ff; --purple: #bc8cff;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: var(--bg); color: var(--text); font: 14px/1.5 'Segoe UI', system-ui, sans-serif; }
+  a { color: var(--cyan); text-decoration: none; }
+
+  /* Layout */
+  #app { display: flex; height: 100vh; overflow: hidden; }
+  #sidebar { width: 230px; min-width: 180px; background: var(--surface); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow-y: auto; }
+  #main { flex: 1; overflow-y: auto; padding: 20px; }
+
+  /* Sidebar */
+  .sb-title { padding: 18px 16px 8px; font-size: 15px; font-weight: 700; color: var(--cyan); letter-spacing: .5px; }
+  .sb-section { padding: 12px 16px 4px; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--dim); }
+  .sb-nav a { display: block; padding: 7px 20px; color: var(--dim); font-size: 13px; cursor: pointer; border-left: 3px solid transparent; transition: .15s; }
+  .sb-nav a:hover, .sb-nav a.active { color: var(--text); background: rgba(255,255,255,.04); border-left-color: var(--cyan); }
+  .sb-kpi { padding: 8px 16px; }
+  .sb-kpi .label { font-size: 11px; color: var(--dim); }
+  .sb-kpi .value { font-size: 16px; font-weight: 600; }
+  #status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 5px; background: var(--dim); }
+  #status-dot.running { background: var(--green); box-shadow: 0 0 6px var(--green); }
+
+  /* Panels */
+  .panel { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .panel-head { padding: 12px 16px; border-bottom: 1px solid var(--border); font-weight: 600; font-size: 13px; display: flex; align-items: center; gap: 8px; justify-content: space-between; }
+  .panel-body { padding: 16px; }
+  .page { display: none; }
+  .page.active { display: block; }
+
+  /* KPIs */
+  .kpi-row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+  .kpi { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; min-width: 130px; flex: 1; }
+  .kpi .k-label { font-size: 11px; color: var(--dim); text-transform: uppercase; letter-spacing: .5px; }
+  .kpi .k-val { font-size: 22px; font-weight: 700; margin-top: 2px; }
+  .kpi .k-sub { font-size: 11px; color: var(--dim); margin-top: 2px; }
+
+  /* Table */
+  .exp-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .exp-table th { padding: 8px 12px; text-align: left; color: var(--dim); font-weight: 500; border-bottom: 1px solid var(--border); font-size: 12px; }
+  .exp-table td { padding: 8px 12px; border-bottom: 1px solid rgba(48,54,61,.5); }
+  .exp-table tr:last-child td { border-bottom: none; }
+  .exp-table tr:hover td { background: rgba(255,255,255,.02); }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 20px; font-size: 11px; font-weight: 600; }
+  .badge.keep { background: rgba(63,185,80,.15); color: var(--green); }
+  .badge.discard { background: rgba(248,81,73,.15); color: var(--red); }
+  .badge.crash { background: rgba(210,153,34,.15); color: var(--amber); }
+  .best-row td { background: rgba(63,185,80,.06) !important; }
+  .commit-link { font-family: monospace; font-size: 12px; color: var(--cyan); cursor: pointer; }
+
+  /* Log stream */
+  #log-output { background: #010409; border-radius: 6px; padding: 12px; height: 400px; overflow-y: auto; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; }
+  .log-step { color: var(--amber); }
+  .log-err { color: var(--red); }
+  .log-git { color: var(--cyan); }
+  .log-sum { color: var(--green); font-weight: 600; }
+
+  /* Charts */
+  .chart-wrap { position: relative; height: 260px; }
+
+  /* Controls */
+  .ctrl-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .form-group { display: flex; flex-direction: column; gap: 4px; }
+  label { font-size: 12px; color: var(--dim); }
+  input, select, textarea { background: var(--bg); border: 1px solid var(--border); color: var(--text); border-radius: 6px; padding: 8px 10px; font-size: 13px; width: 100%; outline: none; transition: border-color .15s; }
+  input:focus, select:focus, textarea:focus { border-color: var(--cyan); }
+  textarea { font-family: monospace; font-size: 12px; resize: vertical; }
+  .btn { padding: 8px 18px; border: none; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; transition: opacity .15s; }
+  .btn:hover { opacity: .85; }
+  .btn-green { background: var(--green); color: #0d1117; }
+  .btn-red { background: var(--red); color: #fff; }
+  .btn-dim { background: var(--border); color: var(--text); }
+  .btn-row { display: flex; gap: 8px; flex-wrap: wrap; }
+
+  /* GPU bar */
+  .gpu-bar-wrap { height: 8px; background: var(--border); border-radius: 4px; overflow: hidden; margin-top: 4px; }
+  .gpu-bar { height: 100%; background: var(--green); border-radius: 4px; transition: width .5s; }
+  .gpu-bar.hot { background: var(--red); }
+
+  /* Diff */
+  #diff-output { background: #010409; border-radius: 6px; padding: 12px; max-height: 500px; overflow-y: auto; font-family: monospace; font-size: 12px; white-space: pre; }
+  .diff-add { color: var(--green); }
+  .diff-del { color: var(--red); }
+  .diff-meta { color: var(--cyan); }
+
+  /* Progress bar */
+  .progress-wrap { height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; }
+  .progress-bar { height: 100%; background: var(--cyan); border-radius: 3px; transition: width .5s; }
+
+  /* Responsive */
+  @media (max-width: 700px) {
+    #sidebar { width: 52px; }
+    .sb-title, .sb-section, .sb-nav a span, .sb-kpi .label, .sb-kpi .value { display: none; }
+  }
+</style>
+</head>
+<body>
+<div id="app">
+
+<!-- Sidebar -->
+<div id="sidebar">
+  <div class="sb-title">⚗ AutoResearch</div>
+  <div class="sb-kpi">
+    <div class="label">Status</div>
+    <div class="value" id="sb-status"><span id="status-dot"></span><span id="sb-status-text">—</span></div>
+  </div>
+  <div class="sb-kpi">
+    <div class="label">Best val_bpb</div>
+    <div class="value" id="sb-best">—</div>
+  </div>
+  <div class="sb-kpi">
+    <div class="label">Experiments</div>
+    <div class="value" id="sb-count">—</div>
+  </div>
+  <div class="sb-kpi">
+    <div class="label">Branch</div>
+    <div class="value" style="font-size:12px;word-break:break-all" id="sb-branch">—</div>
+  </div>
+  <div class="sb-section">Navigate</div>
+  <div class="sb-nav">
+    <a onclick="showPage('overview')" class="active">📊 Overview</a>
+    <a onclick="showPage('live')">⚡ Live Training</a>
+    <a onclick="showPage('experiments')">🔬 Experiments</a>
+    <a onclick="showPage('git')">🌿 Git History</a>
+    <a onclick="showPage('controls')">⚙ Controls</a>
+    <a onclick="showPage('settings')">📝 Settings</a>
+  </div>
+</div>
+
+<!-- Main -->
+<div id="main">
+
+  <!-- Overview -->
+  <div id="page-overview" class="page active">
+    <div class="kpi-row" id="kpi-row"></div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px">
+      <div class="panel">
+        <div class="panel-head">val_bpb over time</div>
+        <div class="panel-body"><div class="chart-wrap"><canvas id="chart-bpb"></canvas></div></div>
+      </div>
+      <div class="panel">
+        <div class="panel-head">Keep / Discard distribution</div>
+        <div class="panel-body"><div class="chart-wrap"><canvas id="chart-status"></canvas></div></div>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="panel-head">GPU Status</div>
+      <div class="panel-body" id="gpu-overview"></div>
+    </div>
+  </div>
+
+  <!-- Live -->
+  <div id="page-live" class="page">
+    <div class="panel">
+      <div class="panel-head">
+        <span>Live Training Progress</span>
+        <label style="font-size:12px;color:var(--dim)">
+          <input type="checkbox" id="autoscroll" checked> autoscroll
+        </label>
+      </div>
+      <div class="panel-body">
+        <div id="live-progress-wrap" style="margin-bottom:12px;display:none">
+          <div style="display:flex;justify-content:space-between;font-size:12px;color:var(--dim);margin-bottom:4px">
+            <span id="live-step-label">step 0</span>
+            <span id="live-pct-label">0%</span>
+          </div>
+          <div class="progress-wrap"><div class="progress-bar" id="live-progress-bar" style="width:0%"></div></div>
+          <div style="display:flex;gap:16px;margin-top:8px;font-size:12px;flex-wrap:wrap" id="live-stats"></div>
+        </div>
+        <div class="chart-wrap" style="height:200px;margin-bottom:12px"><canvas id="chart-live-loss"></canvas></div>
+        <div id="log-output"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Experiments -->
+  <div id="page-experiments" class="page">
+    <div class="panel">
+      <div class="panel-head">
+        <span>All Experiments</span>
+        <input type="text" id="exp-search" placeholder="filter..." style="width:160px;padding:4px 8px;font-size:12px">
+      </div>
+      <div class="panel-body" style="overflow-x:auto">
+        <table class="exp-table">
+          <thead><tr>
+            <th>#</th><th>Commit</th><th>val_bpb</th><th>VRAM GB</th><th>Status</th><th>Description</th>
+          </tr></thead>
+          <tbody id="exp-tbody"></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="panel" id="diff-panel" style="display:none">
+      <div class="panel-head">
+        <span id="diff-title">Diff</span>
+        <button class="btn btn-dim" style="padding:3px 10px;font-size:12px" onclick="document.getElementById('diff-panel').style.display='none'">✕</button>
+      </div>
+      <div class="panel-body"><div id="diff-output"></div></div>
+    </div>
+  </div>
+
+  <!-- Git -->
+  <div id="page-git" class="page">
+    <div class="panel">
+      <div class="panel-head">Git History (last 40 commits)</div>
+      <div class="panel-body" style="overflow-x:auto">
+        <table class="exp-table">
+          <thead><tr><th>Hash</th><th>Message</th></tr></thead>
+          <tbody id="git-tbody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div id="page-controls" class="page">
+    <div class="panel">
+      <div class="panel-head">Launch Autonomous Research Loop</div>
+      <div class="panel-body">
+        <div class="ctrl-grid" style="margin-bottom:16px">
+          <div class="form-group">
+            <label>Run tag (e.g. mar18)</label>
+            <input type="text" id="ctrl-tag" placeholder="mar18">
+          </div>
+          <div class="form-group">
+            <label>Model</label>
+            <select id="ctrl-model">
+              <option value="">Default (from config)</option>
+              <option value="anthropic/claude-opus-4.6">claude-opus-4.6</option>
+              <option value="anthropic/claude-sonnet-4-20250514">claude-sonnet-4</option>
+              <option value="openai/gpt-4o">gpt-4o</option>
+              <option value="cerebras/qwen-3-235b-a22b-instruct-2507">Qwen3-235B (Cerebras)</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>Max experiments (0 = unlimited)</label>
+            <input type="number" id="ctrl-max-exp" value="0" min="0">
+          </div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-green" onclick="launchAgent()">▶ Launch Agent</button>
+          <button class="btn btn-red" onclick="stopAgent()">■ Stop</button>
+        </div>
+        <div id="ctrl-result" style="margin-top:12px;font-size:13px;color:var(--dim)"></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-head">Current Hyperparameters (live from train.py)</div>
+      <div class="panel-body">
+        <table class="exp-table" id="hparam-table">
+          <thead><tr><th>Parameter</th><th>Value</th></tr></thead>
+          <tbody id="hparam-tbody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Settings -->
+  <div id="page-settings" class="page">
+    <div class="panel">
+      <div class="panel-head">program.md</div>
+      <div class="panel-body">
+        <textarea id="settings-program" rows="30" style="width:100%"></textarea>
+        <div class="btn-row" style="margin-top:12px">
+          <button class="btn btn-green" onclick="saveSettings()">Save</button>
+          <div id="settings-result" style="color:var(--dim);font-size:12px;align-self:center;margin-left:8px"></div>
+        </div>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="panel-head">train.py (read-only)</div>
+      <div class="panel-body">
+        <textarea id="settings-train" rows="30" style="width:100%" readonly></textarea>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /main -->
+</div><!-- /app -->
+
+<script>
+// ---- State ----
+let chartBpb = null, chartStatus = null, chartLiveLoss = null;
+let liveSteps = [];
+let allResults = [];
+let logBuffer = [];
+const MAX_LOG = 500;
+let eventSource = null;
+
+// ---- Page nav ----
+function showPage(name) {
+  document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.sb-nav a').forEach(a => a.classList.remove('active'));
+  document.getElementById('page-' + name).classList.add('active');
+  const links = document.querySelectorAll('.sb-nav a');
+  for (const l of links) {
+    if (l.getAttribute('onclick') && l.getAttribute('onclick').includes(name)) l.classList.add('active');
+  }
+  if (name === 'git') loadGit();
+  if (name === 'settings') loadSettings();
+  if (name === 'controls') loadHparams();
+}
+
+// ---- Init charts ----
+function initCharts() {
+  const darkBg = 'transparent';
+  const gridColor = 'rgba(48,54,61,.6)';
+  const baseOpts = {
+    responsive: true, maintainAspectRatio: false,
+    animation: { duration: 300 },
+    plugins: { legend: { labels: { color: '#7d8590', font: { size: 11 } } } },
+    scales: {
+      x: { grid: { color: gridColor }, ticks: { color: '#7d8590', font: { size: 10 } } },
+      y: { grid: { color: gridColor }, ticks: { color: '#7d8590', font: { size: 10 } } },
+    }
+  };
+
+  chartBpb = new Chart(document.getElementById('chart-bpb'), {
+    type: 'scatter',
+    data: { datasets: [
+      { label: 'KEEP', data: [], pointBackgroundColor: '#3fb950', pointRadius: 6 },
+      { label: 'DISCARD', data: [], pointBackgroundColor: '#f85149', pointRadius: 4, pointStyle: 'crossRot' },
+    ]},
+    options: { ...baseOpts, plugins: { ...baseOpts.plugins, tooltip: { callbacks: {
+      label: ctx => {
+        const p = ctx.raw;
+        return `#${p.idx} ${p.desc || ''}: ${p.y?.toFixed(6)}`;
+      }
+    }}}}
+  });
+
+  chartStatus = new Chart(document.getElementById('chart-status'), {
+    type: 'doughnut',
+    data: { labels: ['keep', 'discard', 'crash'], datasets: [{ data: [0,0,0], backgroundColor: ['#3fb950','#f85149','#d29922'], borderWidth: 0 }]},
+    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#7d8590' } } } }
+  });
+
+  chartLiveLoss = new Chart(document.getElementById('chart-live-loss'), {
+    type: 'line',
+    data: { labels: [], datasets: [
+      { label: 'loss', data: [], borderColor: '#d29922', borderWidth: 1.5, pointRadius: 0, tension: 0.3 },
+      { label: 'mfu%', data: [], borderColor: '#58a6ff', borderWidth: 1.5, pointRadius: 0, tension: 0.3, yAxisID: 'y2' },
+    ]},
+    options: {
+      ...baseOpts,
+      scales: {
+        x: { grid: { color: gridColor }, ticks: { color: '#7d8590', font: { size: 10 }, maxTicksLimit: 8 } },
+        y: { grid: { color: gridColor }, ticks: { color: '#7d8590', font: { size: 10 } }, title: { display: true, text: 'loss', color: '#d29922' } },
+        y2: { position: 'right', grid: { drawOnChartArea: false }, ticks: { color: '#58a6ff', font: { size: 10 } }, title: { display: true, text: 'mfu%', color: '#58a6ff' } },
+      }
+    }
+  });
+}
+
+// ---- Results ----
+async function loadResults() {
+  const res = await fetch('/api/results');
+  allResults = await res.json();
+  renderResultsTable(allResults);
+  updateOverviewCharts(allResults);
+  updateKpis(allResults);
+}
+
+function updateKpis(results) {
+  const keeps = results.filter(r => r.status === 'keep' || r.status === 'baseline');
+  const discards = results.filter(r => r.status === 'discard');
+  const crashes = results.filter(r => r.status === 'crash');
+  const bpbs = keeps.map(r => r.val_bpb).filter(v => v > 0);
+  const best = bpbs.length ? Math.min(...bpbs) : null;
+  const baseline = bpbs.length ? bpbs[0] : null;
+  const pctImprove = best && baseline ? ((baseline - best) / baseline * 100).toFixed(2) : null;
+
+  document.getElementById('kpi-row').innerHTML = `
+    <div class="kpi"><div class="k-label">Best val_bpb</div><div class="k-val" style="color:var(--green)">${best ? best.toFixed(6) : '—'}</div></div>
+    <div class="kpi"><div class="k-label">Baseline val_bpb</div><div class="k-val">${baseline ? baseline.toFixed(6) : '—'}</div></div>
+    <div class="kpi"><div class="k-label">Improvement</div><div class="k-val" style="color:var(--cyan)">${pctImprove ? pctImprove + '%' : '—'}</div></div>
+    <div class="kpi"><div class="k-label">Total Runs</div><div class="k-val">${results.length}</div><div class="k-sub">${keeps.length} kept · ${discards.length} discarded · ${crashes.length} crashed</div></div>
+  `;
+}
+
+function updateOverviewCharts(results) {
+  let keepPts = [], discardPts = [];
+  let keep = 0, discard = 0, crash = 0;
+  results.forEach((r, i) => {
+    const pt = { x: i + 1, y: r.val_bpb, idx: i + 1, desc: r.description };
+    if (r.status === 'keep' || r.status === 'baseline') { keepPts.push(pt); keep++; }
+    else if (r.status === 'discard') { discardPts.push(pt); discard++; }
+    else crash++;
+  });
+  chartBpb.data.datasets[0].data = keepPts;
+  chartBpb.data.datasets[1].data = discardPts;
+  chartBpb.update('none');
+  chartStatus.data.datasets[0].data = [keep, discard, crash];
+  chartStatus.update('none');
+}
+
+function renderResultsTable(results) {
+  const bpbs = results.filter(r => r.val_bpb > 0).map(r => r.val_bpb);
+  const bestBpb = bpbs.length ? Math.min(...bpbs) : null;
+  const tbody = document.getElementById('exp-tbody');
+  tbody.innerHTML = '';
+  const filter = document.getElementById('exp-search').value.toLowerCase();
+  const filtered = results.filter(r =>
+    !filter || JSON.stringify(r).toLowerCase().includes(filter)
+  );
+  [...filtered].reverse().forEach((r, i) => {
+    const realIdx = results.length - i;
+    const isBest = r.val_bpb === bestBpb;
+    const tr = document.createElement('tr');
+    if (isBest) tr.className = 'best-row';
+    tr.innerHTML = `
+      <td>${realIdx}</td>
+      <td><span class="commit-link" onclick="showDiff('${r.commit}')">${r.commit}</span></td>
+      <td><b>${r.val_bpb > 0 ? r.val_bpb.toFixed(6) : '—'}</b> ${isBest ? '★' : ''}</td>
+      <td>${r.memory_gb > 0 ? r.memory_gb.toFixed(1) : '—'}</td>
+      <td><span class="badge ${r.status}">${r.status}</span></td>
+      <td style="color:var(--dim)">${r.description || ''}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('exp-search').addEventListener('input', () => renderResultsTable(allResults));
+
+// ---- Diff ----
+async function showDiff(commit) {
+  const res = await fetch(`/api/diff/${commit}`);
+  const data = await res.json();
+  const panel = document.getElementById('diff-panel');
+  document.getElementById('diff-title').textContent = `Diff — ${commit}`;
+  panel.style.display = '';
+  const out = document.getElementById('diff-output');
+  out.innerHTML = '';
+  (data.diff || '').split('\n').forEach(line => {
+    const span = document.createElement('span');
+    if (line.startsWith('+')) span.className = 'diff-add';
+    else if (line.startsWith('-')) span.className = 'diff-del';
+    else if (line.startsWith('@@') || line.startsWith('diff')) span.className = 'diff-meta';
+    span.textContent = line + '\n';
+    out.appendChild(span);
+  });
+  panel.scrollIntoView({ behavior: 'smooth' });
+}
+
+// ---- Live training ----
+function initSSE() {
+  if (eventSource) eventSource.close();
+  eventSource = new EventSource('/api/stream');
+  eventSource.onmessage = e => {
+    const line = JSON.parse(e.data);
+    appendLog(line);
+  };
+  eventSource.onerror = () => {
+    setTimeout(initSSE, 3000);
+  };
+}
+
+function appendLog(line) {
+  logBuffer.push(line);
+  if (logBuffer.length > MAX_LOG) logBuffer.shift();
+  const el = document.getElementById('log-output');
+  const span = document.createElement('span');
+  if (/^step \d+/.test(line)) span.className = 'log-step';
+  else if (/val_bpb|training_seconds|peak_vram_mb/.test(line)) span.className = 'log-sum';
+  else if (/error|Error|FAIL/.test(line)) span.className = 'log-err';
+  else if (/git|branch|commit/.test(line)) span.className = 'log-git';
+  span.textContent = line + '\n';
+  el.appendChild(span);
+  if (document.getElementById('autoscroll').checked) el.scrollTop = el.scrollHeight;
+  if (el.childNodes.length > MAX_LOG) el.removeChild(el.firstChild);
+}
+
+async function pollLive() {
+  const res = await fetch('/api/live');
+  const data = await res.json();
+  liveSteps = data.steps;
+  updateLiveChart(liveSteps);
+  if (liveSteps.length) {
+    const last = liveSteps[liveSteps.length - 1];
+    const wrap = document.getElementById('live-progress-wrap');
+    wrap.style.display = '';
+    document.getElementById('live-step-label').textContent = `step ${last.step}`;
+    document.getElementById('live-pct-label').textContent = `${last.progress.toFixed(1)}%`;
+    document.getElementById('live-progress-bar').style.width = last.progress + '%';
+    document.getElementById('live-stats').innerHTML = `
+      <span style="color:var(--amber)">loss: <b>${last.loss.toFixed(4)}</b></span>
+      <span style="color:var(--cyan)">mfu: <b>${last.mfu.toFixed(1)}%</b></span>
+      <span style="color:var(--purple)">tok/s: <b>${last.tok_sec.toLocaleString()}</b></span>
+      <span style="color:var(--dim)">remaining: <b>${last.remaining.toFixed(0)}s</b></span>
+    `;
+  }
+  // Update status
+  const dot = document.getElementById('status-dot');
+  const txt = document.getElementById('sb-status-text');
+  if (data.running) { dot.className = 'running'; txt.textContent = 'Running'; }
+  else { dot.className = ''; txt.textContent = 'Idle'; }
+  if (data.summary) {
+    const s = data.summary;
+    document.getElementById('sb-best').textContent = s.val_bpb ? s.val_bpb.toFixed(6) : '—';
+  }
+}
+
+function updateLiveChart(steps) {
+  if (!steps.length) return;
+  const labels = steps.map(s => s.step);
+  chartLiveLoss.data.labels = labels;
+  chartLiveLoss.data.datasets[0].data = steps.map(s => s.loss);
+  chartLiveLoss.data.datasets[1].data = steps.map(s => s.mfu);
+  chartLiveLoss.update('none');
+}
+
+// ---- Status polling ----
+async function pollStatus() {
+  const res = await fetch('/api/status');
+  const data = await res.json();
+  document.getElementById('sb-branch').textContent = data.branch || '—';
+  document.getElementById('sb-count').textContent = data.experiment_count;
+  if (data.best_bpb) document.getElementById('sb-best').textContent = data.best_bpb.toFixed(6);
+  const dot = document.getElementById('status-dot');
+  const txt = document.getElementById('sb-status-text');
+  if (data.running) { dot.className = 'running'; txt.textContent = 'Running'; }
+  else { dot.className = ''; txt.textContent = 'Idle'; }
+  renderGpuOverview(data.gpus);
+}
+
+function renderGpuOverview(gpus) {
+  const el = document.getElementById('gpu-overview');
+  if (!gpus.length) { el.innerHTML = '<span style="color:var(--dim)">No GPU info available</span>'; return; }
+  el.innerHTML = gpus.map(g => `
+    <div style="margin-bottom:12px">
+      <div style="display:flex;justify-content:space-between;font-size:12px;margin-bottom:4px">
+        <span><b>GPU ${g.index}</b> ${g.name}</span>
+        <span style="color:var(--dim)">${g.util_pct}% util · ${(g.mem_used_mb/1024).toFixed(1)}/${(g.mem_total_mb/1024).toFixed(1)} GB · ${g.temp_c}°C</span>
+      </div>
+      <div class="gpu-bar-wrap"><div class="gpu-bar ${g.temp_c > 80 ? 'hot' : ''}" style="width:${g.util_pct}%"></div></div>
+      <div class="gpu-bar-wrap" style="margin-top:3px"><div class="gpu-bar" style="width:${g.mem_used_mb/g.mem_total_mb*100}%;background:var(--purple)"></div></div>
+    </div>
+  `).join('');
+}
+
+// ---- Git ----
+async function loadGit() {
+  const res = await fetch('/api/git-log');
+  const commits = await res.json();
+  const tbody = document.getElementById('git-tbody');
+  tbody.innerHTML = commits.map(c => `
+    <tr>
+      <td><span class="commit-link" onclick="showDiff('${c.hash}')">${c.hash}</span></td>
+      <td style="color:var(--dim)">${c.message}</td>
+    </tr>
+  `).join('');
+}
+
+// ---- Controls ----
+async function launchAgent() {
+  const tag = document.getElementById('ctrl-tag').value.trim();
+  const model = document.getElementById('ctrl-model').value;
+  const maxExp = parseInt(document.getElementById('ctrl-max-exp').value) || 0;
+  const res = await fetch('/api/launch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ run_tag: tag, model, max_experiments: maxExp }),
+  });
+  const data = await res.json();
+  const el = document.getElementById('ctrl-result');
+  if (data.error) el.innerHTML = `<span style="color:var(--red)">${data.error}</span>`;
+  else el.innerHTML = `<span style="color:var(--green)">Launched (PID ${data.pid})</span>`;
+}
+
+async function stopAgent() {
+  const res = await fetch('/api/stop', { method: 'POST' });
+  const data = await res.json();
+  document.getElementById('ctrl-result').innerHTML =
+    `<span style="color:var(--amber)">Stopped. Killed PIDs: ${data.killed.join(', ') || 'none'}</span>`;
+}
+
+async function loadHparams() {
+  const res = await fetch('/api/hyperparams');
+  const params = await res.json();
+  const tbody = document.getElementById('hparam-tbody');
+  tbody.innerHTML = Object.entries(params).map(([k, v]) =>
+    `<tr><td style="font-family:monospace;color:var(--cyan)">${k}</td><td style="font-family:monospace">${JSON.stringify(v)}</td></tr>`
+  ).join('');
+}
+
+// ---- Settings ----
+async function loadSettings() {
+  const [prog, train] = await Promise.all([
+    fetch('/api/file/program.md').then(r => r.json()),
+    fetch('/api/file/train.py').then(r => r.json()),
+  ]);
+  document.getElementById('settings-program').value = prog.content;
+  document.getElementById('settings-train').value = train.content;
+}
+
+async function saveSettings() {
+  const content = document.getElementById('settings-program').value;
+  const res = await fetch('/api/file/program.md', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  const data = await res.json();
+  document.getElementById('settings-result').textContent =
+    data.status === 'saved' ? '✓ Saved' : '✗ Error';
+}
+
+// ---- Init ----
+initCharts();
+initSSE();
+loadResults();
+pollStatus();
+pollLive();
+
+setInterval(loadResults, 10_000);
+setInterval(pollStatus, 5_000);
+setInterval(pollLive, 2_000);
+</script>
+</body>
+</html>
+"""
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard():
+    return DASHBOARD_HTML
+
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ.get("PORT", 7788))
+    print(f"Dashboard starting at http://localhost:{port}")
+    print(f"Repo dir: {REPO_DIR}")
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Autonomous pretraining research swarm"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "fastapi>=0.135.1",
     "kernels>=0.11.7",
     "matplotlib>=3.10.8",
     "numpy>=2.2.6",
@@ -14,6 +15,7 @@ dependencies = [
     "rustbpe>=0.1.0",
     "tiktoken>=0.11.0",
     "torch==2.9.1",
+    "uvicorn>=0.42.0",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -46,6 +55,7 @@ name = "autoresearch"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "kernels" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -57,10 +67,12 @@ dependencies = [
     { name = "rustbpe" },
     { name = "tiktoken" },
     { name = "torch" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "kernels", specifier = ">=0.11.7" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -70,6 +82,7 @@ requires-dist = [
     { name = "rustbpe", specifier = ">=0.1.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "torch", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "uvicorn", specifier = ">=0.42.0" },
 ]
 
 [[package]]
@@ -377,6 +390,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -1525,6 +1554,139 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1841,6 +2003,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2079,6 +2254,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2094,4 +2281,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
 ]


### PR DESCRIPTION
## What this adds

A single-file FastAPI dashboard (`dashboard.py`) that gives autoresearch a proper UI for monitoring and controlling experiments in real time.

### Start it
```bash
cd autoresearch
uv run dashboard.py
# open http://localhost:7788
```
Set `REPO_DIR` env var to point at any autoresearch clone. Set `PORT` to change from 7788.

---

### Tabs

**Overview**
- KPI cards: best val_bpb, baseline, improvement %, total/kept/discarded run counts
- val_bpb scatter chart colored by status (keep=green, discard=red, crash=gray)
- Status pie chart
- Live GPU stats: utilization %, VRAM used, temperature (polls `nvidia-smi`)

**Live Training**
- Step progress bar with % complete
- Loss + mfu% dual-axis chart, updates every 2 seconds via polling
- SSE log stream from run.log — color-coded (amber for step lines, green for summary blocks, red for errors)
- Autoscroll toggle

**Experiments**
- Full results table sorted newest-first, best run highlighted in gold
- Click any commit hash → inline diff of that experiment's train.py changes

**Git History**
- Last 40 commits with click-to-diff

**Controls**
- Launch form: run tag, model picker, max experiments
- Stop button for the running experiment
- Live hyperparameter table parsed directly from train.py

**Settings**
- Edit program.md in-browser with save
- Read-only train.py viewer

---

### Implementation notes
- Zero frontend dependencies — all HTML/CSS/JS served inline from the single Python file
- FastAPI + uvicorn only (added to pyproject.toml)
- SSE endpoint for streaming log tail to the browser
- All file reads are relative to `REPO_DIR` so it works with any clone location