### PR TITLE
Add davesque/autoresearch-mlx to notable forks (1.280 val_bpb, best Apple Silicon result I've seen?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
+- [davesque/autoresearch-mlx](https://github.com/davesque/autoresearch-mlx) (MacOS, literature-driven search, strategy journal)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
 


### PR DESCRIPTION
Best val_bpb: 1.280 on M4 Max (vs 1.295 prior Apple Silicon best).
Key additions: Muon optimizer, Peri-LN normalization, and an enhanced
experiment protocol with literature-driven search and a persistent
strategy journal.