### PR TITLE
fix: GPU-aware MFU with Blackwell (sm_100/sm_120) coverage

### DIFF
--- a/train.py
+++ b/train.py
@@ -460,7 +460,22 @@ torch.cuda.manual_seed(42)
 torch.set_float32_matmul_precision("high")
 device = torch.device("cuda")
 autocast_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
-H100_BF16_PEAK_FLOPS = 989.5e12
+
+# Theoretical bf16 peak FLOPS keyed by CUDA compute capability. Hardcoding the
+# H100 number made the reported MFU 3-6x too high on every other GPU and
+# meaningless across community runs. See issues #5 and #29 (Blackwell support).
+_BF16_PEAK_FLOPS_BY_CAPABILITY = {
+    (7, 0): 125e12,    # V100 (fp16 tensor; bf16 unsupported, used as proxy)
+    (7, 5): 65e12,     # T4 / RTX 20xx
+    (8, 0): 312e12,    # A100
+    (8, 6): 165e12,    # RTX 30xx / A40 / A10
+    (8, 9): 165e12,    # RTX 40xx / L4 / L40
+    (9, 0): 989.5e12,  # H100 / H200
+    (10, 0): 2250e12,  # B100 / B200 (datacenter Blackwell, dense bf16)
+    (12, 0): 209e12,   # RTX 50xx (consumer Blackwell, dense bf16)
+}
+GPU_BF16_PEAK_FLOPS = _BF16_PEAK_FLOPS_BY_CAPABILITY.get(cap, 989.5e12)
+print(f"GPU: sm_{cap[0]}{cap[1]} -> bf16 peak {GPU_BF16_PEAK_FLOPS:.2e} FLOPS")
 
 tokenizer = Tokenizer.from_directory()
 vocab_size = tokenizer.get_vocab_size()
@@ -584,7 +599,7 @@ while True:
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
     pct_done = 100 * progress
     tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
-    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
+    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / GPU_BF16_PEAK_FLOPS
     remaining = max(0, TIME_BUDGET - total_training_time)
 
     print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
@@ -615,7 +630,7 @@ with autocast_ctx:
 # Final summary
 t_end = time.time()
 startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / GPU_BF16_PEAK_FLOPS if total_training_time > 0 else 0
 peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
 print("---")


### PR DESCRIPTION
## Summary

Closes #5 and addresses the MFU side of #29 (Blackwell support).

The existing constant `H100_BF16_PEAK_FLOPS = 989.5e12` makes the reported MFU silently wrong on every non-Hopper GPU — ~3x too high on A100, ~6x too high on a 4090 — and is undefined on Blackwell hardware that the existing FA3 dispatch already runs on.

Replace it with a compute-capability lookup table that falls back to the H100 number for unknown hardware. This complements the FA3 fallback that already exists at the top of `train.py` for non-Hopper GPUs (`cap == (9, 0)` else `kernels-community/flash-attn3`).

### Coverage table

| Compute capability | GPU | bf16 peak |
|---|---|---|
| sm_70 | V100 | 125 TFLOPS (fp16 proxy) |
| sm_75 | T4 / RTX 20xx | 65 TFLOPS |
| sm_80 | A100 | 312 TFLOPS |
| sm_86 | RTX 30xx / A40 / A10 | 165 TFLOPS |
| sm_89 | RTX 40xx / L4 / L40 | 165 TFLOPS |
| sm_90 | H100 / H200 | 989.5 TFLOPS |
| **sm_100** | **B100 / B200** | **2250 TFLOPS** |
| **sm_120** | **RTX 50xx** | **209 TFLOPS** |

The Blackwell rows are the delta vs the in-flight #12, which stops at sm_89.

### Why now?

The repo already runs on Blackwell hardware via the existing `kernels-community/flash-attn3` fallback. Without this fix, MFU on Blackwell is silently nonsense, which makes cross-platform community results in `results.tsv` non-comparable.

## Test plan

- [x] `python -m py_compile train.py`
- [ ] On H100: confirm MFU output matches the previous behavior (table fallback to 989.5 TFLOPS for sm_90)
- [ ] On A100/4090: confirm MFU drops from a clearly-too-high number into a plausible 30-50% range
- [ ] On Blackwell: confirm the script no longer reports nonsense MFU (and the new GPU log line confirms the lookup hit)

## Notes for reviewers

- Acknowledges #12 — that PR uses the same approach but doesn't include Blackwell. Either land #12 first and I'll close this, or land this and close #12. Happy either way.
- Adds a single GPU-detection log line at startup so contributors can see at a glance which peak the lookup chose.