### PR TITLE
feat: add CLI analysis tool for experiment results

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,233 @@
+"""
+CLI analysis tool for autoresearch experiment results.
+
+Reads results.tsv and produces a summary report, optionally as JSON
+or with a progress chart. Designed to be called by the autonomous agent
+between experiments for structured feedback on what's working.
+
+Usage:
+    uv run analysis.py                          # text report to stdout
+    uv run analysis.py --json                   # machine-readable JSON
+    uv run analysis.py --plot progress.png      # save progress chart
+    uv run analysis.py --tsv path/to/results.tsv  # custom TSV path
+"""
+
+import argparse
+import json
+import sys
+
+import pandas as pd
+import numpy as np
+
+
+def load_results(tsv_path):
+    """Load and clean results.tsv."""
+    df = pd.read_csv(tsv_path, sep="\t")
+    df["val_bpb"] = pd.to_numeric(df["val_bpb"], errors="coerce")
+    df["memory_gb"] = pd.to_numeric(df["memory_gb"], errors="coerce")
+    df["status"] = df["status"].str.strip().str.upper()
+    return df
+
+
+def compute_stats(df):
+    """Compute summary statistics from experiment results."""
+    counts = df["status"].value_counts()
+    n_total = len(df)
+    n_keep = int(counts.get("KEEP", 0))
+    n_discard = int(counts.get("DISCARD", 0))
+    n_crash = int(counts.get("CRASH", 0))
+    n_decided = n_keep + n_discard
+
+    kept = df[df["status"] == "KEEP"].copy()
+
+    stats = {
+        "total_experiments": n_total,
+        "kept": n_keep,
+        "discarded": n_discard,
+        "crashed": n_crash,
+        "keep_rate": round(n_keep / n_decided, 4) if n_decided > 0 else None,
+    }
+
+    if len(kept) == 0:
+        stats["baseline_bpb"] = None
+        stats["best_bpb"] = None
+        stats["improvement"] = None
+        stats["improvement_pct"] = None
+        stats["best_experiment"] = None
+        stats["top_hits"] = []
+        stats["trajectory"] = "no_data"
+        return stats
+
+    baseline_bpb = float(kept.iloc[0]["val_bpb"])
+    best_bpb = float(kept["val_bpb"].min())
+    best_row = kept.loc[kept["val_bpb"].idxmin()]
+    improvement = baseline_bpb - best_bpb
+
+    stats["baseline_bpb"] = round(baseline_bpb, 6)
+    stats["best_bpb"] = round(best_bpb, 6)
+    stats["improvement"] = round(improvement, 6)
+    stats["improvement_pct"] = round(improvement / baseline_bpb * 100, 2) if baseline_bpb > 0 else 0
+    stats["best_experiment"] = str(best_row["description"]).strip()
+
+    # Top hits: each kept experiment's delta vs previous kept
+    kept = kept.reset_index(drop=True)
+    top_hits = []
+    for i in range(1, len(kept)):
+        delta = float(kept.loc[i - 1, "val_bpb"] - kept.loc[i, "val_bpb"])
+        top_hits.append({
+            "commit": str(kept.loc[i, "commit"]),
+            "val_bpb": round(float(kept.loc[i, "val_bpb"]), 6),
+            "delta": round(delta, 6),
+            "description": str(kept.loc[i, "description"]).strip(),
+        })
+    top_hits.sort(key=lambda x: x["delta"], reverse=True)
+    stats["top_hits"] = top_hits
+
+    # Trajectory: are recent experiments improving or plateauing?
+    if len(kept) >= 3:
+        recent_deltas = [
+            float(kept.loc[i - 1, "val_bpb"] - kept.loc[i, "val_bpb"])
+            for i in range(max(1, len(kept) - 3), len(kept))
+        ]
+        avg_recent = np.mean(recent_deltas)
+        if avg_recent > 0.001:
+            stats["trajectory"] = "improving"
+        elif avg_recent > 0:
+            stats["trajectory"] = "plateauing"
+        else:
+            stats["trajectory"] = "stuck"
+    else:
+        stats["trajectory"] = "early"
+
+    return stats
+
+
+def print_text_report(stats):
+    """Print a human-readable text report."""
+    print("=" * 60)
+    print("AUTORESEARCH EXPERIMENT REPORT")
+    print("=" * 60)
+    print()
+
+    print(f"Total experiments:  {stats['total_experiments']}")
+    print(f"  Kept:             {stats['kept']}")
+    print(f"  Discarded:        {stats['discarded']}")
+    print(f"  Crashed:          {stats['crashed']}")
+    if stats["keep_rate"] is not None:
+        print(f"  Keep rate:        {stats['keep_rate']:.1%}")
+    print()
+
+    if stats["baseline_bpb"] is None:
+        print("No kept experiments yet.")
+        return
+
+    print(f"Baseline val_bpb:   {stats['baseline_bpb']:.6f}")
+    print(f"Best val_bpb:       {stats['best_bpb']:.6f}")
+    print(f"Total improvement:  {stats['improvement']:.6f} ({stats['improvement_pct']:.2f}%)")
+    print(f"Best experiment:    {stats['best_experiment']}")
+    print(f"Trajectory:         {stats['trajectory']}")
+    print()
+
+    if stats["top_hits"]:
+        print("Top improvements (by delta):")
+        print(f"  {'Rank':>4}  {'Delta':>9}  {'BPB':>10}  Description")
+        print("  " + "-" * 56)
+        for rank, hit in enumerate(stats["top_hits"][:10], 1):
+            print(f"  {rank:4d}  {hit['delta']:+.6f}  {hit['val_bpb']:.6f}  {hit['description']}")
+    print()
+
+
+def save_plot(df, output_path):
+    """Save the progress chart to a file."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(16, 8))
+
+    valid = df[df["status"] != "CRASH"].copy().reset_index(drop=True)
+    if len(valid) == 0:
+        print(f"No valid experiments to plot.", file=sys.stderr)
+        return
+
+    kept_mask = valid["status"] == "KEEP"
+    if not kept_mask.any():
+        print(f"No kept experiments to plot.", file=sys.stderr)
+        return
+
+    baseline_bpb = valid.loc[0, "val_bpb"]
+    below = valid[valid["val_bpb"] <= baseline_bpb + 0.0005]
+
+    # Discarded points
+    disc = below[below["status"] == "DISCARD"]
+    ax.scatter(disc.index, disc["val_bpb"],
+               c="#cccccc", s=12, alpha=0.5, zorder=2, label="Discarded")
+
+    # Kept points
+    kept_v = below[below["status"] == "KEEP"]
+    ax.scatter(kept_v.index, kept_v["val_bpb"],
+               c="#2ecc71", s=50, zorder=4, label="Kept", edgecolors="black", linewidths=0.5)
+
+    # Running minimum
+    kept_idx = valid.index[kept_mask]
+    kept_bpb = valid.loc[kept_mask, "val_bpb"]
+    running_min = kept_bpb.cummin()
+    ax.step(kept_idx, running_min, where="post", color="#27ae60",
+            linewidth=2, alpha=0.7, zorder=3, label="Running best")
+
+    # Labels
+    for idx, bpb in zip(kept_idx, kept_bpb):
+        desc = str(valid.loc[idx, "description"]).strip()
+        if len(desc) > 45:
+            desc = desc[:42] + "..."
+        ax.annotate(desc, (idx, bpb),
+                    textcoords="offset points", xytext=(6, 6), fontsize=8.0,
+                    color="#1a7a3a", alpha=0.9, rotation=30, ha="left", va="bottom")
+
+    n_total = len(df)
+    n_kept = len(df[df["status"] == "KEEP"])
+    ax.set_xlabel("Experiment #", fontsize=12)
+    ax.set_ylabel("Validation BPB (lower is better)", fontsize=12)
+    ax.set_title(f"Autoresearch Progress: {n_total} Experiments, {n_kept} Kept Improvements", fontsize=14)
+    ax.legend(loc="upper right", fontsize=9)
+    ax.grid(True, alpha=0.2)
+
+    best_bpb = kept_bpb.min()
+    margin = (baseline_bpb - best_bpb) * 0.15
+    if margin > 0:
+        ax.set_ylim(best_bpb - margin, baseline_bpb + margin)
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    print(f"Saved plot to {output_path}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze autoresearch experiment results")
+    parser.add_argument("--tsv", default="results.tsv", help="Path to results.tsv (default: results.tsv)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON instead of text")
+    parser.add_argument("--plot", metavar="PATH", help="Save progress chart to file (e.g. progress.png)")
+    args = parser.parse_args()
+
+    try:
+        df = load_results(args.tsv)
+    except FileNotFoundError:
+        print(f"Error: {args.tsv} not found. Run some experiments first.", file=sys.stderr)
+        sys.exit(1)
+    except pd.errors.EmptyDataError:
+        print(f"Error: {args.tsv} is empty.", file=sys.stderr)
+        sys.exit(1)
+
+    stats = compute_stats(df)
+
+    if args.json:
+        print(json.dumps(stats, indent=2))
+    else:
+        print_text_report(stats)
+
+    if args.plot:
+        save_plot(df, args.plot)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_analysis.py
+++ b/test_analysis.py
@@ -1,0 +1,235 @@
+"""Tests for analysis.py."""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+
+import pandas as pd
+
+from analysis import compute_stats, load_results, print_text_report, save_plot
+
+
+def _write_tsv(rows):
+    """Write rows to a temp TSV file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".tsv")
+    os.close(fd)
+    header = "commit\tdescription\tval_bpb\tmemory_gb\tstatus\n"
+    with open(path, "w") as f:
+        f.write(header)
+        for r in rows:
+            f.write("\t".join(str(x) for x in r) + "\n")
+    return path
+
+
+BASELINE_ROWS = [
+    ("abc001", "baseline",                 0.9979, 4.2, "KEEP"),
+    ("abc002", "tweak lr",                 1.0050, 4.2, "DISCARD"),
+    ("abc003", "increase LR to 0.04",      0.9932, 4.2, "KEEP"),
+    ("abc004", "bad experiment",           1.0100, 4.2, "DISCARD"),
+    ("abc005", "add warmup ratio 0.05",    0.9901, 4.2, "KEEP"),
+    ("abc006", "OOM attempt",              "NaN",  4.2, "CRASH"),
+    ("abc007", "increase batch size 2**20", 0.9885, 4.2, "KEEP"),
+]
+
+
+class LoadResultsTests(unittest.TestCase):
+    def test_parses_tsv_and_normalizes_status(self):
+        path = _write_tsv([
+            ("abc", "desc", 0.99, 4.0, " keep "),
+            ("def", "desc", 0.98, 4.0, "discard"),
+        ])
+        try:
+            df = load_results(path)
+        finally:
+            os.remove(path)
+        self.assertEqual(list(df["status"]), ["KEEP", "DISCARD"])
+        self.assertAlmostEqual(df.loc[0, "val_bpb"], 0.99)
+
+    def test_non_numeric_val_bpb_becomes_nan(self):
+        path = _write_tsv([("abc", "crashed", "NaN", "NaN", "CRASH")])
+        try:
+            df = load_results(path)
+        finally:
+            os.remove(path)
+        self.assertTrue(pd.isna(df.loc[0, "val_bpb"]))
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            load_results("/nonexistent/path/results.tsv")
+
+
+class ComputeStatsTests(unittest.TestCase):
+    def setUp(self):
+        self.path = _write_tsv(BASELINE_ROWS)
+        self.df = load_results(self.path)
+        self.stats = compute_stats(self.df)
+
+    def tearDown(self):
+        os.remove(self.path)
+
+    def test_counts(self):
+        self.assertEqual(self.stats["total_experiments"], 7)
+        self.assertEqual(self.stats["kept"], 4)
+        self.assertEqual(self.stats["discarded"], 2)
+        self.assertEqual(self.stats["crashed"], 1)
+
+    def test_keep_rate_excludes_crashes(self):
+        # 4 kept / (4 kept + 2 discarded) = 0.6667
+        self.assertAlmostEqual(self.stats["keep_rate"], 0.6667, places=4)
+
+    def test_baseline_and_best(self):
+        self.assertAlmostEqual(self.stats["baseline_bpb"], 0.9979)
+        self.assertAlmostEqual(self.stats["best_bpb"], 0.9885)
+        self.assertAlmostEqual(self.stats["improvement"], 0.0094, places=6)
+        self.assertEqual(self.stats["best_experiment"], "increase batch size 2**20")
+
+    def test_top_hits_sorted_by_delta_desc(self):
+        hits = self.stats["top_hits"]
+        self.assertEqual(len(hits), 3)  # one per kept beyond baseline
+        deltas = [h["delta"] for h in hits]
+        self.assertEqual(deltas, sorted(deltas, reverse=True))
+        # Biggest single-step improvement is baseline (0.9979) -> LR 0.04 (0.9932)
+        self.assertEqual(hits[0]["description"], "increase LR to 0.04")
+
+    def test_trajectory_improving(self):
+        # baseline case has steady improvement across recent kept
+        self.assertEqual(self.stats["trajectory"], "improving")
+
+
+class TrajectoryTests(unittest.TestCase):
+    def _trajectory(self, kept_bpbs):
+        rows = [
+            (f"c{i:03d}", f"exp{i}", bpb, 4.0, "KEEP")
+            for i, bpb in enumerate(kept_bpbs)
+        ]
+        path = _write_tsv(rows)
+        try:
+            return compute_stats(load_results(path))["trajectory"]
+        finally:
+            os.remove(path)
+
+    def test_early_when_fewer_than_three_kept(self):
+        self.assertEqual(self._trajectory([1.00, 0.99]), "early")
+
+    def test_plateauing_on_tiny_positive_deltas(self):
+        # recent avg delta in (0, 0.001] -> plateauing
+        self.assertEqual(
+            self._trajectory([1.0000, 0.9998, 0.9996, 0.9995]),
+            "plateauing",
+        )
+
+    def test_stuck_when_no_recent_improvement(self):
+        # recent avg delta <= 0 -> stuck
+        self.assertEqual(
+            self._trajectory([0.9900, 0.9900, 0.9900, 0.9900]),
+            "stuck",
+        )
+
+    def test_no_data_when_no_keeps(self):
+        path = _write_tsv([
+            ("abc", "x", 1.0, 4.0, "DISCARD"),
+            ("def", "y", "NaN", 4.0, "CRASH"),
+        ])
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        self.assertEqual(stats["trajectory"], "no_data")
+        self.assertIsNone(stats["baseline_bpb"])
+        self.assertIsNone(stats["best_bpb"])
+        self.assertEqual(stats["top_hits"], [])
+
+
+class EdgeCaseTests(unittest.TestCase):
+    def test_keep_rate_none_when_only_crashes(self):
+        path = _write_tsv([("abc", "x", "NaN", "NaN", "CRASH")])
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        self.assertIsNone(stats["keep_rate"])
+
+    def test_single_keep_has_no_top_hits(self):
+        path = _write_tsv([("abc", "only", 0.99, 4.0, "KEEP")])
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        self.assertEqual(stats["top_hits"], [])
+        self.assertAlmostEqual(stats["improvement"], 0.0)
+        self.assertEqual(stats["trajectory"], "early")
+
+
+class TextReportTests(unittest.TestCase):
+    def test_report_runs_and_mentions_key_fields(self):
+        path = _write_tsv(BASELINE_ROWS)
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_text_report(stats)
+        out = buf.getvalue()
+        self.assertIn("AUTORESEARCH EXPERIMENT REPORT", out)
+        self.assertIn("Total experiments:", out)
+        self.assertIn("Best experiment:", out)
+        self.assertIn("Trajectory:", out)
+
+    def test_report_handles_no_keeps(self):
+        path = _write_tsv([("abc", "x", 1.0, 4.0, "DISCARD")])
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_text_report(stats)
+        self.assertIn("No kept experiments yet.", buf.getvalue())
+
+    def test_stats_are_json_serializable(self):
+        path = _write_tsv(BASELINE_ROWS)
+        try:
+            stats = compute_stats(load_results(path))
+        finally:
+            os.remove(path)
+        # Should not raise.
+        json.dumps(stats)
+
+
+class SavePlotTests(unittest.TestCase):
+    def test_save_plot_creates_file(self):
+        path = _write_tsv(BASELINE_ROWS)
+        df = load_results(path)
+        fd, out = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            with redirect_stderr(io.StringIO()):
+                save_plot(df, out)
+            self.assertTrue(os.path.getsize(out) > 0)
+        finally:
+            os.remove(path)
+            if os.path.exists(out):
+                os.remove(out)
+
+    def test_save_plot_noop_when_no_keeps(self):
+        path = _write_tsv([("abc", "x", 1.0, 4.0, "DISCARD")])
+        df = load_results(path)
+        fd, out = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        os.remove(out)  # so we can check it wasn't created
+        buf = io.StringIO()
+        try:
+            with redirect_stderr(buf):
+                save_plot(df, out)
+            self.assertIn("No kept experiments to plot.", buf.getvalue())
+            self.assertFalse(os.path.exists(out))
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `analysis.py` — a CLI version of `analysis.ipynb` that the autonomous agent can call between experiments for structured feedback
- Supports three output modes: human-readable text report, machine-readable JSON (`--json`), and progress chart (`--plot`)
- Uses only existing dependencies (pandas, numpy, matplotlib) — no new packages

