### PR TITLE
feat(program): require a reverse-move statement (Feynman ratchet check)

### DIFF
--- a/program.md
+++ b/program.md
@@ -95,6 +95,7 @@ LOOP FOREVER:
 
 1. Look at the git state: the current branch/commit we're on
 2. Tune `train.py` with an experimental idea by directly hacking the code.
+   Before committing, write down (in the commit message body) the **reverse move** — the smallest change that would undo this one. If the reverse isn't easily expressible ("change LR back to 0.04", "remove this block", "swap activation back to ReLU²"), the search is operating with an asymmetric pawl: you can move forward but not backward. Asymmetric reject rules let noise ratchet the search in one direction even when the underlying landscape is flat. (See [Feynman's analysis of the Brownian ratchet](https://en.wikipedia.org/wiki/Brownian_ratchet): a one-way pawl plus thermal noise looks like net work, but at uniform temperature it isn't. Same trap, same fix — make the move set symmetric.) If you can't write the reverse, either pick a different change or explicitly add the reverse to your move set so the loop has both directions available.
 3. git commit
 4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
 5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`


### PR DESCRIPTION
## Summary
One sentence inserted into step 2 of the ``LOOP FOREVER`` block:

> *Before committing, write down the **reverse move** — the smallest change that would undo this one. If the reverse isn't easily expressible, the search has an asymmetric pawl: it can step forward but not backward.*

## Why
[Feynman's analysis of the Brownian ratchet](https://en.wikipedia.org/wiki/Brownian_ratchet) (Feynman Lectures Vol I, Ch. 46) shows that a one-way pawl plus thermal noise *looks like* sustained directed rotation — and isn't. At uniform temperature the pawl is itself buffeted by noise and lifts at exactly the rate the wheel kicks it; net work is zero. Any apparent net motion is an artefact of the asymmetry of the model, not real work extracted from heat.

The autoresearch loop is full of opportunities to build accidental ratchets:

- *"It's easier to add capacity than to remove it."* If the agent's available mutations are skewed toward "make-it-bigger," the loop ratchets toward larger models even when smaller ones are equivalent.
- *"It's easier to add a hyperparameter knob than to delete one."* Same asymmetry, different axis.
- *"Failures don't get logged in detail; successes get analyzed."* This ratchets confirmation bias.

These are all the same physics: an asymmetric move set + noise = directed motion *without underlying gradient*. The cure is the same Feynman applied: **make the move set symmetric** so both directions face the same friction.

The single-sentence change asks the agent to *prove* the move set is symmetric for each experiment — by stating the reverse explicitly. If the reverse is hard to express, that's the diagnostic signal that an accidental pawl exists.

## How this composes with sibling PRs
- **PR #555 (Lévy)** — controls *how big* the next step is.
- **PR #558 (IoR)** — controls *which axis* to step on.
- **PR #560 (noise floor)** — controls *whether to believe* the metric reading.
- **PR #561 (MDL)** — formalizes *the simplicity prior* in the accept rule.
- **This PR** — controls *whether the move set itself is symmetric* so the previous four protections actually do what they claim.

Without this check, even a perfectly calibrated noise-floor + MDL accept rule can ratchet into bias if the *proposal* distribution is asymmetric. This is the often-missed half: most exploration literature focuses on the accept rule; biases in the *propose* step are the silent killer.

## Cost
One commit-message-body line per experiment. The "reverse move" is usually trivial to state (most changes have an obvious inverse). When it isn't trivial, that's exactly the case where this check is doing real work.

## Citations
- [Brownian / Feynman–Smoluchowski ratchet](https://en.wikipedia.org/wiki/Brownian_ratchet)
- [Feynman Lectures Vol I, Ch. 46 — *Ratchet and pawl*](https://www.feynmanlectures.caltech.edu/I_46.html)
- ``physics_inspired.md`` §4 in this repo (PR #559)

## Test plan
- [x] Diff is +1 sentence in one bullet of the ``LOOP FOREVER`` block
- [x] No semantic change to the loop's accept/reject behaviour — this is a *proposal-side* discipline, not an accept-rule change
- [x] Trivial to comply with for almost every experiment; serves as a real diagnostic on the rare experiments where the reverse is genuinely hard