### PR TITLE
Add kcxain/autoresearch-slurm to notable forks (Slurm / HPC clusters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
+- [kcxain/autoresearch-slurm](https://github.com/kcxain/autoresearch-slurm) (Slurm)
 
 ## License
 


### PR DESCRIPTION
Hi! This adds my Slurm port to the notable forks list.
                                                                                                                
  **What it does:** lets the agent run on HPC clusters managed by Slurm. Instead of executing `uv run train.py` directly, the agent submits `sbatch` jobs from the login node, polls with `squeue`, and reads results from the job log — so compute nodes don't need internet access. The rest of the rules are unchanged: one mutable `train.py`, one metric (`val_bpb`), fixed 5-minute budget, keep-or-revert via git.

  - Repo: https://github.com/kcxain/autoresearch-slurm
  - Tested on A100 via Slurm