### PR TITLE
Add cron job infrastructure for automated experiment loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dev/
 
 # Results file
 results.tsv
+
+# Cron logs
+cron/logs/

--- a/cron/auto_research.sh
+++ b/cron/auto_research.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Loop 2 - Auto-Research (continuous experiment loop)
+# Runs multiple experiments in sequence, applying the keep/discard methodology.
+# Each experiment: run train.py, evaluate, keep if improved, discard if not.
+#
+# Usage:
+#   ./auto_research.sh              # Run 12 experiments (~1 hour)
+#   ./auto_research.sh 100          # Run 100 experiments (~8 hours, overnight)
+#   ./auto_research.sh unlimited    # Run until manually stopped
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$REPO_DIR/cron/logs"
+RESULTS_FILE="$REPO_DIR/results.tsv"
+TIMEOUT_SECONDS=600  # 10 min hard timeout per experiment
+
+MAX_EXPERIMENTS="${1:-12}"
+UNLIMITED=false
+if [ "$MAX_EXPERIMENTS" = "unlimited" ]; then
+    UNLIMITED=true
+    MAX_EXPERIMENTS=999999
+fi
+
+mkdir -p "$LOG_DIR"
+
+SESSION_LOG="$LOG_DIR/session_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$SESSION_LOG") 2>&1
+
+cd "$REPO_DIR"
+
+# Initialize results.tsv if it doesn't exist
+if [ ! -f "$RESULTS_FILE" ]; then
+    printf 'commit\tval_bpb\tmemory_gb\tstatus\tdescription\n' > "$RESULTS_FILE"
+fi
+
+# Read the best val_bpb from results so far
+get_best_bpb() {
+    if [ -f "$RESULTS_FILE" ] && [ "$(wc -l < "$RESULTS_FILE")" -gt 1 ]; then
+        tail -n +2 "$RESULTS_FILE" | awk -F'\t' '$4=="keep" && $2+0>0 {print $2}' | sort -n | head -1
+    else
+        echo ""
+    fi
+}
+
+echo "============================================="
+echo "  Auto-Research Loop"
+echo "  Started: $(date)"
+if [ "$UNLIMITED" = true ]; then
+    echo "  Mode: Unlimited (run until stopped)"
+else
+    echo "  Experiments: $MAX_EXPERIMENTS"
+fi
+echo "============================================="
+echo ""
+
+EXPERIMENT_NUM=0
+KEPT=0
+DISCARDED=0
+CRASHED=0
+
+while [ "$EXPERIMENT_NUM" -lt "$MAX_EXPERIMENTS" ]; do
+    EXPERIMENT_NUM=$((EXPERIMENT_NUM + 1))
+    TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+    RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+
+    echo "--- Experiment $EXPERIMENT_NUM / $([ "$UNLIMITED" = true ] && echo 'unlimited' || echo "$MAX_EXPERIMENTS") ---"
+    echo "Time: $(date)"
+
+    BEST_BEFORE="$(get_best_bpb)"
+    COMMIT_BEFORE="$(git rev-parse --short=7 HEAD)"
+
+    echo "Current best val_bpb: ${BEST_BEFORE:-N/A (no baseline)}"
+    echo "Running training..."
+
+    if timeout "$TIMEOUT_SECONDS" uv run train.py > "$RUN_LOG" 2>&1; then
+        VAL_BPB="$(grep '^val_bpb:' "$RUN_LOG" | awk '{print $2}' || echo '')"
+        PEAK_VRAM="$(grep '^peak_vram_mb:' "$RUN_LOG" | awk '{print $2}' || echo '0.0')"
+
+        if [ -z "$VAL_BPB" ]; then
+            echo "ERROR: Could not extract val_bpb"
+            MEMORY_GB="0.0"
+            STATUS="crash"
+            DESCRIPTION="experiment $EXPERIMENT_NUM - no metrics extracted"
+            CRASHED=$((CRASHED + 1))
+        else
+            MEMORY_GB="$(echo "$PEAK_VRAM" | awk '{printf "%.1f", $1/1024}')"
+
+            # Decide: keep or discard
+            if [ -z "$BEST_BEFORE" ]; then
+                # No baseline yet - this is the baseline
+                STATUS="keep"
+                DESCRIPTION="baseline (experiment $EXPERIMENT_NUM)"
+                KEPT=$((KEPT + 1))
+                echo "BASELINE: val_bpb=$VAL_BPB memory=${MEMORY_GB}GB"
+            else
+                # Compare against best
+                IMPROVED="$(echo "$VAL_BPB $BEST_BEFORE" | awk '{print ($1 < $2) ? "yes" : "no"}')"
+                if [ "$IMPROVED" = "yes" ]; then
+                    STATUS="keep"
+                    DESCRIPTION="experiment $EXPERIMENT_NUM - improved from $BEST_BEFORE to $VAL_BPB"
+                    KEPT=$((KEPT + 1))
+                    echo "KEEP: val_bpb=$VAL_BPB (improved from $BEST_BEFORE) memory=${MEMORY_GB}GB"
+                else
+                    STATUS="discard"
+                    DESCRIPTION="experiment $EXPERIMENT_NUM - no improvement ($VAL_BPB >= $BEST_BEFORE)"
+                    DISCARDED=$((DISCARDED + 1))
+                    echo "DISCARD: val_bpb=$VAL_BPB (not better than $BEST_BEFORE) memory=${MEMORY_GB}GB"
+                    # Reset to the commit before this experiment
+                    git checkout -- train.py 2>/dev/null || true
+                fi
+            fi
+        fi
+    else
+        EXIT_CODE=$?
+        echo "CRASH: Training failed (exit code: $EXIT_CODE)"
+        if [ -f "$RUN_LOG" ]; then
+            tail -n 10 "$RUN_LOG" >&2
+        fi
+        VAL_BPB="0.000000"
+        MEMORY_GB="0.0"
+        STATUS="crash"
+        if [ "$EXIT_CODE" -eq 124 ]; then
+            DESCRIPTION="experiment $EXPERIMENT_NUM - timed out"
+        else
+            DESCRIPTION="experiment $EXPERIMENT_NUM - crashed"
+        fi
+        CRASHED=$((CRASHED + 1))
+        git checkout -- train.py 2>/dev/null || true
+    fi
+
+    COMMIT="$(git rev-parse --short=7 HEAD)"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$COMMIT" "$VAL_BPB" "$MEMORY_GB" "$STATUS" "$DESCRIPTION" >> "$RESULTS_FILE"
+
+    echo ""
+done
+
+echo "============================================="
+echo "  Auto-Research Complete"
+echo "  Finished: $(date)"
+echo "  Total experiments: $EXPERIMENT_NUM"
+echo "  Kept: $KEPT"
+echo "  Discarded: $DISCARDED"
+echo "  Crashed: $CRASHED"
+echo "  Best val_bpb: $(get_best_bpb)"
+echo "============================================="

