### PR TITLE
fix(prepare): use raw bytes for BPB to avoid U+FFFD inflation (#384)

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -182,15 +182,17 @@ def train_tokenizer():
     print(f"Tokenizer: trained in {t1 - t0:.1f}s, saved to {tokenizer_pkl}")
 
     # --- Build token_bytes lookup for BPB evaluation ---
+    # Use raw token bytes from mergeable_ranks. Decoding each token to a
+    # Python str then re-encoding to UTF-8 silently replaces any non-UTF-8
+    # byte sequences (e.g. a single continuation byte 0x80) with U+FFFD
+    # (3 bytes), inflating the BPB byte denominator and making scores look
+    # artificially better. See issue #384.
     print("Tokenizer: building token_bytes lookup...")
-    special_set = set(SPECIAL_TOKENS)
+    rank_to_bytes = {rank: raw for raw, rank in mergeable_ranks.items()}
     token_bytes_list = []
     for token_id in range(enc.n_vocab):
-        token_str = enc.decode([token_id])
-        if token_str in special_set:
-            token_bytes_list.append(0)
-        else:
-            token_bytes_list.append(len(token_str.encode("utf-8")))
+        raw = rank_to_bytes.get(token_id)
+        token_bytes_list.append(len(raw) if raw is not None else 0)
     token_bytes_tensor = torch.tensor(token_bytes_list, dtype=torch.int32)
     torch.save(token_bytes_tensor, token_bytes_path)
     print(f"Tokenizer: saved token_bytes to {token_bytes_path}")


### PR DESCRIPTION
## Summary
- BPB byte denominator is computed by decoding each token to a Python str then re-encoding to UTF-8. For BPE tokens whose raw bytes are not valid standalone UTF-8 (e.g. a single continuation byte ``0x80``), tiktoken's ``decode()`` replaces them with U+FFFD which encodes to 3 UTF-8 bytes. This inflates the byte denominator and makes BPB scores look artificially better — the metric driving the entire autoresearch loop.
- Switch to reading raw bytes directly from ``mergeable_ranks``. Special tokens (not in ``mergeable_ranks``) keep their 0 byte length.

Closes #384.

## Root cause
``prepare.py`` (around line 188 before this change) had:

```python
token_str = enc.decode([token_id])
token_bytes_list.append(len(token_str.encode("utf-8")))
```

For a token whose raw bytes are ``b'\x80'`` (1 byte), ``decode`` returns ``'�'`` and ``encode('utf-8')`` returns 3 bytes. The reported denominator is 3× the true value, deflating BPB.

## Reproduction
Synthetic tiktoken Encoding with a ``0x80`` token shows old=3 bytes vs new=1 byte per affected token. Verified locally:

```
OLD: [3, 3, 1, 1, 0]
NEW: [1, 1, 1, 1, 0]
```

## Fix
Build ``rank_to_bytes`` from ``mergeable_ranks`` (which already lives in scope right above), then look up each token id directly. Special tokens fall through ``rank_to_bytes.get(...)`` and get a 0 byte length.

## Test plan
- [x] Synthetic tiktoken Encoding with ``0x80`` raw byte: confirms inflation in old path, recovery in new path.
- [ ] Cross-check on a fully-trained tokenizer that ``sum(token_bytes)`` is no larger than under the old path (and strictly smaller whenever any token has non-UTF-8 raw bytes).
- [ ] Sanity-check that downstream ``evaluate_bpb`` still runs unchanged — the evaluation function itself is untouched; only the precomputed lookup it consumes changes.