### PR TITLE
Add cloud GPU infrastructure (RunPod, US-TX-3, RTX 4090)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'entrypoint.sh'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.python-version'
+      - '.github/workflows/docker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dev/
 
 # Results file
 results.tsv
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# =============================================================================
+# Dockerfile — autoresearch
+# Source code lives on /working (network volume), NOT baked in.
+# Image contains: CUDA runtime, system packages, Rust, uv, all Python deps.
+# Rebuild trigger: push changes to Dockerfile, pyproject.toml, or uv.lock
+# =============================================================================
+
+FROM runpod/autoresearch:1.0.2-cuda1281-ubuntu2204
+
+# System packages
+RUN apt-get update && apt-get install -y \
+    git curl wget htop tmux vim \
+    openssh-server \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust (needed for rustbpe and other native extensions)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Pin venv to fixed path — uv run works from /working at runtime
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+
+# Install Python dependencies into /opt/venv (baked into image)
+# Source code is NOT copied — it comes from /working at runtime
+WORKDIR /build
+COPY pyproject.toml uv.lock .python-version ./
+RUN uv sync --frozen --no-install-project --no-cache
+
+# Entrypoint bootstrap (clones/pulls repo, sets up /data, calls startup.sh)
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8888 22
+
+CMD ["/entrypoint.sh"]

