### PR TITLE
Add setup-cloud.sh for running on root-only cloud GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ Seeing as there seems to be a lot of interest in tinkering with autoresearch on 
 
 I think these would be the reasonable hyperparameters to play with. Ask your favorite coding agent for help and copy paste them this guide, as well as the full source code.
 
+## Running on cloud GPUs (RunPod, Lambda, Vast.ai, etc.)
+
+Most cloud GPU providers (RunPod, Lambda, Vast.ai, etc.) run containers as root by default. Claude Code blocks `--dangerously-skip-permissions` when running as root for security reasons, which prevents autonomous operation.
+
+This repo includes a `setup-cloud.sh` script that creates a non-root user and configures the environment for autonomous research:
+
+```bash
+# First, run prepare.py as root to download data
+uv run prepare.py
+
+# Then run the setup script
+./setup-cloud.sh
+
+# Launch autonomous research as the non-root user
+su - researcher -c 'cd ~/autoresearch && claude --dangerously-skip-permissions'
+```
+
+The script handles:
+- Creating a non-root user (`researcher`)
+- Copying the workspace to the user's home directory
+- Configuring git safe directory
+- Setting correct file permissions
+
 ## Notable forks
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)

--- a/setup-cloud.sh
+++ b/setup-cloud.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# setup-cloud.sh — Run autoresearch on root-only cloud GPUs (RunPod, Lambda, Vast.ai, etc.)
+#
+# Usage: ./setup-cloud.sh [workspace_dir]
+# Default workspace: /workspace/autoresearch
+
+set -e
+
+WORK_DIR="${1:-$(dirname "$(realpath "$0")")}"
+USER="researcher"
+
+echo "Setting up non-root user for autonomous Claude Code..."
+echo "Workspace: $WORK_DIR"
+
+# Create user if needed
+if ! id "$USER" &>/dev/null; then
+    echo "Creating user: $USER"
+    useradd -m -s /bin/bash "$USER"
+else
+    echo "User $USER already exists"
+fi
+
+# Copy workspace to user's home
+echo "Copying workspace to /home/$USER/autoresearch..."
+rm -rf "/home/$USER/autoresearch"
+cp -r "$WORK_DIR" "/home/$USER/autoresearch"
+chown -R "$USER:$USER" "/home/$USER/autoresearch"
+
+# Fix git safe directory
+echo "Configuring git safe directory..."
+su - "$USER" -c "git config --global --add safe.directory /home/$USER/autoresearch"
+
+# Check for data directory
+DATA_DIR="/home/$USER/.cache/autoresearch"
+if [ -d "$DATA_DIR" ]; then
+    echo "Data directory found at $DATA_DIR"
+    chown -R "$USER:$USER" "$DATA_DIR"
+else
+    echo ""
+    echo "WARNING: Data not found at $DATA_DIR"
+    echo "Run 'uv run prepare.py' as root first, then re-run this script."
+    echo ""
+fi
+
+echo ""
+echo "========================================"
+echo "Setup complete!"
+echo "========================================"
+echo ""
+echo "To launch autonomous research, run:"
+echo ""
+echo "  su - $USER -c 'cd ~/autoresearch && claude --dangerously-skip-permissions'"
+echo ""
+echo "Or with a custom prompt:"
+echo ""
+echo "  su - $USER -c 'cd ~/autoresearch && claude --dangerously-skip-permissions -p \"Hi, have a look at program.md and let'"'"'s kick off a new experiment!\"'"
+echo ""


### PR DESCRIPTION
## Summary

This PR adds a `setup-cloud.sh` script and updates documentation to help users run autoresearch on root-only cloud GPU environments (RunPod, Lambda, Vast.ai, etc.).

## Problem

Claude Code blocks `--dangerously-skip-permissions` when running as root for security reasons. Most cloud GPU providers run containers as root by default, making autonomous operation impossible without workarounds.

## Solution

1. **Added `setup-cloud.sh`** - A script that:
   - Creates a non-root user (`researcher`)
   - Copies the workspace to the user's home directory
   - Configures git safe directory
   - Sets correct file permissions

2. **Updated README.md** with a new section "Running on cloud GPUs" documenting:
   - The problem and solution
   - Usage instructions

## Changes

- `README.md` - Added "Running on cloud GPUs" section
- `setup-cloud.sh` - New script for cloud GPU setup

## Testing

The script follows the suggested fix from issue #396 and handles all the edge cases mentioned (git ownership, permissions, data directory verification).

---

This PR addresses issue: https://github.com/karpathy/autoresearch/issues/396