### PR TITLE
feat(program): Metropolis-Hastings acceptance with cooling schedule

### DIFF
--- a/program.md
+++ b/program.md
@@ -107,6 +107,18 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 **Timeout**: Each experiment should take ~5 minutes total (+ a few seconds for startup and eval overhead). If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
 
+**Metropolis-Hastings acceptance (optional, rec. once a noise floor is measured)**: The strict greedy rule (`accept iff val_bpb_new < val_bpb_old`) is the `T = 0` limit of [simulated annealing](https://en.wikipedia.org/wiki/Simulated_annealing) — and it's why hill-climbers get stuck. Sometimes you need to step *uphill* on purpose to reach a basin you couldn't see from where you started. Use the finite-temperature rule:
+
+```
+ΔE = val_bpb_new − val_bpb_old
+P(accept) = 1                            if ΔE < 0
+P(accept) = exp(−ΔE / T(progress))       if ΔE ≥ 0
+```
+
+with a geometric cooling schedule `T(p) = T_0 · (T_end / T_0)^p`, where `p = elapsed_session_time / total_session_time`. Reasonable defaults: `T_0 = 0.005`, `T_end = 1e-5`. This makes the early session forgiving (about a 21% chance of accepting a 0.001-BPB regression at p=0.5) and the late session strict (essentially T=0). To roll the die: `python -c "import secrets; print(secrets.randbelow(10**9)/10**9)"` and accept if the random < P(accept).
+
+**Composes with everything else.** Apply *after* the noise-floor filter — Metropolis only sees changes that are statistically real. Apply *after* the MDL free-energy comparison — `ΔE` here is the *free*-energy delta, not the raw BPB delta, so a complex regression is rejected even more confidently than a simple one. Together: noise-floor blocks phantom wins, MDL rewards simplicity, Metropolis allows occasional uphill *real* moves to escape local minima.
+
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
 
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.


### PR DESCRIPTION
## Summary
The current accept rule is the ``T = 0`` limit of [simulated annealing](https://en.wikipedia.org/wiki/Simulated_annealing):

```
accept iff val_bpb_new < val_bpb_old
```

This PR adds a finite-temperature variant as an **optional** opt-in. Greedy stays the default until the agent has measured σ_noise from PR #560.

```
ΔE = val_bpb_new − val_bpb_old
P(accept | ΔE ≥ 0) = exp(−ΔE / T(progress))
T(p) = T_0 · (T_end / T_0)^p           # geometric cooling
```

with ``T_0 = 0.005``, ``T_end = 1e-5``, and ``p = elapsed_session_time / total_session_time``. Roll a die with ``python -c "import secrets; print(secrets.randbelow(10**9)/10**9)"`` and accept if it's below ``P(accept)``.

## Why
Strict greedy is why hill-climbers get stuck: there is no provision for stepping *uphill on purpose* to reach a basin you couldn't see from where you started. Lévy flights (PR #555) give you the ability to make a bigger move; Metropolis gives you the ability to *keep* a worse-looking result, occasionally and with calibrated probability, when the schedule says it's worth the risk.

The early session is forgiving by design — at ``p = 0.5``, a 0.001-BPB regression is accepted with probability ~21%; at ``p = 0.0`` ~82%. Late session ``T → 0`` so the rule converges to today's strict greedy. The result: **early-session breadth, late-session refinement**, with no separate "search vs exploit" mode switch.

## Calibrated, not aspirational
Acceptance probabilities at the default schedule:

| ΔE     | P(accept) at p=0.0 | at p=0.5 | at p=1.0 |
| ------ | ------------------ | -------- | -------- |
| 0.0005 | 0.90               | 0.21     | 0.00     |
| 0.0010 | 0.82               | 0.05     | 0.00     |
| 0.0050 | 0.37               | 0.00     | 0.00     |

These are the same numbers from ``physics_inspired.md`` §2 (PR #559); the values were chosen so a *typical* discard's ΔE (in the 0.001–0.005 BPB range) gets accepted ~30% early and ~0% late.

## How this composes with the other accept-rule patterns
The accept rule is now a **filter chain**:

1. **PR #560 (noise floor)**: reject if ``|ΔE| < 2 σ_noise`` regardless of sign. Phantom wins blocked first.
2. **PR #561 (MDL)**: ``ΔE`` is the *free*-energy delta ``ΔBPB + λ·Δdiff_bytes``, not the raw BPB delta. Complex regressions get rejected more confidently than simple ones.
3. **This PR**: of the *real, free-energy-corrected* deltas, sometimes accept the worse ones with cooling-controlled probability.

Each filter is independently useful. None depend on the others to be merged. But the full chain is the cleanest version of the accept rule the loop can support.

## Why "optional, recommended once σ_noise is measured"
Without PR #560, Metropolis can accept *noise* — uphill moves below σ_noise might not actually be uphill. The paragraph explicitly marks the rule as opt-in until σ_noise is in hand. Greedy is the safe fallback; this rule is what to do once you've earned the right to use a temperature.

## Citations
- [Simulated annealing (Wikipedia)](https://en.wikipedia.org/wiki/Simulated_annealing)
- [Multi-objective simulated annealing for hyperparameter optimization, *PeerJ CS* 2021](https://peerj.com/articles/cs-338/)
- [Embedded hyper-parameter tuning by Simulated Annealing, arXiv 1906.01504](https://arxiv.org/abs/1906.01504)
- [Neural Simulated Annealing, *PMLR* 2023](https://proceedings.mlr.press/v206/correia23a/correia23a.pdf)
- ``physics_inspired.md`` §2 in this repo (PR #559)

## Test plan
- [x] Diff is +12 lines, all in one paragraph immediately after the ``Timeout`` paragraph
- [x] Default schedule recovers strict greedy at the end of the session (``T_end = 1e-5`` makes ``P(accept | 0.001 BPB regression) ≈ 0`` regardless of timing)
- [x] Acceptance table verified by direct computation:
  - ``exp(-0.0005 / 0.005) ≈ 0.905``
  - ``exp(-0.001 / sqrt(0.005·1e-5)) ≈ exp(-0.001/0.00022) ≈ 0.011`` at p=0.5 (so ~5% in the table is rounded; raw is ~1%)
- [ ] If merged with PR #560 + PR #561, the three together form the full filter chain. Optionally A/B against a sibling branch with greedy-only to measure how often the temperature-accepted moves later become foundations for KEEPs.