### PR TITLE
fix(train): warmup off-by-one in steady_state_mfu accumulation

### DIFF
--- a/train.py
+++ b/train.py
@@ -575,7 +575,13 @@ while True:
     t1 = time.time()
     dt = t1 - t0
 
-    if step > 10:
+    # Skip exactly 10 warmup steps (compilation, kernel autotune, etc.) before
+    # accumulating training time. `step` is the index BEFORE the increment at
+    # the bottom of the loop, so step >= 10 means we've completed 10 warmup
+    # iterations and this is the 11th (the first measured) iteration. The old
+    # `step > 10` check skipped 11 iterations instead of 10, which left
+    # `(step - 10)` overcounting measured iterations by one in the final MFU.
+    if step >= 10:
         total_training_time += dt
 
     # Logging


### PR DESCRIPTION
## Summary
``if step > 10`` was checked **before** ``step += 1``, so the very first iteration that contributed to ``total_training_time`` was iteration 12 (when ``step`` at the check is 11), not iteration 11 as intended. That makes the warmup skip *eleven* iterations while the final-summary formula ``(step - 10)`` assumes it skipped *ten*.

Change the predicate to ``step >= 10``. Now ``step >= 10`` at the check means 10 warmup iterations have already completed (1..10), and this is iteration 11 — the first measured one. ``(step - 10)`` then matches the count of accumulated ``dt`` contributions exactly.

## Trace
At the top of iteration K, ``step == K - 1``.

| K | step at check | OLD: ``step > 10`` | NEW: ``step >= 10`` |
|---|---|---|---|
| 10 | 9  | skip          | skip          |
| 11 | 10 | **skip** ❌    | **accumulate** ✅ |
| 12 | 11 | accumulate    | accumulate    |
| 13 | 12 | accumulate    | accumulate    |

After N iterations:
- OLD: measured = N − 11, formula uses N − 10 → overcounts by 1.
- NEW: measured = N − 10, formula uses N − 10 → exact.

## Magnitude of the misreport
Reported ``steady_state_mfu`` was overstated by:
| total iterations N | overstatement |
|---|---|
| 50  | 2.56% |
| 100 | 1.12% |
| 200 | 0.53% |
| 500 | 0.20% |
| 953 | 0.11% |

(953 ≈ the example log in ``program.md``.)

## Why this matters
Reported MFU is a top-level summary metric in ``results.tsv`` style outputs and a frequent comparison point across forks and notable hardware runs. A structural overstatement, however small, makes cross-run comparisons inconsistent — particularly painful at small step counts where the overstatement is largest, which is precisely the regime where people benchmark variants.

## Independence from other open MFU work
- PR #547 (mine) replaces the hardcoded H100 peak with GPU-aware ``GPU_BF16_PEAK_FLOPS`` — touches different lines (``H100_BF16_PEAK_FLOPS`` constant + per-step + summary formula), no merge conflict with this PR.
- The two fixes are orthogonal and address different problems (peak FLOPS hardcoding vs warmup off-by-one).

## Test plan
- [x] Simulated both rules across N ∈ {15, 50, 100, 200, 500, 953} and confirmed: NEW matches measured iteration count exactly; OLD overcounts by 1.
- [x] No behavioral change to the break condition (``if step > 10 and total_training_time >= TIME_BUDGET``) — that runs *after* ``step += 1``, so it still uses count semantics correctly.
- [x] Commit comment explains the off-by-one for future readers.