### PR TITLE
docs(program): add hypothesis column to results.tsv format

### DIFF
--- a/program.md
+++ b/program.md
@@ -65,10 +65,10 @@ grep "^val_bpb:" run.log
 
 When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated — commas break in descriptions).
 
-The TSV has a header row and 5 columns:
+The TSV has a header row and 6 columns:
 
 ```
-commit	val_bpb	memory_gb	status	description
+commit	val_bpb	memory_gb	status	description	hypothesis
 ```
 
 1. git commit hash (short, 7 chars)
@@ -76,15 +76,16 @@ commit	val_bpb	memory_gb	status	description
 3. peak memory in GB, round to .1f (e.g. 12.3 — divide peak_vram_mb by 1024) — use 0.0 for crashes
 4. status: `keep`, `discard`, or `crash`
 5. short text description of what this experiment tried
+6. hypothesis: a non-obvious idea to explore based on this result — a combination, condition, or unexpected connection worth testing later (use `-` for baseline)
 
 Example:
 
 ```
-commit	val_bpb	memory_gb	status	description
-a1b2c3d	0.997900	44.0	keep	baseline
-b2c3d4e	0.993200	44.2	keep	increase LR to 0.04
-c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
-d4e5f6g	0.000000	0.0	crash	double model width (OOM)
+commit	val_bpb	memory_gb	status	description	hypothesis
+a1b2c3d	0.997900	44.0	keep	baseline	-
+b2c3d4e	0.993200	44.2	keep	increase LR to 0.04	LR gain + depth increase might compound
+c3d4e5f	1.005000	44.0	discard	switch to GeLU activation	GeLU might unlock with RMSNorm instead of LayerNorm
+d4e5f6g	0.000000	0.0	crash	double model width (OOM)	wide + shallow + gradient checkpointing unexplored
 ```
 
 ## The experiment loop
@@ -109,6 +110,6 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
 
-**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
+**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — gather hypotheses from results.tsv and look for unexplored combinations, read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
 
 As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!


### PR DESCRIPTION
## Add hypothesis column to results.tsv for learning

This PR introduces a lightweight mechanism for the agent to accumulate non-obvious research directions during experimentation.

### Changes:
- Added `hypothesis` column to `results.tsv` format
- Updated `program.md`: column spec and examples for agent
- Added "gather hypotheses from results.tsv and look for unexplored combinations" to the "out of ideas" recovery flow

### What is a hypothesis here:
Not a restatement of what was tried (that's `description`), but a non-obvious combination, condition, or connection worth exploring later. Example: experiment fails with GeLU → hypothesis is "GeLU might unlock with RMSNorm instead of LayerNorm", not "GeLU didn't work".

### Why this matters:
When the agent exhausts obvious directions after 50+ experiments, it can revisit its own accumulated hypotheses — ideas it generated in context but never tested. This creates a passive memory that survives context window limits.

---

### Open question – needs A/B testing:
The hypothesis gathering instruction is currently placed at the beginning of the "out of ideas" list. Unclear if it should be first (prioritize own insights) or last (use as final fallback). Requires empirical testing.