### PR TITLE
fix(prepare): detect truncated shard downloads via Content-Length

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -67,11 +67,21 @@ def download_single_shard(index):
         try:
             response = requests.get(url, stream=True, timeout=30)
             response.raise_for_status()
+            # Capture expected size BEFORE streaming so we can detect truncation
+            # caused by mid-stream socket drops, partial gateway responses, etc.
+            expected_size = int(response.headers.get("Content-Length", "0"))
             temp_path = filepath + ".tmp"
             with open(temp_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=1024 * 1024):
                     if chunk:
                         f.write(chunk)
+            if expected_size > 0:
+                actual_size = os.path.getsize(temp_path)
+                if actual_size != expected_size:
+                    raise IOError(
+                        f"truncated download for {filename}: "
+                        f"got {actual_size} bytes, expected {expected_size}"
+                    )
             os.rename(temp_path, filepath)
             print(f"  Downloaded {filename}")
             return True


### PR DESCRIPTION
## Summary

Catch truncated shard downloads at download time instead of letting them silently corrupt the cache.

## Failure mode this prevents

`download_single_shard` calls `requests.iter_content` and writes chunks to a `.tmp` file, then renames to the final path. If the connection drops mid-stream — a flaky CDN edge, a 30s read timeout firing on a slow chunk, a partial gateway response — `iter_content` silently completes with whatever bytes arrived. The rename promotes the partial file to a "valid" shard. The function returns `True`, the worker pool moves on, and the next `prepare.py` run sees the file exists and skips re-download. The corruption only surfaces much later when `pq.ParquetFile(...)` chokes on the malformed shard, often inside `train_tokenizer` or the dataloader.

## Fix

Capture `Content-Length` before streaming, verify on-disk size after the stream completes. Mismatches raise `IOError`, which the existing `except` block already catches and converts to a retry with exponential backoff.

```python
expected_size = int(response.headers.get("Content-Length", "0"))
# ... stream into temp_path ...
if expected_size > 0:
    actual_size = os.path.getsize(temp_path)
    if actual_size != expected_size:
        raise IOError(...)
```

CDNs that omit `Content-Length` (rare but possible) fall through unchanged — the check is opt-in via header presence.

## Why a separate PR

- **#215** addresses verifying *already-cached* shards on reuse — this PR addresses truncation *at download time*. Complementary.
- **#546** scopes the response object to a `with`-block — also complementary; this can land before, after, or alongside.

## Test plan

- [x] `python -m py_compile prepare.py`
- [ ] `uv run prepare.py --num-shards 4` happy path: confirm normal downloads succeed and Content-Length matches
- [ ] Simulate truncation (e.g., kill the response mid-stream with a proxy that closes the socket): confirm IOError is raised and the retry loop kicks in