### PR TITLE
fix(tokenizer): support multi-token prepend and tighten scope (#348)

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -226,17 +226,35 @@ class Tokenizer:
         return self.bos_token_id
 
     def encode(self, text, prepend=None, num_threads=8):
+        # Resolve `prepend` to a list of token ids once, up front. The previous
+        # implementation defined `prepend_id` only inside `if prepend is not None`
+        # and referenced it from nested branches, and called encode_single_token
+        # on string prepends — which raises ValueError for any prepend that maps
+        # to multiple tokens (e.g. a multi-token BOS marker). See issue #348.
+        prepend_ids: list[int] = []
         if prepend is not None:
-            prepend_id = prepend if isinstance(prepend, int) else self.enc.encode_single_token(prepend)
+            if isinstance(prepend, int):
+                prepend_ids = [prepend]
+            elif isinstance(prepend, (list, tuple)):
+                prepend_ids = [int(t) for t in prepend]
+            elif isinstance(prepend, str):
+                try:
+                    prepend_ids = [self.enc.encode_single_token(prepend)]
+                except (KeyError, ValueError):
+                    # Fall back to ordinary encoding so multi-token strings work.
+                    prepend_ids = self.enc.encode_ordinary(prepend)
+            else:
+                raise TypeError(f"Invalid prepend type: {type(prepend)}")
+
         if isinstance(text, str):
             ids = self.enc.encode_ordinary(text)
-            if prepend is not None:
-                ids.insert(0, prepend_id)
+            if prepend_ids:
+                ids = prepend_ids + ids
         elif isinstance(text, list):
             ids = self.enc.encode_ordinary_batch(text, num_threads=num_threads)
-            if prepend is not None:
+            if prepend_ids:
                 for row in ids:
-                    row.insert(0, prepend_id)
+                    row[0:0] = prepend_ids
         else:
             raise ValueError(f"Invalid input type: {type(text)}")
         return ids


### PR DESCRIPTION
## Summary
``Tokenizer.encode`` assigned ``prepend_id`` only inside the outer ``if prepend is not None:`` block and resolved string prepends via ``encode_single_token()``. Any prepend that mapped to more than one token raised ``KeyError`` / ``ValueError``. Closes #348.

## Repro
With a tiny demo encoding where ``"abcd"`` is 4 separate tokens:

```python
old_encode("aaaa", prepend="abcd")
# -> KeyError: b'abcd'
```

## Fix
Resolve ``prepend`` once into a list of token ids:

| input              | result                       |
| ------------------ | ---------------------------- |
| ``int``            | ``[int]``                    |
| ``list``/``tuple`` | list of ints                 |
| ``str``            | ``encode_single_token`` fast path, falling back to ``encode_ordinary`` for multi-token strings |
| ``None``           | ``[]``                       |

The list is then prepended to single-row and batch-row outputs uniformly. The production code path (``prepend=bos_token_id``, an int) is unchanged.

## Test plan
- [x] ``int`` prepend (the dataloader path)
- [x] ``int`` prepend on batch
- [x] single-token ``str`` prepend (fast path)
- [x] multi-token ``str`` prepend (previously crashed) — now produces 4 prepended ids
- [x] multi-token ``str`` prepend on batch
- [x] ``list[int]`` prepend
- [x] ``None`` prepend (no insertion, no NameError)
- [x] ``None`` prepend on batch

```
int prepend -> [7, 0, 1, 2, 3]
multi-token str prepend -> [0, 1, 2, 3, 0, 0, 0, 0]
batch multi-token str prepend -> [[0, 1, 2, 3, 0, 0, 0, 0], [0, 1, 2, 3, 1, 1, 1, 1]]
ALL TOKENIZER PREPEND CASES PASS
```