### PR TITLE
feat(program): read local curvature out of the discard log (fluctuation-dissipation)

### DIFF
--- a/program.md
+++ b/program.md
@@ -87,6 +87,16 @@ c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
 d4e5f6g	0.000000	0.0	crash	double model width (OOM)
 ```
 
+**Read the curvature out of your discards (free)**: Every K=10 experiments, look back at the last 10 *signed* deltas (`val_bpb_new − val_bpb_old`, including discards). Compute their stdev — call it `σ_local`. This is a free local-curvature estimate from data you already have, by the [fluctuation-dissipation theorem](https://en.wikipedia.org/wiki/Fluctuation-dissipation_theorem): in equilibrium, the variance of fluctuations is proportional to the susceptibility, so the spread of nearby attempts tells you the local stiffness without any extra runs.
+
+| `σ_local` regime         | What it means                              | What to do next                                |
+| ------------------------ | ------------------------------------------ | ---------------------------------------------- |
+| `σ_local ≲ 2 × σ_noise`  | locally flat; small steps are wasted       | jump (Lévy *long*, or change axis)             |
+| `σ_local ≈ 5 × σ_noise`  | normal slope                               | continue with default mutation size            |
+| `σ_local ≳ 20 × σ_noise` | cliff; one-line tweaks could break things  | shrink mutation size, only short hops          |
+
+Same intuition as classical [trust-region](https://en.wikipedia.org/wiki/Trust_region) optimizers, derived in two lines from the discard log instead of estimating a Hessian. Costs nothing — the data is already on disk in `results.tsv`.
+
 ## The experiment loop
 
 The experiment runs on a dedicated branch (e.g. `autoresearch/mar5` or `autoresearch/mar5-gpu0`).


### PR DESCRIPTION
## Summary
Adds one paragraph to ``program.md``: every K=10 experiments, compute ``σ_local`` = stdev of the last 10 *signed* deltas (``val_bpb_new − val_bpb_old``, including discards) and let it pick the next mutation size.

| ``σ_local`` regime         | Reading                                       | Next move                                      |
| -------------------------- | --------------------------------------------- | ---------------------------------------------- |
| ``≲ 2 × σ_noise``          | locally flat; short steps wasted              | jump (Lévy long, or change axis)               |
| ``≈ 5 × σ_noise``          | normal slope                                  | default mutation size                          |
| ``≳ 20 × σ_noise``         | cliff; one-line tweaks could break things     | shrink mutation size, short hops only          |

## Why
The [fluctuation-dissipation theorem](https://en.wikipedia.org/wiki/Fluctuation-dissipation_theorem): in equilibrium, the variance of fluctuations is proportional to the susceptibility (i.e. the local stiffness of the response). So the spread of nearby attempts is a *free* local-curvature estimate — the system tells you its stiffness for free.

Every discard is a measurement of the local landscape. Today, that data sits in ``results.tsv`` and is never read. This teaches the agent to read it. Same intuition as classical [trust-region](https://en.wikipedia.org/wiki/Trust_region) optimizers, but derived from the discard log in two lines instead of estimating a Hessian.

## How this composes with the other patterns
This pattern is the *bridge* between the noise-floor protocol (PR #560) and the Lévy mutation-size policy (PR #555):

- ``σ_noise`` from PR #560 sets the unit.
- ``σ_local`` from this PR sets the regime.
- The Lévy policy from PR #555 picks the next step size *given* the regime.

Without ``σ_local``, the Lévy policy is a fixed 65/25/10 split. With ``σ_local``, the policy adapts: tilt toward longer jumps on flat ground, shorter hops on cliffs.

## Cost
Zero new data collection; just teaches the agent to read what it already writes. The K=10 cadence is a hyperparameter; the table is the scaffolding.

## Citations
- [Fluctuation-dissipation theorem (Wikipedia)](https://en.wikipedia.org/wiki/Fluctuation-dissipation_theorem)
- [Trust region method (Wikipedia)](https://en.wikipedia.org/wiki/Trust_region)
- ``physics_inspired.md`` §3 in this repo (PR #559)

## Test plan
- [x] Diff is +10 lines, all in one paragraph + a 3-row decision table immediately before the ``LOOP FOREVER`` block
- [x] Computes from ``results.tsv`` data the agent already maintains; no new logging required
- [x] Composes with PRs #555 (Lévy), #560 (noise floor) without code overlap or semantic conflict
- [ ] Optional follow-up: log a 6th column ``mutation_size_regime`` (``flat`` / ``slope`` / ``cliff``) in ``results.tsv`` so the policy is auditable post-hoc