### PR TITLE
Add MIT license file matching README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andrej Karpathy and autoresearch contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This adds a standalone MIT license file matching the existing README license section, which currently says:

```text
## License

MIT
```

I noticed GitHub does not currently detect a license for the repository, likely because there is no root `LICENSE` file. This PR is intended as a small housekeeping change so downstream forks and contributors can reference the license unambiguously.

I used `Copyright (c) 2026 Andrej Karpathy and autoresearch contributors` as the notice, but I am happy to adjust that line to whatever wording you prefer.

Validation:
- Confirmed the repository currently has no `LICENSE`, `LICENSE.md`, or `COPYING` file.
- Confirmed the README already states MIT.