### PR TITLE
fix: add explicit py-modules for editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ torch = [
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
 explicit = true
+
+[tool.setuptools]
+py-modules = ["train", "prepare"]


### PR DESCRIPTION
## Summary

- Add `[tool.setuptools]` with explicit `py-modules` to `pyproject.toml`
- Fixes setuptools flat-layout auto-discovery failure when multiple top-level `.py` files exist (`train.py`, `prepare.py`)
- Enables `pip install -e .` and `uv pip install -e .` without errors

## Test plan

- [x] Verified two top-level `.py` files cause `Multiple top-level modules discovered` error
- [x] `[tool.setuptools] py-modules` is the standard setuptools fix for flat layouts
- [x] No runtime behavior change — declarative config only

Fixes #387

🤖 Generated with [Claude Code](https://claude.ai/code)