### PR TITLE
fix(prepare): enforce int type for prepend in Tokenizer.encode

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -226,24 +226,19 @@ class Tokenizer:
         return self.bos_token_id
 
     def encode(self, text, prepend=None, num_threads=8):
-        prepend_ids = None
         if prepend is not None:
-            if isinstance(prepend, int):
-                prepend_ids = [prepend]
-            else:
-                try:
-                    prepend_ids = [self.enc.encode_single_token(prepend)]
-                except KeyError:
-                    prepend_ids = self.enc.encode_ordinary(prepend)
+            if not isinstance(prepend, int):
+                raise TypeError(f"prepend must be an int token id, got {type(prepend)}")
+            prepend_id = prepend
         if isinstance(text, str):
             ids = self.enc.encode_ordinary(text)
-            if prepend_ids is not None:
-                ids[0:0] = prepend_ids
+            if prepend is not None:
+                ids.insert(0, prepend_id)
         elif isinstance(text, list):
             ids = self.enc.encode_ordinary_batch(text, num_threads=num_threads)
-            if prepend_ids is not None:
+            if prepend is not None:
                 for row in ids:
-                    row[0:0] = prepend_ids
+                    row.insert(0, prepend_id)
         else:
             raise ValueError(f"Invalid input type: {type(text)}")
         return ids

--- a/prepare.py
+++ b/prepare.py
@@ -226,17 +226,24 @@ class Tokenizer:
         return self.bos_token_id
 
     def encode(self, text, prepend=None, num_threads=8):
+        prepend_ids = None
         if prepend is not None:
-            prepend_id = prepend if isinstance(prepend, int) else self.enc.encode_single_token(prepend)
+            if isinstance(prepend, int):
+                prepend_ids = [prepend]
+            else:
+                try:
+                    prepend_ids = [self.enc.encode_single_token(prepend)]
+                except KeyError:
+                    prepend_ids = self.enc.encode_ordinary(prepend)
         if isinstance(text, str):
             ids = self.enc.encode_ordinary(text)
-            if prepend is not None:
-                ids.insert(0, prepend_id)
+            if prepend_ids is not None:
+                ids[0:0] = prepend_ids
         elif isinstance(text, list):
             ids = self.enc.encode_ordinary_batch(text, num_threads=num_threads)
-            if prepend is not None:
+            if prepend_ids is not None:
                 for row in ids:
-                    row.insert(0, prepend_id)
+                    row[0:0] = prepend_ids
         else:
             raise ValueError(f"Invalid input type: {type(text)}")
         return ids


### PR DESCRIPTION
## Summary
- Refs #348: `Tokenizer.encode` accepted string `prepend` args via `encode_single_token()`, which raises an obscure `KeyError` on multi-token strings
- Replace with an explicit `TypeError` so misuse fails loudly with a clear message
- 3 lines changed from upstream — zero behavioral change for the existing int-based BOS usage

## Test plan
- [x] Existing usage (`prepend=bos_token` as int): behavior identical — same code path as before
- [x] String prepend: now raises `TypeError` with a clear message instead of an obscure `KeyError` from tiktoken internals