### PR TITLE
feat(program): add axis column to results.tsv schema (5 → 6 columns)

### DIFF
--- a/program.md
+++ b/program.md
@@ -65,26 +65,28 @@ grep "^val_bpb:" run.log
 
 When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated — commas break in descriptions).
 
-The TSV has a header row and 5 columns:
+The TSV has a header row and 6 columns:
 
 ```
-commit	val_bpb	memory_gb	status	description
+commit	val_bpb	memory_gb	status	axis	description
 ```
 
 1. git commit hash (short, 7 chars)
 2. val_bpb achieved (e.g. 1.234567) — use 0.000000 for crashes
 3. peak memory in GB, round to .1f (e.g. 12.3 — divide peak_vram_mb by 1024) — use 0.0 for crashes
 4. status: `keep`, `discard`, or `crash`
-5. short text description of what this experiment tried
+5. **axis**: a short tag for the primary search axis touched by this experiment (e.g. `lr`, `depth`, `head_dim`, `optimizer`, `activation`, `attn_window`, `weight_decay`, `init`, `architecture`). Use `baseline` for the first run and `multi` if the change touched 2+ axes. This makes the inhibition-of-return rule, the pheromone trail, and the fluctuation-dissipation curvature estimate auditable post-hoc — without it, all three rely on the agent's working memory and can't be reconstructed across sessions.
+6. short text description of what this experiment tried (free-form)
 
 Example:
 
 ```
-commit	val_bpb	memory_gb	status	description
-a1b2c3d	0.997900	44.0	keep	baseline
-b2c3d4e	0.993200	44.2	keep	increase LR to 0.04
-c3d4e5f	1.005000	44.0	discard	switch to GeLU activation
-d4e5f6g	0.000000	0.0	crash	double model width (OOM)
+commit	val_bpb	memory_gb	status	axis	description
+a1b2c3d	0.997900	44.0	keep	baseline	first baseline run
+b2c3d4e	0.997931	44.0	keep	baseline	second baseline (sigma_noise = 3.1e-5)
+c3d4e5f	0.993200	44.2	keep	lr	increase MATRIX_LR 0.04 -> 0.06
+d4e5f6g	1.005000	44.0	discard	activation	switch to GeLU
+e5f6g7h	0.000000	0.0	crash	architecture	double model width (OOM)
 ```
 
 ## The experiment loop


### PR DESCRIPTION
## Summary
Extends ``results.tsv`` from 5 columns to 6, with a new ``axis`` column between ``status`` and ``description``:

```
commit	val_bpb	memory_gb	status	axis	description
a1b2c3d	0.997900	44.0	keep	baseline	first baseline run
b2c3d4e	0.997931	44.0	keep	baseline	second baseline (σ_noise = 3.1e-5)
c3d4e5f	0.993200	44.2	keep	lr	increase MATRIX_LR 0.04 → 0.06
d4e5f6g	1.005000	44.0	discard	activation	switch to GeLU
e5f6g7h	0.000000	0.0	crash	architecture	double model width (OOM)
```

Allowed values: ``lr``, ``depth``, ``head_dim``, ``optimizer``, ``activation``, ``attn_window``, ``weight_decay``, ``init``, ``architecture``, plus ``baseline`` (first runs) and ``multi`` (2+ axes touched).

## Why this matters
Three of the prompt patterns shipped this round are *per-axis*:

- **PR #558 (Inhibition of Return)** — "rotate axes" — needs to know which axis was touched last.
- **PR #569 (Pheromone Trail)** — pheromone is keyed by axis.
- **PR #565 (Fluctuation-dissipation)** — curvature is per-axis.

Without recording axis explicitly, all three rules rely entirely on the agent's *working memory* and become unreconstructable across sessions or after context resets. The agent might not even know what its last touched axis was after a long context.

Adding the column upgrades the patterns from "in-context heuristics" → "auditable, reproducible policies" that can be **re-fit empirically** from past sessions' ``results.tsv`` data. Three concrete consequences:

1. The pheromone **evaporation rate ρ** (PR #569) can be tuned to maximize observed KEEP rate over the historical dataset.
2. The IoR **refractory window M** (PR #558) can be calibrated empirically — does M=1 or M=3 produce more keeps?
3. The fluctuation-dissipation **σ_local thresholds** (PR #565) can be calibrated against the actual joint distribution of (axis, Δ) seen in the wild.

## Backward compatibility
Existing 5-column ``results.tsv`` files migrate trivially — add a ``multi`` or ``unknown`` axis column to old rows; the patterns above degrade gracefully when the axis is unknown (axis-aware policies fall back to uniform).

## Independence and composition
- Pure documentation/protocol change in ``program.md``. No code, no infra.
- Independent of all other open PRs.
- **Unlocks** PRs #558, #565, #569 — they're written to *use* the axis column once it exists, but were shipped earlier so the patterns could be evaluated in isolation.

## Test plan
- [x] Diff is +10/-8 lines, all in the ``Logging results`` section
- [x] Allowed values listed inline; ``baseline`` and ``multi`` fallbacks specified
- [x] Example block updated to show the new column with realistic axis tags
- [x] Backward-compatibility migration described
- [ ] Optional follow-up: a ``tools/recalibrate.py`` that consumes a historical ``results.tsv`` and refits ρ (PR #569), M (PR #558), and σ_local thresholds (PR #565). The data shape this PR enables is what makes that script possible.