### PR TITLE
fix(prepare): load token_bytes.pt with weights_only=True

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -246,9 +246,13 @@ class Tokenizer:
 
 
 def get_token_bytes(device="cpu"):
+    # weights_only=True restricts unpickling to a small safe allowlist of tensor
+    # types, preventing arbitrary code execution from a tampered cache file on
+    # shared machines or copied cache directories. The file only ever contains
+    # a single int32 tensor, so the restricted unpickler is sufficient.
     path = os.path.join(TOKENIZER_DIR, "token_bytes.pt")
     with open(path, "rb") as f:
-        return torch.load(f, map_location=device)
+        return torch.load(f, map_location=device, weights_only=True)
 
 
 def _document_batches(split, tokenizer_batch_size=128):


### PR DESCRIPTION
## Summary

Minimal mitigation for the security half of #41. Default `torch.load` runs the full pickle protocol, which can execute arbitrary code from a tampered or copied cache file on shared machines. `weights_only=True` restricts unpickling to a small allowlist of tensor types — sufficient here because `token_bytes.pt` only stores a single int32 tensor.

## Why a separate, narrower PR?

Two existing PRs already address #41, but both bundle larger scope:
- **PR #145** adds SHA-256 sidecar files and `metadata.json` (73 line additions)
- **PR #366** wraps in broader refactoring including `exit(1)` → `RuntimeError` (70 additions / 24 deletions, "From audit 2026-03-21")

This PR is **+5 / -1**, only the `weights_only=True` flag. It can land alongside or independently of the larger PRs without conflict — the flag is forward-compatible with any future hash-verification layer.

## Scope

- ✅ `token_bytes.pt` — covered by this PR. Single tensor, restricted unpickler is sufficient.
- ❌ `tokenizer.pkl` — covered by PR #63 (replaces pickle with JSON serialization). `weights_only=True` doesn't apply to a generic `pickle.load` call.

## Test plan

- [x] `python -m py_compile prepare.py`
- [ ] `uv run prepare.py` to regenerate caches, then `uv run train.py` — confirm `get_token_bytes()` still loads the int32 tensor under `weights_only=True`
- [ ] Hand-craft a malicious `token_bytes.pt` with a custom `__reduce__` payload — confirm load now raises instead of executing