### PR TITLE
fix: accumulate `train_loss` correctly across micro-steps

### DIFF
--- a/train.py
+++ b/train.py
@@ -543,10 +543,11 @@ step = 0
 while True:
     torch.cuda.synchronize()
     t0 = time.time()
+    train_loss = 0.0
     for micro_step in range(grad_accum_steps):
         with autocast_ctx:
             loss = model(x, y)
-        train_loss = loss.detach()
+        train_loss += loss.detach() / grad_accum_steps
         loss = loss / grad_accum_steps
         loss.backward()
         x, y, epoch = next(train_loader)


### PR DESCRIPTION
Currently, `train_loss = loss.detach()` overwrites the loss tracking on each micro-step, meaning the reported `train_loss_f` solely reflects the loss of the *final* micro-batch instead of the true mean of the entire global batch.

This PR fixes this by accumulating `loss.detach() / grad_accum_steps` over the loop. This reduces the variance in the logged `debiased_smooth_loss` and provides an exact mean loss corresponding to the global batch.