--- a/cron/crontab.conf
+++ b/cron/crontab.conf
@@ -1,0 +1,20 @@
+# autoresearch cron jobs
+# Install with: crontab cron/crontab.conf
+# Or merge with existing: crontab -l | cat - cron/crontab.conf | crontab -
+#
+# NOTE: Edit REPO_DIR below to match your installation path.
+
+REPO_DIR=/home/user/autoresearch
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+
+# Loop 1 - Daily Report: 9pm CET (19:00 UTC) on weekdays (Mon-Fri)
+# Runs a single training experiment and logs the result.
+0 19 * * 1-5 $REPO_DIR/cron/daily_report.sh
+
+# Loop 2 - Auto-Research: Overnight batch (11pm CET / 21:00 UTC) on weekdays
+# Runs ~100 experiments overnight (~8 hours of 5-min experiments).
+0 21 * * 1-5 $REPO_DIR/cron/auto_research.sh 100
+
+# Cleanup: Remove logs older than 30 days (Sundays at 3am UTC)
+0 3 * * 0 find $REPO_DIR/cron/logs -name '*.log' -mtime +30 -delete

--- a/cron/daily_report.sh
+++ b/cron/daily_report.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Loop 1 - Daily Report (9pm CET, weekdays)
+# Runs the training experiment, captures results, and logs them.
+# Designed to be invoked by cron on a schedule.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$REPO_DIR/cron/logs"
+RESULTS_FILE="$REPO_DIR/results.tsv"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+REPORT_LOG="$LOG_DIR/report_${TIMESTAMP}.log"
+
+# Ensure log directory exists
+mkdir -p "$LOG_DIR"
+
+exec > "$REPORT_LOG" 2>&1
+echo "=== Daily Report - $(date) ==="
+
+cd "$REPO_DIR"
+
+# Initialize results.tsv if it doesn't exist
+if [ ! -f "$RESULTS_FILE" ]; then
+    printf 'commit\tval_bpb\tmemory_gb\tstatus\tdescription\n' > "$RESULTS_FILE"
+    echo "Initialized results.tsv"
+fi
+
+# Record the current commit before the run
+BASELINE_COMMIT="$(git rev-parse --short=7 HEAD)"
+echo "Current commit: $BASELINE_COMMIT"
+
+# Run the training experiment (5-minute budget)
+echo "Starting training run..."
+TIMEOUT_SECONDS=600  # 10 min hard timeout (5 min budget + overhead)
+
+if timeout "$TIMEOUT_SECONDS" uv run train.py > "$RUN_LOG" 2>&1; then
+    echo "Training completed successfully."
+
+    # Extract metrics
+    VAL_BPB="$(grep '^val_bpb:' "$RUN_LOG" | awk '{print $2}' || echo '0.000000')"
+    PEAK_VRAM="$(grep '^peak_vram_mb:' "$RUN_LOG" | awk '{print $2}' || echo '0.0')"
+
+    if [ -z "$VAL_BPB" ] || [ "$VAL_BPB" = "0.000000" ]; then
+        echo "WARNING: Could not extract val_bpb from run log"
+        MEMORY_GB="0.0"
+        STATUS="crash"
+        DESCRIPTION="daily run - failed to extract metrics"
+    else
+        # Convert peak VRAM from MB to GB
+        MEMORY_GB="$(echo "$PEAK_VRAM" | awk '{printf "%.1f", $1/1024}')"
+        STATUS="keep"
+        DESCRIPTION="daily scheduled run"
+    fi
+else
+    EXIT_CODE=$?
+    echo "Training failed or timed out (exit code: $EXIT_CODE)"
+
+    # Check last 50 lines for error context
+    if [ -f "$RUN_LOG" ]; then
+        echo "--- Last 50 lines of run log ---"
+        tail -n 50 "$RUN_LOG"
+        echo "--- End of error context ---"
+    fi
+
+    VAL_BPB="0.000000"
+    MEMORY_GB="0.0"
+    if [ "$EXIT_CODE" -eq 124 ]; then
+        STATUS="crash"
+        DESCRIPTION="daily run - timed out after ${TIMEOUT_SECONDS}s"
+    else
+        STATUS="crash"
+        DESCRIPTION="daily run - training crashed"
+    fi
+fi
+
+COMMIT="$(git rev-parse --short=7 HEAD)"
+
+# Log to results.tsv
+printf '%s\t%s\t%s\t%s\t%s\n' "$COMMIT" "$VAL_BPB" "$MEMORY_GB" "$STATUS" "$DESCRIPTION" >> "$RESULTS_FILE"
+
+echo ""
+echo "=== Results ==="
+echo "Commit:    $COMMIT"
+echo "val_bpb:   $VAL_BPB"
+echo "Memory:    ${MEMORY_GB} GB"
+echo "Status:    $STATUS"
+echo "=== Daily Report Complete - $(date) ==="

