### PR TITLE
fix: PYTORCH_CUDA_ALLOC_CONF env var + scope shard-download response

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -65,13 +65,16 @@ def download_single_shard(index):
     max_attempts = 5
     for attempt in range(1, max_attempts + 1):
         try:
-            response = requests.get(url, stream=True, timeout=30)
-            response.raise_for_status()
-            temp_path = filepath + ".tmp"
-            with open(temp_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=1024 * 1024):
-                    if chunk:
-                        f.write(chunk)
+            # Scope the response to a with-block so the underlying socket is
+            # released promptly on success or partial-stream failure, instead
+            # of waiting for GC to trigger urllib3 cleanup.
+            with requests.get(url, stream=True, timeout=30) as response:
+                response.raise_for_status()
+                temp_path = filepath + ".tmp"
+                with open(temp_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=1024 * 1024):
+                        if chunk:
+                            f.write(chunk)
             os.rename(temp_path, filepath)
             print(f"  Downloaded {filename}")
             return True

--- a/train.py
+++ b/train.py
@@ -5,7 +5,10 @@ Usage: uv run train.py
 """
 
 import os
-os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+# PyTorch reads PYTORCH_CUDA_ALLOC_CONF for the CUDA caching allocator. The
+# previous name (PYTORCH_ALLOC_CONF) is silently ignored, leaving expandable
+# segments off and producing more allocator fragmentation than necessary.
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 
 import gc


### PR DESCRIPTION
## Summary

Two small, focused fixes that don't overlap with any other open PR:

- **`PYTORCH_ALLOC_CONF` → `PYTORCH_CUDA_ALLOC_CONF`** in `train.py`. PyTorch silently ignores the previous name, so `expandable_segments:True` was never actually applied and the CUDA caching allocator ran with more fragmentation than intended. PR #510 also fixes this but bundles it with a larger function-level refactor; this PR is just the one-line rename so it's mergeable independently.
- **Scope `requests.get` to a `with`-block** in `prepare.py::download_single_shard`. `stream=True` requests leave the underlying urllib3 connection open until GC runs the response object's finalizer; with the parallel-download fan-out (`Pool(processes=8)`), sockets can pile up. Wrapping the response in `with` releases them deterministically on both success and partial-stream failures inside `iter_content`.

Both changes are commented inline so the rationale is visible to future readers.

## Test plan

- [x] `python -m py_compile train.py prepare.py`
- [ ] `uv run prepare.py` — confirms shard download still completes (no functional change in success path)
- [ ] `uv run train.py` — confirms training still starts; `nvidia-smi` should show fewer/no allocator warnings on tight VRAM configs once expandable segments engages