--- a/cloud-gpu.json
+++ b/cloud-gpu.json
@@ -1,0 +1,12 @@
+{
+  "provider": "runpod",
+  "github_repo": "rstager/autoresearch",
+  "network_volume_id": "ay7m01er4v",
+  "network_volume_name": "autoresearch-working",
+  "network_volume_size_gb": 10,
+  "container_disk_gb": 40,
+  "data_persistent": false,
+  "data_center_id": "US-TX-3",
+  "gpu_type": "NVIDIA GeForce RTX 4090",
+  "image": "ghcr.io/rstager/autoresearch:latest"
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# =============================================================================
+# entrypoint.sh — Baked into Docker image.
+# Bootstraps /working volume: clones/pulls repo, sets up /data, hands off
+# to /working/REPO_NAME/startup.sh.
+#
+# Environment variables (set in pod config):
+#   REPO_NAME        - repo directory name under /working (default: autoresearch)
+#   GITHUB_REPO      - GitHub repo path (default: rstager/autoresearch)
+#   DATA_PERSISTENT  - "true" = /data → /working/data | "false" = /data on root fs
+# =============================================================================
+set -euo pipefail
+
+export UV_PROJECT_ENVIRONMENT=/opt/venv
+
+REPO_NAME="${REPO_NAME:-autoresearch}"
+GITHUB_REPO="${GITHUB_REPO:-rstager/autoresearch}"
+DATA_PERSISTENT="${DATA_PERSISTENT:-false}"
+WORKING_DIR="/working"
+REPO_DIR="$WORKING_DIR/$REPO_NAME"
+
+echo "[entrypoint] Starting at $(date)"
+
+# --- Verify /working is mounted ---
+if [ ! -d "$WORKING_DIR" ]; then
+    echo "[entrypoint] ERROR: /working volume not mounted — keeping alive for debug"
+    tail -f /dev/null
+    exit 1
+fi
+
+# --- Clone or pull repo ---
+if [ ! -d "$REPO_DIR/.git" ]; then
+    echo "[entrypoint] Cloning https://github.com/$GITHUB_REPO → $REPO_DIR"
+    git clone "https://github.com/$GITHUB_REPO.git" "$REPO_DIR"
+else
+    echo "[entrypoint] Updating $REPO_DIR"
+    git -C "$REPO_DIR" pull --ff-only || echo "[entrypoint] WARNING: git pull failed, using existing code"
+fi
+
+# --- Set up /data ---
+if [ "$DATA_PERSISTENT" = "true" ]; then
+    echo "[entrypoint] /data → /working/data (persistent)"
+    mkdir -p "$WORKING_DIR/data"
+    ln -sfn "$WORKING_DIR/data" /data
+else
+    echo "[entrypoint] /data on container root (ephemeral)"
+    mkdir -p /data
+fi
+
+# --- Set up /scratch ---
+mkdir -p /scratch/tmp /scratch/compile
+echo "[entrypoint] /scratch ready (ephemeral)"
+
+# --- Hand off to repo's startup.sh ---
+STARTUP="$REPO_DIR/startup.sh"
+if [ -f "$STARTUP" ]; then
+    chmod +x "$STARTUP"
+    echo "[entrypoint] Handing off to $STARTUP"
+    exec bash "$STARTUP"
+else
+    echo "[entrypoint] WARNING: $STARTUP not found — keeping alive for debug"
+    tail -f /dev/null
+fi

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# =============================================================================
+# startup.sh — Lives in the repo at /working/autoresearch/startup.sh
+# Called by entrypoint.sh after clone/pull.
+# =============================================================================
+set -euo pipefail
+
+REPO_NAME="${REPO_NAME:-autoresearch}"
+REPO_DIR="/working/$REPO_NAME"
+ENV_FILE="$REPO_DIR/.env"
+BASHRC="/root/.bashrc"
+
+echo "[startup] $(date)"
+
+# -----------------------------------------------------------------------------
+# 1. Source .env for this session
+# -----------------------------------------------------------------------------
+if [ -f "$ENV_FILE" ]; then
+    echo "[startup] Sourcing $ENV_FILE"
+    set -a; source "$ENV_FILE"; set +a
+else
+    echo "[startup] NOTE: $ENV_FILE not found — create it with HF_TOKEN, WANDB_KEY, etc."
+fi
+
+# -----------------------------------------------------------------------------
+# 2. Patch .bashrc so .env and UV_PROJECT_ENVIRONMENT are set in every shell
+# -----------------------------------------------------------------------------
+BASHRC_MARKER="# cloud-gpu: auto-source project .env"
+if ! grep -qF "$BASHRC_MARKER" "$BASHRC" 2>/dev/null; then
+    echo "[startup] Patching $BASHRC"
+    cat >> "$BASHRC" << BASHEOF
+
+$BASHRC_MARKER
+export UV_PROJECT_ENVIRONMENT=/opt/venv
+if [ -f "$ENV_FILE" ]; then
+    set -a; source "$ENV_FILE"; set +a
+fi
+BASHEOF
+fi
+
+# -----------------------------------------------------------------------------
+# 3. GPU check
+# -----------------------------------------------------------------------------
+echo "[startup] GPU:"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader \
+    || echo "[startup] WARNING: nvidia-smi failed"
+
+# -----------------------------------------------------------------------------
+# 4. Volume / disk check
+# -----------------------------------------------------------------------------
+for vol in /working /data /scratch; do
+    if [ -d "$vol" ]; then
+        echo "[startup] $vol: $(df -h "$vol" | tail -1 | awk '{print $4}') free"
+    else
+        echo "[startup] WARNING: $vol not available"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# 5. Standard directories
+# -----------------------------------------------------------------------------
+mkdir -p /data/datasets /data/checkpoints /data/logs /data/wandb /data/.cache/huggingface
+mkdir -p /scratch/tmp /scratch/compile
+
+# -----------------------------------------------------------------------------
+# 6. Export standard paths
+# -----------------------------------------------------------------------------
+export HF_HOME="${HF_HOME:-/data/.cache/huggingface}"
+export WANDB_DIR="${WANDB_DIR:-/data/wandb}"
+export TMPDIR="${TMPDIR:-/scratch/tmp}"
+export PYTHONPATH="${PYTHONPATH:-$REPO_DIR}"
+
+# -----------------------------------------------------------------------------
+# 7. DATA SETUP — download data if not already present
+# -----------------------------------------------------------------------------
+DATA_READY_FLAG="/data/datasets/.ready"
+if [ ! -f "$DATA_READY_FLAG" ]; then
+    echo "[startup] Downloading data (prepare.py)..."
+    cd "$REPO_DIR"
+    uv run prepare.py
+    touch "$DATA_READY_FLAG"
+else
+    echo "[startup] Data already present, skipping download"
+fi
+
+# -----------------------------------------------------------------------------
+# 8. Convenience symlinks into repo dir
+# -----------------------------------------------------------------------------
+ln -sfn /data/checkpoints "$REPO_DIR/checkpoints" 2>/dev/null || true
+ln -sfn /data/datasets    "$REPO_DIR/datasets"    2>/dev/null || true
+ln -sfn /data/logs        "$REPO_DIR/logs"        2>/dev/null || true
+
+# -----------------------------------------------------------------------------
+# 9. Ready — keep alive for interactive SSH use
+#    To auto-start training: replace with: exec uv run train.py
+# -----------------------------------------------------------------------------
+echo "[startup] Ready — repo at $REPO_DIR"
+cd "$REPO_DIR"
+tail -f /dev/null


### PR DESCRIPTION
## Summary
- Adds RunPod cloud GPU setup with network volume `autoresearch-working` (10GB, US-TX-3)
- `entrypoint.sh` baked into Docker image: clones/pulls repo on start, sets up `/data` and `/scratch`
- `startup.sh` in repo: sources `.env`, patches `.bashrc`, downloads data via `prepare.py` if missing
- `Dockerfile` updated: packages baked into `/opt/venv`, source code comes from `/working` at runtime
- `cloud-gpu.json` stores pod config for future launches (RTX 4090, 40GB container disk, ephemeral `/data`)
- GitHub Actions builds and pushes `ghcr.io/rstager/autoresearch:latest` on push to main

## Test plan
- [ ] Merge triggers Docker build in GitHub Actions
- [ ] Make ghcr.io package public after first build
- [ ] Launch pod via `cloud-gpu.json` config