### PR TITLE
Add autoresearch-swift to Notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
+- [PsychQuant/autoresearch-swift](https://github.com/PsychQuant/autoresearch-swift) (MacOS, native Swift + MLX-Swift, Muon optimizer)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
 


### PR DESCRIPTION
Adds [PsychQuant/autoresearch-swift](https://github.com/PsychQuant/autoresearch-swift) to the Notable forks section.

**What it is**: Native Swift + MLX-Swift implementation for Apple Silicon. Zero Python at runtime. Includes Muon + AdamW optimizer (first MLX implementation with Muon).

**Benchmark on M4 Max 128GB** (same 5-min budget, depth=4):

| | Swift | Python MLX |
|---|---|---|
| val_bpb | **1.406** | 1.863 |
| tok/sec | **54,051** | ~50,000 |
| Startup | **0.1s** | 1.4s |

Same `program.md` agent loop workflow, same `results.tsv` format.