Closes #476

## Motivation

The agent logs results to `results.tsv` but has no programmatic way to analyze them. Currently it has to manually grep/reason about raw TSV data. This script lets the agent run:

```bash
uv run analysis.py --json
```

...and get a structured summary of what's working, what's not, and whether progress is plateauing — directly informing its next experiment choice.

## Usage

```bash
uv run analysis.py                          # text report to stdout
uv run analysis.py --json                   # machine-readable JSON
uv run analysis.py --plot progress.png      # save progress chart
uv run analysis.py --tsv path/to/results.tsv  # custom TSV path
```

### Example text output
```
============================================================
AUTORESEARCH EXPERIMENT REPORT
============================================================

Total experiments:  7
  Kept:             4
  Discarded:        2
  Crashed:          1
  Keep rate:        66.7%

Baseline val_bpb:   0.997900
Best val_bpb:       0.988500
Total improvement:  0.009400 (0.94%)
Best experiment:    increase batch size to 2**20
Trajectory:         improving

Top improvements (by delta):
  Rank      Delta         BPB  Description
  --------------------------------------------------------
     1  +0.004700  0.993200  increase LR to 0.04
     2  +0.003100  0.990100  add warmup ratio 0.05
     3  +0.001600  0.988500  increase batch size to 2**20
```

### Example JSON output
```json
{
  "total_experiments": 7,
  "kept": 4,
  "discarded": 2,
  "crashed": 1,
  "keep_rate": 0.6667,
  "baseline_bpb": 0.9979,
  "best_bpb": 0.9885,
  "improvement": 0.0094,
  "improvement_pct": 0.94,
  "best_experiment": "increase batch size to 2**20",
  "top_hits": [...],
  "trajectory": "improving"
}
```

## Test plan
- [x] Tested with sample results.tsv (7 experiments, mixed keep/discard/crash)
- [x] Tested `--json` output parses as valid JSON
- [x] Tested `--plot` generates PNG
- [x] Tested missing file error handling
- [x] Tested empty keep set edge case