### PR TITLE
Make DEVICE_BATCH_SIZE and TOTAL_BATCH_SIZE configurable via env vars

### DIFF
--- a/train.py
+++ b/train.py
@@ -435,7 +435,7 @@ HEAD_DIM = 128          # target head dimension for attention
 WINDOW_PATTERN = "SSSL" # sliding window pattern: L=full, S=half context
 
 # Optimization
-TOTAL_BATCH_SIZE = 2**19 # ~524K tokens per optimizer step
+TOTAL_BATCH_SIZE = int(os.environ.get("TOTAL_BATCH_SIZE", 2**19)) # ~524K tokens per optimizer step
 EMBEDDING_LR = 0.6      # learning rate for token embeddings (Adam)
 UNEMBEDDING_LR = 0.004  # learning rate for lm_head (Adam)
 MATRIX_LR = 0.04        # learning rate for matrix parameters (Muon)
@@ -448,7 +448,7 @@ FINAL_LR_FRAC = 0.0     # final LR as fraction of initial
 
 # Model size
 DEPTH = 8               # number of transformer layers
-DEVICE_BATCH_SIZE = 128  # per-device batch size (reduce if OOM)
+DEVICE_BATCH_SIZE = int(os.environ.get("DEVICE_BATCH_SIZE", 128))  # per-device batch size (reduce if OOM)
 
 # ---------------------------------------------------------------------------
 # Setup: tokenizer, model, optimizer, dataloader


### PR DESCRIPTION
## Summary

- `DEVICE_BATCH_SIZE` and `TOTAL_BATCH_SIZE` in `train.py` can now be overridden via environment variables
- Defaults are unchanged — existing behavior is identical
- Two-line change, no new dependencies

## Motivation

These values are hardcoded for H100 80GB GPUs. Cloud GPUs with less VRAM (A10G 24GB, T4 16GB) OOM with the defaults. Tools that run autoresearch on various cloud GPUs currently have to `sed`-patch these values before training. Environment variables are cleaner:

```bash
DEVICE_BATCH_SIZE=32 TOTAL_BATCH_SIZE=131072 uv run train.py
```

## Test plan

- [x] Verified on Mac (MPS) with `DEVICE_BATCH_SIZE=8` — gradient accumulation steps changed from 2 to 4 as expected, training completed successfully
- [x] Verified default behavior unchanged (no env vars set — same output as before)