### PR TITLE
feat(train): log final resid_lambdas / x0_lambdas — does this complexity actually do work?

### DIFF
--- a/train.py
+++ b/train.py
@@ -628,3 +628,13 @@ print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
 print(f"num_steps:        {step}")
 print(f"num_params_M:     {num_params / 1e6:.1f}")
 print(f"depth:            {DEPTH}")
+# Final values of the per-layer scalar mixing coefficients. Two ways to read
+# them: (a) if x0_lambdas converge to ~0 across all layers, the input-skip
+# mechanism is dead weight and the model collapses to a vanilla pre-norm
+# transformer at convergence; (b) if resid_lambdas stay ~1 across all layers,
+# those scalars are also dead weight. Non-trivial values (especially per-layer
+# variation) mean the rescaling is load-bearing and worth keeping. After
+# torch.compile, the parameters live on the wrapped _orig_mod.
+_m = getattr(model, "_orig_mod", model)
+print("resid_lambdas:    [" + ", ".join(f"{v:.3f}" for v in _m.resid_lambdas.detach().float().cpu().tolist()) + "]")
+print("x0_lambdas:       [" + ", ".join(f"{v:.3f}" for v in _m.x0_lambdas.detach().float().cpu().tolist()) + "]")


### PR DESCRIPTION
## Summary
Adds two lines to ``train.py``'s final summary:

```
resid_lambdas:    [1.000, 0.987, 1.014, 0.952, 1.083, 0.918, 1.157, 0.864]
x0_lambdas:       [0.123, 0.094, 0.076, 0.054, 0.041, 0.029, 0.018, 0.005]
```

(numbers above are illustrative formatting; real values come from converged training).

## Why this specifically
``resid_lambdas`` and ``x0_lambdas`` are learnable per-layer scalars on the residual path:

```python
# train.py, GPT.forward
x = self.transformer.wte(idx)
x = norm(x)
x0 = x
for i, block in enumerate(self.transformer.h):
    x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
    ...
```

Initialized to ``(1.0, 0.1)`` and trained with Adam at ``scalar_lr = 0.5``. The natural questions to ask, that the loop has no machinery for, are:

1. **Do they converge to non-trivial values, or stay near init?**
2. **Do values vary across layers, or are they uniform?**

The two answers settle different things:

| ``x0_lambdas[i]``  | ``resid_lambdas[i]`` | Reading                                                         |
| ------------------ | -------------------- | --------------------------------------------------------------- |
| ≈ 0 ∀i             | ≈ 1 ∀i               | **input-skip and rescaling are dead weight** — model collapses to vanilla pre-norm transformer at convergence; per-layer scalars are pure complexity tax. **Simplification candidate.** |
| Vary across i      | ≈ 1 ∀i               | input-skip is doing real per-layer work; resid rescaling isn't. Keep ``x0_lambdas``, drop ``resid_lambdas``. |
| ≈ 0 ∀i             | Vary across i        | Symmetric: keep resid, drop x0.                                 |
| Both vary          | Both vary            | Mechanism is fully load-bearing. Keep as-is.                    |

Right now the loop has no signal for which row of this table is true. The natural place for that signal is the final summary — log the converged vector for both, let the agent (or human) read it after a session.

## Why this matters specifically for the autoresearch loop
``program.md``'s ``Simplicity criterion`` says *"removing something and getting equal or better results is a great outcome — that's a simplification win."* But the agent has no information to *target* simplifications at — it can guess "let me try removing X" and run the experiment, but in a 5-minute time budget that's expensive. Two extra lines in the summary tell the agent which knobs are vestigial vs load-bearing *for free* — every existing run already produces this signal, we just don't read it.

This is a Feynman-style move: rather than guessing whether the complexity matters, **measure it**. If after 50 sessions the converged ``x0_lambdas`` vector consistently looks like ``[0, 0, ..., 0]``, the case for removing the input-skip mechanism becomes overwhelming.

## Implementation
4 lines (plus a 7-line explanatory comment). Stdlib only. Zero hot-path impact — runs once at the end of training. Accesses ``_orig_mod`` because ``model = torch.compile(model, dynamic=False)`` at line 508 wraps the original.

## How this composes
- **PR #571 (``loss_std_last_100``)**: another diagnostic that requires no extra runs.
- **PR #566 (RG scale-confirm)**: divergence in lambda values between d=8 and d=12 is itself a transferability signal — if d=12 converges to materially different lambdas, the mechanism is scale-dependent.
- **``program.md``'s Simplicity criterion**: this PR gives that criterion *an actual signal to act on*.

## Test plan
- [x] Verified format with a synthetic ``Stub`` module: prints clean `[1.000, 0.987, ...]` style with 3-decimal precision
- [x] ``_orig_mod`` access path is correct for ``torch.compile``-wrapped modules
- [x] No change to training behaviour or to ``val_bpb``; pure additional logging
- [x] Diff is +10 lines (2 print lines + 1 ``_m`` alias + 7-line explanatory comment)
- [ ] Optional follow-up: log lambdas for a kept long run to establish what *typical* converged values look like, so future agents have a reference point