### PR TITLE
feat(program): add Lévy-flight mutation-size guidance to the loop

### DIFF
--- a/program.md
+++ b/program.md
@@ -109,6 +109,14 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
 
+**Mutation size (Lévy-flight)**: Sparse-reward search rewards heavy-tailed step distributions — many short hops and rare long jumps — over uniform-size steps. Before each experiment, sample a mutation size from this distribution and let it constrain the change you propose:
+
+- **65%** *short*: tweak a single hyperparameter, scalar, or one line of code.
+- **25%** *medium*: change 2–3 related knobs (e.g. LR + weight decay + warmup; or head_dim + n_head; or one block of the model).
+- **10%** *long*: a deliberately radical change — swap optimizer family, replace activation, change attention mechanism, restructure the residual path, halve depth and double width, etc.
+
+The point of the long jumps is *not* that they usually win; most won't. The point is that a hill-climber confined to short steps can never reach a basin separated by even a small ridge. The 10% long-jump tax is a cheap insurance policy against getting stuck near a plateau.
+
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
 
 As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!


### PR DESCRIPTION
## Summary
A pure prompt change in ``program.md``. Before each experiment, the agent samples a mutation size from a heavy-tailed distribution and lets it constrain the change it proposes:

- **65%** *short* — single hyperparameter / one line
- **25%** *medium* — 2–3 related knobs
- **10%** *long*  — deliberately radical (swap optimizer family, replace activation, restructure residual path, …)

## Why
The current loop is a greedy hill-climber with effectively-uniform step sizes (every commit looks roughly the same in surface area). On a sparse-reward, non-convex landscape that is exactly the regime where Lévy-flight foragers — sharks, albatrosses, fruit flies, deer — measurably outperform Brownian-motion foragers. The same heavy-tailed perturbation operator powers the most-cited modern metaheuristics (Cuckoo Search, Manta Ray, Prairie Dog, …).

The 10% long-jump budget isn't claiming most long jumps win — most won't. It's the cheap insurance against the hill-climber stalling on a plateau separated from a better basin by even a small ridge.

## Why this is the smallest possible step
``bioinspired.md`` (PR #554) proposes 9 patterns ordered cheapest-first. This is pattern #1 — pure prompt change, zero infra, zero code, single paragraph in ``program.md``. It validates whether the proposal is actionable in isolation before any of the more invasive patterns (pheromone trail, replay buffer, lateral roots) are layered on.

## Citations
- [The Lévy flight foraging hypothesis](https://pubmed.ncbi.nlm.nih.gov/25709823/)
- [Survey of Lévy-flight metaheuristics, *Mathematics* 2022](https://www.mdpi.com/2227-7390/10/15/2785)
- [Manta Ray Foraging + chaotic Lévy + restart, *Sci. Rep.* 2025](https://www.nature.com/articles/s41598-025-25766-y)

## Test plan
- [x] Diff is +8 lines, all in one paragraph
- [x] Existing loop semantics unchanged — agent still hill-climbs, this only constrains *how big* the next step is
- [ ] If merged, observe over a multi-hour autoresearch run whether long jumps measurably extend the time-to-stagnation. Easy to A/B against a parallel run on a sibling branch without this paragraph.