### PR TITLE
feat(program): measure-the-noise-floor protocol — "you are the easiest person to fool"

### DIFF
--- a/program.md
+++ b/program.md
@@ -38,6 +38,14 @@ Each experiment runs on a single GPU. The training script runs for a **fixed tim
 
 **The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
 
+**Measure the noise floor (second run)**: After the first baseline run, do a *second* baseline run on the unchanged code. The two `val_bpb` values will differ because of CUDA kernel non-determinism, GC scheduling, and floating-point reduction order. The absolute difference between them is your **noise floor σ_noise** — back-of-envelope, ~3e-4 BPB on the 21M-token val shard, but measure it, don't assume it. Record both as `keep` (the second is the new baseline). All future experiments are interpreted against this floor:
+
+- |Δval_bpb| < 2 × σ_noise → **discard**, no matter the sign. The change is indistinguishable from noise; keeping it anchors 12+ downstream experiments on what is essentially a coin flip.
+- |Δval_bpb| ≥ 2 × σ_noise *and* improving → **keep** (subject to the simplicity criterion).
+- Anything else → **discard**.
+
+This is the single highest-leverage protocol change in the loop: most "0.0003 BPB improvements" celebrated in greedy hill-climbs are noise. One free run at the start saves dozens of experiments wasted building on a phantom win.
+
 ## Output format
 
 Once the script finishes it prints a summary like this:


### PR DESCRIPTION
## Summary
A pure prompt change in ``program.md``. After the first baseline run, do a *second* baseline run on the unchanged code. The two ``val_bpb`` values will differ — because of CUDA kernel non-determinism, GC scheduling jitter, and floating-point reduction order. Their absolute difference is the **noise floor σ_noise**.

Then every future experiment is interpreted against this floor:

- ``|Δval_bpb| < 2 × σ_noise`` → **discard, no matter the sign.** Indistinguishable from noise.
- ``|Δval_bpb| ≥ 2 × σ_noise`` → normal keep/discard rule applies.

## Why
Cargo Cult Science, Caltech 1974:
> *"The first principle is that you must not fool yourself — and you are the easiest person to fool."*

The current greedy rule (\"any improvement is a keep\") treats every BPB wiggle as signal. Back-of-envelope, the irreducible statistical floor on a 21M-token val shard with per-token loss std ~0.5 and ~3 bytes/token is

```
σ_stat  ≈  0.5 / sqrt(21e6) / log(2) / 3  ≈  5e-5
```

CUDA kernel jitter pushes the empirical floor to a few × 1e-4. Anything below ~3e-4 is structurally suspect. Without measuring it, the agent celebrates 0.0003-BPB \"wins\" and then anchors the next 12 experiments on what is, in expectation, a coin flip. One extra baseline run at the start of the session pays for itself the first time it catches a phantom KEEP.

This is pattern #1 from ``physics_inspired.md`` (PR #559) — the cheapest and highest-leverage protocol change. No code, no infra; pure ``program.md`` paragraph.

## How this stacks with prior PRs
- **PR #555 (Lévy-flight mutation size)** controls *step size*.
- **PR #558 (inhibition of return)** controls *which axis to step on*.
- **This PR** controls *whether the step actually happened* — i.e. whether to believe the metric reading.

Together: the agent gets broad axis coverage with heavy-tailed step sizes, and refuses to anchor on wiggles below the noise floor. That is the minimum exploration *and* honesty scaffolding before any of the more ambitious patterns from ``bioinspired.md`` / ``physics_inspired.md`` (pheromone trails, Metropolis acceptance, MDL prior, replay buffers) become worthwhile.

## Test plan
- [x] Diff is +8 lines, all in one paragraph + a 3-bullet decision rule
- [x] Existing loop semantics unchanged — agent still hill-climbs, this only adds a floor under the accept rule
- [ ] On the first session run with this prompt, observe what σ_noise actually is on H100 vs A100 vs other; the back-of-envelope ~3e-4 will be calibrated empirically the first time anyone runs the protocol.
- [ ] Optional: log σ_noise as a header comment in ``results.tsv`` for cross-session comparability

## Citations
- [Feynman, *Cargo Cult Science*, Caltech 1974](https://calteches.library.caltech.edu/51/2/CargoCult.htm)
- ``physics_inspired.md`` §1 in this repo (PR #559)