### PR TITLE
feat(program): formalize Simplicity criterion as MDL free-energy comparison

### DIFF
--- a/program.md
+++ b/program.md
@@ -36,6 +36,15 @@ Each experiment runs on a single GPU. The training script runs for a **fixed tim
 
 **Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 val_bpb improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep.
 
+To make this less subjective, use a free-energy comparison rather than a pure energy comparison. Compute `diff_bytes = git diff --shortstat HEAD^ HEAD` (added + removed bytes; `wc -c` on the diff hunk is fine). Then:
+
+```
+F  =  val_bpb  +  λ · diff_bytes
+λ  ≈  5e-6 BPB/byte         (so a 100-byte change "costs" ~0.0005 BPB)
+```
+
+Accept iff `F_new < F_old`. A pure deletion has negative `diff_bytes` and is rewarded automatically. A 100-byte addition that improves BPB by 0.0001 (less than its complexity cost) is rejected, even though greedy energy comparison would accept it. Two agents arguing about "is this complexity worth it" can now compare numbers instead of vibes; calibrate λ if it's miscalibrated for your taste, but keep the form. (This is the [Hinton & Zemel autoencoder MDL framing](https://proceedings.neurips.cc/paper/1993/hash/9e3cfc48eccf81a0d57663e129aef3cb-Abstract.html) applied to architecture search: minimize description length of the change, not just the test loss.)
+
 **The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
 
 ## Output format


### PR DESCRIPTION
## Summary
The existing English ``Simplicity criterion`` paragraph leaves the agent (and any reviewer) with subjective judgments — *small*, *ugly*, *worth it*. This PR keeps the English paragraph (no semantic change) and **adds a calibrated form below it**:

```
F  =  val_bpb  +  λ · diff_bytes
λ  ≈  5e-6 BPB/byte
```

Accept iff ``F_new < F_old``.

A 100-byte addition costs ~0.0005 BPB. A pure deletion has negative ``diff_bytes`` and is rewarded automatically. A 100-byte addition that improves BPB by only 0.0001 (less than its complexity cost) is *rejected* — even though strict greedy energy comparison would accept it.

## Why
Two agents arguing about "is this complexity worth it" can now compare numbers instead of vibes. λ is the only knob to tune, and it's a single number with a clear unit (BPB per byte of diff). The English form is preserved alongside the formula so the agent gets *both* the prose intuition and the comparable scalar.

This is the **Hinton & Zemel autoencoder MDL framing** ([NeurIPS 1993](https://proceedings.neurips.cc/paper/1993/hash/9e3cfc48eccf81a0d57663e129aef3cb-Abstract.html)) applied to architecture search: minimize description length of the change itself, not just the test-set log-loss. Same intuition as ``L1`` regularization, but on *code* rather than weights.

## Calibration
The default ``λ ≈ 5e-6`` is calibrated to match the existing English examples in the same paragraph:

| change                           | ΔBPB    | diff_bytes (est.) | λ × bytes | accepted? (default λ) |
| -------------------------------- | ------- | ----------------- | --------- | --------------------- |
| 0.001 BPB win, +20 lines hacky   | -0.001  | +600              | +0.003    | **rejected** (matches the existing English: "probably not worth it") |
| 0.001 BPB win, deleting code     | -0.001  | -200              | -0.001    | **accepted** (matches: "definitely keep") |
| ~0 ΔBPB, much simpler code       | 0       | -300              | -0.0015   | **accepted** (matches: "Keep") |

The formula recovers the three examples in the existing paragraph automatically — calibrating λ against existing intent rather than introducing new policy.

## Independence from sibling PRs
- Builds on the *concept* of finite-temperature acceptance from ``physics_inspired.md`` (PR #559) but does **not** depend on it.
- Compatible with PR #560 (noise floor) — both are filters in front of the same accept rule. Use them in series: first reject if ``|ΔBPB| < 2σ_noise`` (PR #560), then compare ``F_new < F_old``.
- No conflict with PR #555 (Lévy) or PR #558 (IoR), which control *which* change to propose, not *whether* to accept it.

## Test plan
- [x] Diff is +9 lines, all in one paragraph immediately after the existing Simplicity criterion English paragraph
- [x] No semantic change to the English form — the formula is added below, not replacing
- [x] Default λ calibrated against the three English examples in the same paragraph (table above)
- [ ] Optional follow-up: if log a ``diff_bytes`` 6th column in ``results.tsv``, the calibration becomes auditable post-hoc and λ can be re-fit empirically from kept changes