### PR TITLE
Add MLX native fork to Notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 
 - [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
+- [SingggggYee/autoresearch-mlx](https://github.com/SingggggYee/autoresearch-mlx) (MacOS, MLX native — runs on 8GB+ Macs)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
 


### PR DESCRIPTION
## Summary
- Adds [SingggggYee/autoresearch-mlx](https://github.com/SingggggYee/autoresearch-mlx) to the Notable forks section

## What is it
A complete MLX rewrite (not a PyTorch MPS wrapper) that runs on any Apple Silicon Mac:
- **8GB Macs work**: PyTorch MPS forks OOM on base-model Macs, this doesn't
- **37MB install**: just `mlx` instead of `torch` (~2GB)
- **~65K tok/s on M3 8GB**: hardware-accelerated causal attention + `mx.compile` JIT
- **Muon + AdamW optimizer**, val_bpb ~1.86 on 3.5M param model (DEPTH=2, 8GB Mac)
- Scales from 8GB MacBook Air to 192GB Mac Studio

Benchmark on M3 8GB:
```
val_bpb:          1.856
training_seconds: 300
peak_memory_mb:   1829
num_steps:        2123
throughput:       ~65,000 tok/s
step_time:        ~125ms
```