### PR TITLE
docs: add V100 fork to Notable forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ I think these would be the reasonable hyperparameters to play with. Ask your fav
 - [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS)
 - [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
 - [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
+- [yuvrajpant56/autoresearch_v100](https://github.com/yuvrajpant56/autoresearch_v100) (V100)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds [yuvrajpant56/autoresearch_v100](https://github.com/yuvrajpant56/autoresearch_v100) to the Notable forks section in the README

Closes #437

## Test plan
- [x] Link is valid and points to a working V100 fork