--- a/cron/setup.sh
+++ b/cron/setup.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Setup script for autoresearch cron jobs
+# Usage: ./cron/setup.sh [install|uninstall|status]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+CRON_MARKER="# autoresearch cron jobs"
+
+usage() {
+    echo "Usage: $0 [install|uninstall|status]"
+    echo ""
+    echo "Commands:"
+    echo "  install    Install cron jobs (merges with existing crontab)"
+    echo "  uninstall  Remove autoresearch cron jobs from crontab"
+    echo "  status     Show current autoresearch cron job status"
+    echo ""
+    echo "The cron jobs will:"
+    echo "  - Run a daily training report at 9pm CET (weekdays)"
+    echo "  - Run overnight auto-research (~100 experiments) at 11pm CET (weekdays)"
+    echo "  - Clean up old logs weekly"
+}
+
+install_crons() {
+    # Make scripts executable
+    chmod +x "$SCRIPT_DIR/daily_report.sh"
+    chmod +x "$SCRIPT_DIR/auto_research.sh"
+
+    # Create log directory
+    mkdir -p "$SCRIPT_DIR/logs"
+
+    # Update REPO_DIR in crontab.conf to actual path
+    CRONTAB_CONTENT="$(sed "s|REPO_DIR=.*|REPO_DIR=$REPO_DIR|" "$SCRIPT_DIR/crontab.conf")"
+
+    # Check if autoresearch crons already installed
+    EXISTING="$(crontab -l 2>/dev/null || true)"
+    if echo "$EXISTING" | grep -q "$CRON_MARKER"; then
+        echo "Autoresearch cron jobs already installed. Updating..."
+        # Remove old entries and add new ones
+        CLEANED="$(echo "$EXISTING" | sed "/$CRON_MARKER/,/^$/d")"
+        echo "$CLEANED"$'\n'"$CRONTAB_CONTENT" | crontab -
+    else
+        # Append to existing crontab
+        if [ -n "$EXISTING" ]; then
+            echo "$EXISTING"$'\n'"$CRONTAB_CONTENT" | crontab -
+        else
+            echo "$CRONTAB_CONTENT" | crontab -
+        fi
+    fi
+
+    echo "Cron jobs installed successfully."
+    echo ""
+    echo "Schedule:"
+    echo "  Daily report:   9pm CET (19:00 UTC) Mon-Fri"
+    echo "  Auto-research: 11pm CET (21:00 UTC) Mon-Fri (~100 experiments)"
+    echo "  Log cleanup:    3am UTC Sundays"
+    echo ""
+    echo "Logs: $SCRIPT_DIR/logs/"
+    echo ""
+    echo "To verify: crontab -l"
+}
+
+uninstall_crons() {
+    EXISTING="$(crontab -l 2>/dev/null || true)"
+    if [ -z "$EXISTING" ]; then
+        echo "No crontab found."
+        return
+    fi
+
+    if echo "$EXISTING" | grep -q "$CRON_MARKER"; then
+        # Remove autoresearch block
+        CLEANED="$(echo "$EXISTING" | sed "/$CRON_MARKER/,/^$/d" | sed '/^$/N;/^\n$/d')"
+        if [ -z "$CLEANED" ]; then
+            crontab -r 2>/dev/null || true
+        else
+            echo "$CLEANED" | crontab -
+        fi
+        echo "Autoresearch cron jobs removed."
+    else
+        echo "No autoresearch cron jobs found in crontab."
+    fi
+}
+
+show_status() {
+    echo "=== Autoresearch Cron Status ==="
+    echo ""
+
+    # Check if crons are installed
+    EXISTING="$(crontab -l 2>/dev/null || true)"
+    if echo "$EXISTING" | grep -q "$CRON_MARKER"; then
+        echo "Status: INSTALLED"
+        echo ""
+        echo "Active cron entries:"
+        echo "$EXISTING" | grep -A1 "$CRON_MARKER" | grep -v "^#" | grep -v "^$" | grep -v "REPO_DIR\|SHELL\|PATH" || true
+    else
+        echo "Status: NOT INSTALLED"
+        echo "Run '$0 install' to set up cron jobs."
+    fi
+
+    echo ""
+
+    # Show recent logs if any
+    if [ -d "$SCRIPT_DIR/logs" ]; then
+        LOG_COUNT="$(find "$SCRIPT_DIR/logs" -name '*.log' 2>/dev/null | wc -l)"
+        echo "Logs: $LOG_COUNT files in $SCRIPT_DIR/logs/"
+        if [ "$LOG_COUNT" -gt 0 ]; then
+            echo "Latest:"
+            ls -lt "$SCRIPT_DIR/logs/"*.log 2>/dev/null | head -3 | awk '{print "  " $NF " (" $6, $7, $8 ")"}'
+        fi
+    else
+        echo "Logs: No log directory yet"
+    fi
+
+    echo ""
+
+    # Show results summary if available
+    RESULTS_FILE="$REPO_DIR/results.tsv"
+    if [ -f "$RESULTS_FILE" ] && [ "$(wc -l < "$RESULTS_FILE")" -gt 1 ]; then
+        TOTAL="$(tail -n +2 "$RESULTS_FILE" | wc -l)"
+        KEEPS="$(tail -n +2 "$RESULTS_FILE" | awk -F'\t' '$4=="keep"' | wc -l)"
+        BEST="$(tail -n +2 "$RESULTS_FILE" | awk -F'\t' '$4=="keep" && $2+0>0 {print $2}' | sort -n | head -1)"
+        echo "Results: $TOTAL experiments ($KEEPS kept)"
+        echo "Best val_bpb: ${BEST:-N/A}"
+    else
+        echo "Results: No experiments recorded yet"
+    fi
+}
+
+case "${1:-}" in
+    install)   install_crons ;;
+    uninstall) uninstall_crons ;;
+    status)    show_status ;;
+    *)         usage ;;
+esac


### PR DESCRIPTION
Two scheduled loops based on the autoresearch keep/discard methodology:
- Loop 1 (daily_report.sh): Single experiment run at 9pm CET weekdays
- Loop 2 (auto_research.sh): Overnight batch of ~100 experiments
- Setup script for easy install/uninstall of crontab entries
- Log cleanup cron to remove logs older than 30 days

https://claude.ai/code/session_01XP5y6a2yuHQKo4z9QzJ8ZZ