### PR TITLE
Add autoloop to related projects — generalizes the loop to any domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
 
+## Related projects
+
+- [autoloop](https://github.com/menonpg/autoloop) — generalizes the autoresearch loop beyond ML training. Point it at any file (system prompts, SQL queries, trading strategies, RAG pipelines) with any metric function, and it runs the same overnight experiment loop. Works with Anthropic, OpenAI, or Ollama locally. MIT.
+
 ## License
 
 MIT


### PR DESCRIPTION
**What this adds:** A single bullet under a new "Related projects" section pointing to [autoloop](https://github.com/menonpg/autoloop).

**What autoloop is:** It extracts the core autoresearch experiment loop and generalizes it beyond ML training. Same design — single target file, fixed budget per experiment, one metric, agent proposes changes overnight — but works for any optimization domain: system prompts, SQL queries, trading strategies, RAG pipelines, anything with a quantifiable metric.

Works with Anthropic, OpenAI, or Ollama locally. MIT licensed.

You mentioned in the README: *'feel free to create forks or discussions for other platforms and I'm happy to link to them here in the README in some new notable forks section or etc.'* — autoloop is more of a generalization than a fork, so I put it under a separate "Related projects" heading rather than Notable forks. Happy to move it if you prefer.