### PR TITLE
Deep docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes are listed here in reverse chronological order. The repo's evolution is otherwise visible in `git log`; this file calls out user-facing or contract-affecting changes that an agent or maintainer should be aware of.
+
+## 2026-05-08
+
+### Documentation
+
+- Added a full `docs/` documentation set: architecture (with mermaid diagrams), getting-started guide, agent-workflow guide, reference pages for `prepare.py` / `train.py` / `results.tsv`, internals pages for the GPT model and `MuonAdamW`, operations pages for forking and analysis, and an agent-skills index.
+- Added `llms.txt` (concise LLM index) and `llms-full.txt` (single-file ingestion bundle) so LLM agents can navigate the docs without crawling the tree.
+- Added this `CHANGELOG.md`.
+- README updated to link the new docs set, `llms.txt`, and `llms-full.txt`.
+
+No code or contract changes — `prepare.py`, `train.py`, and `program.md` are unchanged.
+
+## Earlier history
+
+The repo was small and pre-CHANGELOG. Notable shifts from `git log`:
+
+- **Notable-forks section** added to README, with MacOS, MLX, Windows, and AMD ROCm forks linked.
+- **Forking guidance** added to README for tuning on smaller hardware (TinyStories dataset suggestion, `vocab_size`, `MAX_SEQ_LEN`, `DEPTH`, `WINDOW_PATTERN="L"`).
+- **Beginner's guide link** added to README for newcomers to neural networks.
+- **`results.tsv` made untracked** (`.gitignore`) and `program.md` updated to reflect this — the file now survives `git reset`.
+- **Agent loop hardening** in `program.md`: explicit "NEVER STOP" rule, explicit `> run.log 2>&1` redirection (no tee), explicit `tail -n 50 run.log` on crash, explicit timeout.
+- **`download_data` honors `--download-workers`** (was hardcoded to 8).
+- **NaN/exploding-loss fast-fail** added to `train.py`: `print("FAIL"); exit(1)` if loss is NaN or > 100.
+- **Guard against infinite loop when no training shards exist**: `make_dataloader` asserts `len(parquet_paths) > 0`.
+
+## Conventions
+
+- Append entries to the top, dated `YYYY-MM-DD`.
+- Group changes under headings like **Agent**, **Harness**, **Model**, **Documentation**, **Operations**.
+- For breaking changes, lead with **Breaking** and call out who is affected and what they need to do.
+- Cross-link the relevant doc page or PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ All notable changes are listed here in reverse chronological order. The repo's e
 - Added this `CHANGELOG.md`.
 - README updated to link the new docs set, `llms.txt`, and `llms-full.txt`.
 
-No code or contract changes — `prepare.py`, `train.py`, and `program.md` are unchanged.
+### Agent
+
+- `program.md`: added `llms.txt` to the in-scope files the agent reads during setup, so the docs tree is reachable from inside the loop.
+- `program.md`: added an **Exploration discipline** rule next to the simplicity criterion — after two consecutive experiments on the same axis, switch surfaces. Counters re-litigation of the same hyperparameter band.
+- `program.md`: the "out of ideas" line in **NEVER STOP** now points specifically at `docs/internals/model.md` and `docs/internals/optimizer.md` for surfaces to rotate through (init, polar-express coefficients, cautious-WD mask, value-embedding selection, window pattern, schedule shapes).
+- `docs/agent-workflow.md` and `llms-full.txt` synced to mirror the new program.md guidance.
+
+No harness changes — `prepare.py` and `train.py` are unchanged.
 
 ## Earlier history
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,23 @@ prepare.py      — constants, data prep + runtime utilities (do not modify)
 train.py        — model, optimizer, training loop (agent modifies this)
 program.md      — agent instructions
 pyproject.toml  — dependencies
+docs/           — full documentation set (architecture, reference, internals, ops)
+llms.txt        — concise LLM index
+llms-full.txt   — single-file documentation bundle for ingestion
+CHANGELOG.md    — append-only history
 ```
+
+## Documentation
+
+Full docs are in [`docs/`](docs/README.md). Quick links:
+
+- [Architecture](docs/architecture.md) — system overview with mermaid diagrams.
+- [Getting started](docs/getting-started.md) — install, prepare, run, launch the agent.
+- [Agent workflow](docs/agent-workflow.md) — experiment loop, keep/discard rules.
+- Reference: [`prepare.py`](docs/reference/prepare.md), [`train.py`](docs/reference/train.md), [`results.tsv`](docs/reference/results-tsv.md).
+- Internals: [GPT model](docs/internals/model.md), [`MuonAdamW`](docs/internals/optimizer.md).
+- Operations: [forking for smaller hardware](docs/operations/forking.md), [analyzing results](docs/operations/analysis.md).
+- LLM artifacts: [`llms.txt`](llms.txt), [`llms-full.txt`](llms-full.txt).
 
 ## Design choices
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Documentation
+
+Autoresearch is a small, self-contained harness for **autonomous LLM pretraining research**. A coding agent edits a single file (`train.py`), runs a fixed-budget training script, reads one metric (`val_bpb`), and either keeps the change or reverts. You wake up to a log of experiments and a (hopefully) better model.
+
+This documentation set explains the harness, the contract between human and agent, the model and optimizer internals, and how to operate or fork the project.
+
+## Read this first
+
+- [Architecture](architecture.md) — what the pieces are and how they fit, with diagrams.
+- [Getting started](getting-started.md) — install, prepare data, run the baseline, start the agent.
+- [Agent workflow](agent-workflow.md) — the experiment loop, keep/discard rules, what the agent can and cannot modify.
+
+## Reference
+
+Exact interface documentation, grounded in the code.
+
+- [`prepare.py`](reference/prepare.md) — constants, dataloader, `evaluate_bpb` (read-only contract).
+- [`train.py`](reference/train.md) — hyperparameter block, `GPTConfig`, `GPT` model, `MuonAdamW`, schedules, output summary.
+- [`results.tsv`](reference/results-tsv.md) — schema and semantics of the experiment log.
+
+## Internals
+
+For maintainers, forkers, and agents that want to make non-trivial changes.
+
+- [GPT model](internals/model.md) — block layout, attention details (RoPE, FA3, value residual, sliding windows), MLP, init, forward pass.
+- [`MuonAdamW`](internals/optimizer.md) — param-group split, AdamW step, Muon (polar-express orthogonalization, NorMuon, cautious WD), schedules.
+
+## Operations
+
+- [Forking for smaller hardware](operations/forking.md) — knobs to tune for non-H100 setups; pointers to maintained forks.
+- [Analyzing results](operations/analysis.md) — `analysis.ipynb` walkthrough, reading the running-best plot, archiving runs.
+
+## Agent skills
+
+- [Skill index](agent-skills.md) — the one canonical skill (`program.md`) and how to author changes.
+
+## LLM-friendly artifacts
+
+- [`llms.txt`](../llms.txt) — concise index for LLMs.
+- [`llms-full.txt`](../llms-full.txt) — single-file bundle of these docs for ingestion.
+
+## History
+
+- [`CHANGELOG.md`](../CHANGELOG.md) — append-only log of meaningful changes.
+
+## Quick orientation
+
+If you are…
+
+| You are… | Start with |
+|---|---|
+| A new user setting up the repo | [getting-started.md](getting-started.md) |
+| About to launch the agent | [agent-workflow.md](agent-workflow.md) and [`program.md`](../program.md) |
+| Writing or editing `train.py` ideas | [reference/train.md](reference/train.md), then [internals/model.md](internals/model.md) and [internals/optimizer.md](internals/optimizer.md) |
+| Porting to non-H100 hardware | [operations/forking.md](operations/forking.md) |
+| Reviewing a finished run | [operations/analysis.md](operations/analysis.md) |
+| An LLM agent | [`llms.txt`](../llms.txt) → [agent-skills.md](agent-skills.md) → [`program.md`](../program.md) |

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,0 +1,60 @@
+# Agent skills
+
+Autoresearch is structured as a single agent skill. The skill file is [`program.md`](../program.md) at the repo root. It tells the coding agent how to set up a run and how to operate the experiment loop.
+
+## Skill index
+
+| Skill | File | Trigger | What it does |
+|---|---|---|---|
+| **autoresearch experiment loop** | [`program.md`](../program.md) | Human prompts the agent in this repo with something like *"look at program.md and kick off a new experiment"*. | (1) Sets up a tagged branch, verifies cache, initializes `results.tsv`. (2) Runs LOOP FOREVER: edit `train.py` → commit → run → keep/discard → repeat. |
+
+There is exactly one skill today. The repo's design philosophy is that customization happens by editing `program.md`, not by adding more skills. If you need to introduce additional behavior, prefer extending `program.md` first.
+
+## When to use this skill
+
+Use it when the user wants to start (or continue) an autonomous experimentation run on this repo. Concretely:
+
+- They want to leave the agent running while they do something else, expecting a list of kept experiments at the end.
+- They've already done the one-time setup (`uv run prepare.py`) — or they're willing to do it as part of the skill's setup phase.
+- They have a single GPU available and `uv run train.py` works.
+
+## When *not* to use this skill
+
+- The user wants a one-off experiment, not an autonomous loop. Just edit `train.py` and run it directly.
+- Hardware setup (GPU, kernels, dependencies) hasn't been verified. Run the baseline manually first; see [getting-started.md](getting-started.md).
+- The user is working on the harness itself (`prepare.py`, `program.md`, the docs). The skill assumes those are stable.
+
+## Canonical docs the skill depends on
+
+`program.md` references these — keep them in sync if you change behavior:
+
+- [`README.md`](../README.md) — the agent reads it for context during setup.
+- [`prepare.py`](../prepare.py) — read-only contract.
+- [`train.py`](../train.py) — the file the agent edits.
+- [`docs/agent-workflow.md`](agent-workflow.md) — expanded explanation of the skill's loop.
+- [`docs/reference/results-tsv.md`](reference/results-tsv.md) — the file the agent appends to.
+
+## Authoring guidance for changing `program.md`
+
+Properties of the existing skill that matter:
+
+- **Concise.** It's loaded into every agent context. Don't bloat it.
+- **Procedural.** Setup is numbered steps. The loop is a numbered procedure with explicit `LOOP FOREVER`.
+- **Constraints up front.** "What you CAN do / CANNOT do" lists are explicit, not implicit.
+- **Stops only on interruption.** `program.md` says "NEVER STOP" deliberately — this is the most-violated rule when agents try to be polite. Keep it.
+- **No CLI invention.** The agent runs `uv run train.py > run.log 2>&1` and reads via `grep`. Don't add custom flags or wrappers; everything else should still work.
+
+When you change the skill:
+
+- Update [`docs/agent-workflow.md`](agent-workflow.md) so the human-facing explanation matches.
+- Update [`CHANGELOG.md`](../CHANGELOG.md) under the "Agent" section.
+
+## Multi-agent setups
+
+If you want several agents running on the same machine in parallel, give each its own:
+
+- Tag (`autoresearch/mar5-gpu0`, `autoresearch/mar5-gpu1`, …).
+- Working tree (use `git worktree add` so they don't fight over `results.tsv` and `train.py`).
+- GPU (`CUDA_VISIBLE_DEVICES=N`).
+
+The skill itself is single-threaded; coordination is the human's responsibility.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -65,6 +65,8 @@ The metric is `val_bpb` (validation bits-per-byte from `evaluate_bpb`). Lower is
 
 The simplicity criterion modifies #2: if the improvement is tiny (≪0.005 bpb) and adds substantial code complexity, the agent should *discard* it anyway. If a change *removes* code while matching or improving the metric, that is a clear keep.
 
+**Exploration discipline.** After two experiments on the same axis (e.g., learning-rate nudges), the agent should switch surfaces rather than continue stacking marginal wins on the same knob. The metric is noisy at small deltas, so repeated nudges in one direction are usually re-litigation. The internals docs ([model](internals/model.md), [optimizer](internals/optimizer.md)) enumerate surfaces worth rotating through: init scheme, polar-express coefficients, cautious-WD mask form, value-embedding selection, window pattern, schedule shapes. `program.md` codifies this as a soft rule.
+
 ## results.tsv schema
 
 Tab-separated, five columns. Tabs are required because descriptions often contain commas. The format is documented in detail in [reference/results-tsv.md](reference/results-tsv.md).

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,106 @@
+# Agent Workflow
+
+This page documents the contract between the human, the coding agent, and the repo. The canonical source is [`program.md`](../program.md). This page expands on it for human readers and future agents.
+
+## Roles
+
+- **Human**: writes `program.md`, decides when to start/stop, reviews results. Does not edit `train.py` while a run is active.
+- **Agent**: reads `program.md` and `README.md`, mutates `train.py`, commits each experiment, runs the script, decides keep/discard. Runs autonomously until interrupted.
+- **Repo**: enforces the contract. `prepare.py` is read-only. `evaluate_bpb` is the metric. The 5-minute budget is hard-coded.
+
+## Setup phase
+
+Triggered by a human prompt like "look at program.md and kick off a new experiment". The agent:
+
+1. **Proposes a tag** based on today's date (e.g., `mar5`). The branch `autoresearch/<tag>` must not exist yet.
+2. **Creates the branch** off `master`: `git checkout -b autoresearch/<tag>`.
+3. **Reads context**: `README.md`, `prepare.py`, `train.py`. The repo is small enough to keep all three in working memory.
+4. **Verifies the cache**: confirms `~/.cache/autoresearch/data/` has shards and `~/.cache/autoresearch/tokenizer/` has `tokenizer.pkl` plus `token_bytes.pt`. If anything is missing, it asks the human to run `uv run prepare.py`.
+5. **Initializes `results.tsv`** with just the header `commit\tval_bpb\tmemory_gb\tstatus\tdescription`.
+6. **Confirms with the human** before entering the loop.
+
+The first experiment is always the unmodified baseline so subsequent runs have something to compare against.
+
+## Experiment loop
+
+```
+LOOP FOREVER:
+  1. Inspect git state
+  2. Modify train.py with one experimental idea
+  3. git commit -m "<idea>"
+  4. uv run train.py > run.log 2>&1
+  5. grep '^val_bpb:|^peak_vram_mb:' run.log
+  6. If empty → tail run.log, decide whether to fix or skip
+  7. Append a row to results.tsv (keep | discard | crash)
+  8. If improved → branch advances, continue
+     If equal/worse → git reset to previous commit, continue
+```
+
+Key rules:
+
+- **Redirect, do not tee.** `> run.log 2>&1` keeps the agent's context window clean. Streaming step output (~hundreds of lines) would otherwise flood it.
+- **Read just the metric.** `grep '^val_bpb:|^peak_vram_mb:' run.log` is enough to make the keep/discard decision. Only fall back to `tail -n 50 run.log` on crashes.
+- **One experiment per commit.** The branch is the experiment trail; resets are how rejections are expressed.
+- **Never stop and ask.** The human may be asleep. The agent runs until interrupted, and "I'm out of ideas" is not a stopping condition — re-read the in-scope files, combine near-misses, try something more radical.
+
+## What can and cannot be modified
+
+| Can edit | Cannot edit |
+|---|---|
+| Anything in `train.py` | Anything in `prepare.py` |
+| `GPTConfig`, `GPT`, `MLP`, `CausalSelfAttention`, `Block` | `evaluate_bpb` |
+| `MuonAdamW`, polar-express coeffs, schedules | `MAX_SEQ_LEN`, `TIME_BUDGET`, `EVAL_TOKENS`, `VOCAB_SIZE` |
+| Hyperparameter block (lines ~432-451 of `train.py`) | The pinned val shard |
+| Adding/removing modules in `train.py` | `pyproject.toml` (no new dependencies) |
+
+If the agent wants to add a new dependency, that is a hard stop — it must be explicitly approved by the human.
+
+## Keep/discard decision
+
+The metric is `val_bpb` (validation bits-per-byte from `evaluate_bpb`). Lower is better. The decision tree:
+
+1. **Crash** (Python exception, OOM, NaN-loss fast-fail, run >10 min): log status `crash` with `val_bpb=0.000000`, `memory_gb=0.0`, `git reset --hard` to the previous commit, move on.
+2. **Improved** (`val_bpb` strictly lower than the current branch tip): log status `keep`, advance the branch.
+3. **Equal or worse**: log status `discard`, `git reset --hard HEAD~1`, move on.
+
+The simplicity criterion modifies #2: if the improvement is tiny (≪0.005 bpb) and adds substantial code complexity, the agent should *discard* it anyway. If a change *removes* code while matching or improving the metric, that is a clear keep.
+
+## results.tsv schema
+
+Tab-separated, five columns. Tabs are required because descriptions often contain commas. The format is documented in detail in [reference/results-tsv.md](reference/results-tsv.md).
+
+```
+commit	val_bpb	memory_gb	status	description
+a1b2c3d	0.997900	44.0	keep	baseline
+b2c3d4e	0.993200	44.2	keep	increase MATRIX_LR to 0.05
+c3d4e5f	1.005000	44.0	discard	switch MLP to GeLU
+d4e5f6g	0.000000	0.0	crash	double n_embd (OOM)
+```
+
+`results.tsv` is gitignored. It survives `git reset` because it's not part of any commit. If multiple agents share a working tree, they'll collide on this file — give each its own tag *and* its own working copy.
+
+## Failure modes the harness already catches
+
+- **NaN loss / loss > 100**: `train.py` exits with `print("FAIL"); exit(1)`. The `val_bpb:` line is absent → grep returns empty → agent treats it as a crash.
+- **No data shards**: `make_dataloader` asserts `len(parquet_paths) > 0`. The crash is informative.
+- **Time over-run**: the loop in `train.py` breaks once `total_training_time >= TIME_BUDGET`. The agent's external "kill if >10 min" rule is a backstop in case of compilation pathologies.
+
+## When to stop the agent manually
+
+- A bug in `train.py` that the agent keeps flailing against. Read its commits, `git reset` to a known-good experiment, and either prompt it with a hint or restart the loop.
+- A regression in throughput (look at `tok/sec` or `mfu` in `run.log`) that suggests the agent has driven the model into a slow regime.
+- Running out of disk for run logs or git objects.
+- You wake up.
+
+After stopping, you have a branch like `autoresearch/mar5` with one commit per kept experiment. That branch is the artifact of the run.
+
+## Tuning the agent itself
+
+`program.md` is the agent's "skill file". To change agent behavior, edit it. Things people commonly change:
+
+- The phrasing of the keep/discard rule (e.g., raise the bar to 0.001 bpb improvement).
+- The first-run instruction (some users want the agent to run a quick smoke test before the real baseline).
+- How aggressive the agent is about radical architectural changes vs. hyperparameter sweeps.
+- Adding a "research log" requirement that the agent writes a short journal entry per experiment.
+
+Treat `program.md` as the lever for steering exploration. The Python files are *not* the lever.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,142 @@
+# Architecture
+
+Autoresearch turns a small, self-contained LLM training setup into an autonomous research target. A coding agent (Claude / Codex / similar) edits a single file, runs a fixed-budget training script, reads a single metric, and either keeps the change or reverts. The repository's role is to define the *experiment harness* so the agent's actions are comparable, reversible, and persistent.
+
+This page explains the moving parts and how they interact. Reference pages cover exact interfaces.
+
+## High-level system
+
+```mermaid
+graph TD
+    Human["Human researcher"]
+    Agent["Coding agent (Claude / Codex)"]
+    Program["program.md (skill)"]
+    Train["train.py (model + loop)"]
+    Prepare["prepare.py (read-only harness)"]
+    Cache[("~/.cache/autoresearch/<br/>shards + tokenizer")]
+    Results["results.tsv (history)"]
+    Notebook["analysis.ipynb (review)"]
+
+    Human -->|edits| Program
+    Human -->|kicks off| Agent
+    Agent -->|reads| Program
+    Agent -->|edits + commits| Train
+    Train -->|imports| Prepare
+    Prepare -->|reads| Cache
+    Train -->|prints val_bpb| Agent
+    Agent -->|appends| Results
+    Human -->|reviews| Notebook
+    Notebook -->|reads| Results
+```
+
+Three roles, three contracts:
+
+- **Human** writes `program.md` and chooses the agent. Never edits `train.py` once the run starts.
+- **Agent** mutates `train.py`, commits, runs `uv run train.py`, decides keep/discard.
+- **Harness** (`prepare.py`) provides constants, dataloader, and the canonical `evaluate_bpb` metric. Read-only by contract.
+
+The `~/.cache/autoresearch/` directory is one-time setup. After `prepare.py` runs once, the data shards and tokenizer are reused across every experiment.
+
+## The experiment loop
+
+The agent's behavior is specified in [`program.md`](../program.md). It runs forever, advancing or rewinding a dedicated branch (`autoresearch/<tag>`).
+
+```mermaid
+flowchart TD
+    Start([Setup: branch + verify cache]) --> Modify[Tune train.py: pick an idea]
+    Modify --> Commit[git commit]
+    Commit --> Run["uv run train.py &gt; run.log 2&gt;&amp;1"]
+    Run --> Grep["grep '^val_bpb:|^peak_vram_mb:' run.log"]
+    Grep --> CheckEmpty{Empty?}
+    CheckEmpty -- yes --> Crash[tail run.log, log 'crash']
+    CheckEmpty -- no --> Improved{val_bpb improved?}
+    Improved -- yes --> Keep["Append 'keep' to results.tsv,<br/>advance branch"]
+    Improved -- no --> Discard["Append 'discard' to results.tsv,<br/>git reset back"]
+    Keep --> Modify
+    Discard --> Modify
+    Crash --> Modify
+```
+
+Key contract: **state is in git, not in memory**. Every experiment is a commit; reverting is `git reset`. The `results.tsv` file is a parallel log that survives resets because it is left untracked (see `.gitignore`).
+
+The 5-minute training budget is enforced by `train.py` itself using `TIME_BUDGET` from `prepare.py`. Compilation and warmup steps don't count — the timer starts after step 10.
+
+## Training pipeline
+
+Inside one experiment run, the data path is fixed and the model + optimizer are mutable.
+
+```mermaid
+flowchart LR
+    Shards[("Parquet shards<br/>climbmix-400b")] --> DocIter[_document_batches]
+    DocIter --> Tokenize["Tokenizer.encode<br/>(rustbpe → tiktoken)"]
+    Tokenize --> Pack["make_dataloader<br/>(BOS-aligned best-fit packing)"]
+    Pack --> GPU[("Pinned CPU buffer<br/>→ CUDA buffer")]
+    GPU --> Forward["GPT.forward<br/>(bf16 autocast)"]
+    Forward --> Loss[F.cross_entropy]
+    Loss --> Backward[backward + grad-accum]
+    Backward --> Step[MuonAdamW.step]
+    Step --> Forward
+    Forward -.->|after time budget| Eval["evaluate_bpb<br/>(fixed val shard)"]
+    Eval --> Print["Print val_bpb summary"]
+```
+
+What is fixed and what is fair game:
+
+| Layer | Fixed (do not edit) | Mutable (agent edits) |
+|---|---|---|
+| Data | shard list, val shard, `MAX_SEQ_LEN`, `EVAL_TOKENS` | none |
+| Tokenizer | `VOCAB_SIZE`, BPE merges, special tokens | none |
+| Dataloader | BOS-aligned best-fit packing in `prepare.py` | `DEVICE_BATCH_SIZE` (called as `B`) |
+| Model | `GPT.forward` is *defined* in train.py | every architectural detail |
+| Optimizer | `MuonAdamW` algorithm is in train.py | every hyperparameter, even the optimizer itself |
+| Eval | `evaluate_bpb` and val shard `shard_06542` | none |
+| Time | `TIME_BUDGET = 300s` | none |
+
+The simplicity criterion: a small win that adds significant complexity is worse than a slightly smaller win that is clean. See [`program.md`](../program.md) for the full keep/discard rubric.
+
+## File layout
+
+```
+autoresearch/
+├── README.md            # human-facing overview
+├── program.md           # agent skill: setup + experiment loop
+├── prepare.py           # constants, data prep, dataloader, evaluate_bpb (read-only contract)
+├── train.py             # model, optimizer, training loop (the only file the agent edits)
+├── analysis.ipynb       # plot results.tsv → progress.png
+├── progress.png         # teaser image (regenerated by the notebook)
+├── pyproject.toml       # dependencies + cu128 PyTorch index
+├── docs/                # this documentation set
+├── llms.txt             # concise LLM index
+├── llms-full.txt        # bundled docs for ingestion
+└── CHANGELOG.md         # append-only history
+```
+
+Untracked, runtime-only:
+
+```
+~/.cache/autoresearch/
+├── data/shard_*.parquet     # downloaded once
+└── tokenizer/
+    ├── tokenizer.pkl        # tiktoken encoding (pickled)
+    └── token_bytes.pt       # per-token-id byte length, used by evaluate_bpb
+
+results.tsv                  # per-experiment log, never committed
+run.log                      # last run's stdout + stderr
+```
+
+## Why these design choices
+
+- **One file to edit.** Diffs are small and reviewable. The agent can't accidentally change the metric.
+- **Fixed wall-clock budget.** The agent can't game the metric by training longer. Cross-experiment comparisons are valid.
+- **BPB instead of cross-entropy.** Bits-per-byte is vocab-size-independent; the agent could change the tokenizer (in principle) without making old runs incomparable. (`VOCAB_SIZE` is currently fixed by the harness, but BPB keeps the door open.)
+- **Pinned validation shard.** `shard_06542.parquet` is held out from training in `_document_batches` and `text_iterator`. Always the same val set, every experiment.
+- **Single GPU, single file, single metric.** Scope is the discipline; see the `prepare.py` constants block.
+
+Cross-references:
+
+- Setup and first run → [getting-started.md](getting-started.md)
+- Agent loop semantics → [agent-workflow.md](agent-workflow.md)
+- `prepare.py` API → [reference/prepare.md](reference/prepare.md)
+- `train.py` knobs → [reference/train.md](reference/train.md)
+- Model details → [internals/model.md](internals/model.md)
+- Optimizer details → [internals/optimizer.md](internals/optimizer.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,110 @@
+# Getting Started
+
+This page takes you from a fresh clone to "the agent is running experiments". It assumes a Linux box with one NVIDIA GPU. macOS / AMD users should jump to [operations/forking.md](operations/forking.md) and pick a fork from the [README's notable-forks list](../README.md#notable-forks).
+
+## Requirements
+
+- A single NVIDIA GPU. Default hyperparameters in `train.py` are tuned for an H100 (80 GB, BF16). Smaller cards work but need lowered `DEPTH`, `DEVICE_BATCH_SIZE`, `TOTAL_BATCH_SIZE`, and `MAX_SEQ_LEN` (see [forking](operations/forking.md)).
+- Python 3.10 or newer.
+- `uv` (project manager). Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- ~20 GB free disk for the default 10 training shards plus the validation shard. `prepare.py --num-shards -1` downloads all 6,542 shards (much larger).
+
+## Install dependencies
+
+```bash
+git clone https://github.com/karpathy/autoresearch
+cd autoresearch
+uv sync
+```
+
+`uv sync` resolves `pyproject.toml` against the cu128 PyTorch index. The `kernels` package fetches a Flash Attention 3 wheel on first use; on Hopper (H100) it pulls `varunneal/flash-attention-3`, on other capabilities `kernels-community/flash-attn3`.
+
+## One-time data preparation
+
+```bash
+uv run prepare.py
+```
+
+Default behavior:
+
+- Downloads 10 training shards plus the pinned validation shard `shard_06542.parquet` from `karpathy/climbmix-400b-shuffle` on Hugging Face.
+- Trains an 8,192-token BPE tokenizer with [`rustbpe`](https://crates.io/crates/rustbpe), wraps it as a `tiktoken` encoding, and pickles it.
+- Builds a `token_bytes.pt` lookup that records the UTF-8 byte length of every token id (used by `evaluate_bpb`).
+
+Everything lands under `~/.cache/autoresearch/`:
+
+```
+~/.cache/autoresearch/data/shard_00000.parquet ... shard_00009.parquet, shard_06542.parquet
+~/.cache/autoresearch/tokenizer/tokenizer.pkl
+~/.cache/autoresearch/tokenizer/token_bytes.pt
+```
+
+Common adjustments:
+
+- `--num-shards 4` to download fewer shards (faster, smaller disk).
+- `--num-shards -1` to download all 6,542 shards (only useful for very long-running setups).
+- `--download-workers 16` to parallelize downloads.
+
+Re-running `prepare.py` is safe; it skips shards that already exist and skips tokenizer training if `tokenizer.pkl` and `token_bytes.pt` are both present.
+
+## Verify the harness with one manual run
+
+Before pointing an agent at the repo, run training once yourself to confirm the GPU + kernels + dataloader all work:
+
+```bash
+uv run train.py
+```
+
+You should see compilation messages, then a streaming step counter, then a final summary:
+
+```
+---
+val_bpb:          0.997900
+training_seconds: 300.1
+total_seconds:    325.9
+peak_vram_mb:     45060.2
+mfu_percent:      39.80
+total_tokens_M:   499.6
+num_steps:        953
+num_params_M:     50.3
+depth:            8
+```
+
+If `val_bpb` prints, the harness is healthy. The exact number depends on the GPU. On H100 expect ~0.99 with the baseline.
+
+If the run crashes, look at the stack trace. Common issues:
+
+- *Flash Attention 3 wheel mismatch* — the `kernels` package downloads a wheel keyed on the GPU capability; non-Hopper cards get `kernels-community/flash-attn3`. If neither is available for your driver/CUDA combo, you'll need a fork that swaps in regular SDPA.
+- *OOM on smaller GPUs* — drop `DEVICE_BATCH_SIZE` (default 128) until peak VRAM fits.
+- *No parquet files found* — `prepare.py` didn't finish; re-run it.
+
+## Start an autonomous run
+
+Open the agent of your choice in this directory with permissions disabled (so it can edit/commit/run without prompts), then prompt:
+
+```
+Hi have a look at program.md and let's kick off a new experiment! let's do the setup first.
+```
+
+The agent reads [`program.md`](../program.md), proposes a tag, creates `autoresearch/<tag>`, verifies the cache, initializes `results.tsv`, runs the baseline, then loops forever until you stop it.
+
+What to expect:
+
+- One experiment ≈ 5 minutes of training plus ~30 s of compilation, eval, and overhead.
+- ~12 experiments per hour, ~100 over an 8-hour sleep.
+- The agent appends to `results.tsv` after every run — keep, discard, or crash. The file is left untracked so resets don't lose history.
+- `run.log` is overwritten every run.
+
+When you wake up:
+
+- `cat results.tsv` to see what was tried.
+- `git log --oneline autoresearch/<tag>` to see the kept changes (one commit each).
+- Open `analysis.ipynb` and run all cells to regenerate `progress.png` (running-best plot).
+
+See [agent-workflow.md](agent-workflow.md) for the full loop semantics and [operations/analysis.md](operations/analysis.md) for the review workflow.
+
+## Next steps
+
+- Iterate on `program.md` to change how the agent picks ideas, weights complexity, or rewinds. The default is intentionally minimal.
+- Try multiple agents on the same compute by giving each its own tag (`autoresearch/mar5-gpu0`, `autoresearch/mar5-gpu1`) and `CUDA_VISIBLE_DEVICES=N`.
+- Adapt for smaller hardware via [operations/forking.md](operations/forking.md).

--- a/docs/internals/model.md
+++ b/docs/internals/model.md
@@ -1,0 +1,193 @@
+# Internals: GPT model
+
+This page explains *what* the modules in `train.py` do, beyond the bare API listing in [reference/train.md](../reference/train.md). The model is a decoder-only transformer with a few non-standard pieces: alternating sliding-window attention, value embeddings (ResFormer-style), per-layer mixing scalars (`resid_lambdas`, `x0_lambdas`), and softcapped logits.
+
+## Overall data flow
+
+```mermaid
+flowchart TD
+    idx[Input ids B,T] --> wte["wte (Embedding, bf16)"]
+    wte --> norm0["RMSNorm"]
+    norm0 --> x0[(x0)]
+    norm0 --> mix["x = resid_λᵢ * x + x0_λᵢ * x0"]
+    mix --> block["Block i:<br/>attn (RoPE + GQA + FA3 + windowed)<br/>+ MLP (4x, ReLU²)"]
+    block -->|"loop n_layer times"| mix
+    block --> normf["RMSNorm"]
+    normf --> lmhead["lm_head (Linear, no bias)"]
+    lmhead --> softcap["softcap = 15 * tanh(logits / 15)"]
+    softcap --> ce["F.cross_entropy(targets)"]
+    valemb["value_embeds[i](idx)<br/>(only for selected layers)"] -.-> block
+```
+
+A few features that distinguish it from a vanilla GPT:
+
+- **`x0_lambdas`** lets every layer mix in the original token embedding (`x0`). The default initial value is `0.1`, so each layer starts with a small re-injection of the first-layer signal.
+- **`resid_lambdas`** scales the running residual. Default initial value `1.0`.
+- **Value embeddings** (`value_embeds`) are a separate `Embedding` table per *selected* layer, contributing directly to attention `V`. Selection rule: `has_ve(i, n_layer)` — alternating layers with the last layer always included.
+- **Sliding window attention** alternates short (`MAX_SEQ_LEN/2`) and long (`MAX_SEQ_LEN`) layers per the `WINDOW_PATTERN`. The last layer is always full.
+- **Logit softcap** at 15 (`15 * tanh(logits / 15)`) keeps logit magnitudes bounded.
+
+## Block layout
+
+```mermaid
+flowchart LR
+    in["x_in"] --> A["RMSNorm"]
+    A --> attn["CausalSelfAttention<br/>(q,k,v projections + RoPE + norm + FA3)"]
+    in --> add1((+))
+    attn --> add1
+    add1 --> B["RMSNorm"]
+    B --> mlp["MLP: 4× expand, ReLU², project"]
+    add1 --> add2((+))
+    mlp --> add2
+    add2 --> out["x_out"]
+```
+
+Pre-norm structure: norm before attention, norm before MLP, residual adds outside the norm. Both `c_proj` weights are zero-initialized so each block starts as the identity, easing initialization.
+
+## Attention
+
+Implementation is in `CausalSelfAttention.forward`. Key features:
+
+```python
+q = self.c_q(x).view(B, T, n_head, head_dim)
+k = self.c_k(x).view(B, T, n_kv_head, head_dim)
+v = self.c_v(x).view(B, T, n_kv_head, head_dim)
+
+if ve is not None:
+    ve = ve.view(B, T, n_kv_head, head_dim)
+    gate = 2 * sigmoid(ve_gate(x[..., :32]))   # per-head gate from first 32 channels of x
+    v = v + gate.unsqueeze(-1) * ve
+
+q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
+q, k = norm(q), norm(k)                         # QK-norm
+
+y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+y = c_proj(y.contiguous().view(B, T, -1))
+```
+
+| Feature | Notes |
+|---|---|
+| **GQA-ready** | `n_kv_head` defaults to `n_head` (no GQA). Setting `n_kv_head < n_head` enables grouped-query attention; the asserts require `n_head % n_kv_head == 0`. |
+| **RoPE** | `apply_rotary_emb` rotates the first half of head channels against the second half. `cos`/`sin` are precomputed for `sequence_len * 10` so the model has headroom to extrapolate. |
+| **QK-norm** | Plain RMS norm on Q and K before attention — stabilizes training, especially under bf16. |
+| **Flash Attention 3** | `kernels.get_kernel(...)` fetches a kernel package keyed by GPU capability. `window_size` is `(left, right)`; the model passes `(window, 0)` (causal). |
+| **Value residual (ResFormer)** | Selected layers add a value-embedding contribution to `V`. The gate is `2 * sigmoid(W_g * x[:, :, :32])` so it lives in `(0, 2)` and starts at `1.0` when `W_g` is zero-initialized. |
+
+`window_size` per layer comes from `_compute_window_sizes`:
+
+```python
+char_to_window = {"L": (long_window, 0), "S": (short_window, 0)}
+window_sizes = [char_to_window[pattern[i % len(pattern)]] for i in range(n_layer)]
+window_sizes[-1] = (long_window, 0)   # last layer always full
+```
+
+With `WINDOW_PATTERN="SSSL"` and `n_layer=8`, every fourth layer is full and the last layer is forced to full, giving `[S, S, S, L, S, S, S, L]`.
+
+## Value embeddings
+
+```python
+def has_ve(layer_idx, n_layer):
+    return layer_idx % 2 == (n_layer - 1) % 2
+```
+
+So with `n_layer=8`: VE on layers `[1, 3, 5, 7]`. The last layer always has VE. Selected layers each own a separate `Embedding(vocab_size, n_kv_head * head_dim)` table cast to bf16.
+
+The contribution path:
+
+1. Look up `ve = value_embeds[i](idx)` — same `idx` as the token embedding.
+2. Compute a per-head gate from the first 32 channels of the layer input: `gate = 2 * sigmoid(ve_gate(x[:, :, :32]))`, shape `(B, T, n_kv_head)`.
+3. Add `gate.unsqueeze(-1) * ve` to `V` before attention.
+
+`ve_gate` is initialized to zero, so initial `gate = 1.0` everywhere — the value residual starts neutral.
+
+## MLP
+
+```python
+class MLP:
+    c_fc:   Linear(n_embd, 4*n_embd)
+    c_proj: Linear(4*n_embd, n_embd)
+    forward: c_proj(F.relu(c_fc(x)).square())
+```
+
+Squared-ReLU activation. Both `c_fc` and `c_proj` are zero-initialized for `c_proj` (identity start) and uniform-initialized for `c_fc`.
+
+## Normalization
+
+`norm(x) = F.rms_norm(x, (x.size(-1),))` — no learnable scale or bias. Used:
+
+- After `wte` (the `x0` source).
+- Before attention and MLP in each block (pre-norm).
+- After the last block (final norm before `lm_head`).
+- On Q and K inside attention.
+
+## Initialization
+
+`init_weights()` runs on a `meta` model materialized via `to_empty`:
+
+- `wte` ~ N(0, 1).
+- `lm_head` ~ N(0, 0.001) — small, so initial logits are nearly zero.
+- All matrix params (`c_q`, `c_k`, `c_v`, `c_fc`) are uniform on `[-s, s]` with `s = sqrt(3) / sqrt(n_embd)`.
+- All projection params (`c_proj`) and `ve_gate.weight` are zero. Each block starts as the identity.
+- `resid_lambdas` ← 1.0, `x0_lambdas` ← 0.1.
+- Each value embedding table is uniform on `[-s, s]`.
+- After init, `wte` and every value embedding table are cast to `bfloat16`.
+
+The result is a model where the first forward pass produces ~zero logits, and the optimizer immediately gets useful gradients from the cross-entropy.
+
+## Forward pass
+
+```python
+def forward(self, idx, targets=None, reduction='mean'):
+    cos_sin = self.cos[:, :T], self.sin[:, :T]
+
+    x = self.transformer.wte(idx)
+    x = norm(x)
+    x0 = x
+
+    for i, block in enumerate(self.transformer.h):
+        x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
+        ve = self.value_embeds[str(i)](idx) if str(i) in self.value_embeds else None
+        x = block(x, ve, cos_sin, self.window_sizes[i])
+
+    x = norm(x)
+    logits = self.lm_head(x).float()
+    logits = 15 * torch.tanh(logits / 15)
+
+    if targets is not None:
+        return F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1),
+                                ignore_index=-1, reduction=reduction)
+    return logits
+```
+
+Notes:
+
+- `cos_sin` is sliced fresh every call. The buffer contains 10× capacity, so changing `MAX_SEQ_LEN` (don't!) is supported up to the buffer length.
+- `logits.float()` lifts to fp32 *before* the softcap, so the cross-entropy is numerically clean even though the rest of the model is bf16.
+- `reduction='none'` is the path used by `evaluate_bpb` to get per-token loss.
+
+## FLOP and parameter accounting
+
+`estimate_flops()` returns *FLOPs per token* for forward + backward:
+
+```python
+nparams_exclude = wte + value_embeds + resid_lambdas + x0_lambdas
+attn_flops = sum(12 * h * q * effective_seq for window in window_sizes)
+return 6 * (nparams - nparams_exclude) + attn_flops
+```
+
+The `6 *` factor is the standard 1× FWD + 2× BWD + 3× activation rule of thumb. Embeddings are excluded because they don't contribute MAC FLOPs at runtime in the same way (lookups, not matmuls). The attention term uses `effective_seq = min(window, T)` per layer to discount the savings from sliding windows.
+
+`num_scaling_params()` returns six entries: `wte`, `value_embeds`, `lm_head`, `transformer_matrices`, `scalars`, `total`. Used for the `num_params_M` line in the run summary.
+
+## What to try when modifying the model
+
+This is just a starting list — the agent should think for itself.
+
+- **Architecture**: GQA via `n_kv_head < n_head`, more or fewer VE layers (edit `has_ve`), different window patterns, different MLP expansion ratios, swap activation.
+- **Mixing scalars**: try removing `x0_lambdas` entirely if it's not pulling its weight; try a learned scalar per *channel* instead of per layer.
+- **Scaling**: tweak `ASPECT_RATIO`, `HEAD_DIM`, and `DEPTH` jointly. The `DEPTH * ASPECT_RATIO` rule is just a heuristic.
+- **Logit softcap**: try other softcap values, or remove it.
+- **Numerics**: cast more (or fewer) modules to bf16, try fp8 matmul in projections.
+- **Init**: change the `s = sqrt(3)/sqrt(n_embd)` scale factor or seed.
+
+Whatever you try, the keep/discard rule applies: if the change adds 50 lines for 0.001 bpb, discard.

--- a/docs/internals/optimizer.md
+++ b/docs/internals/optimizer.md
@@ -1,0 +1,182 @@
+# Internals: `MuonAdamW`
+
+`MuonAdamW` is a single optimizer that dispatches each parameter group to either AdamW or Muon depending on the `kind` field. AdamW handles embeddings, the LM head, and the per-layer scalars. Muon handles the 2-D matrices in transformer blocks.
+
+This page explains the algorithm, the param-group split, and the schedules that wrap it.
+
+## Param-group split
+
+`GPT.setup_optimizer` constructs the groups:
+
+```mermaid
+flowchart LR
+    setup["setup_optimizer()"] --> g1[adamw: lm_head]
+    setup --> g2[adamw: wte]
+    setup --> g3[adamw: value_embeds]
+    setup --> g4["adamw: resid_lambdas (lr × 0.01)"]
+    setup --> g5["adamw: x0_lambdas (β = 0.96, 0.95)"]
+    setup --> g6["muon: matrix_params shape A"]
+    setup --> g7["muon: matrix_params shape B"]
+    setup --> g8["muon: matrix_params shape ..."]
+```
+
+Important details:
+
+- AdamW LRs (`lm_head`, `wte`, `value_embeds`) are scaled by `(model_dim / 768)^-0.5`. The defaults were tuned at `model_dim = 768`.
+- `x0_lambdas` uses Adam betas `(0.96, 0.95)` — slightly higher β1 than the rest, to smooth out a noisy scalar.
+- Muon groups are **bucketed by parameter shape**. Every block exposes the same set of shapes (e.g., `c_q.weight`, `c_k.weight`, …), so each shape's tensors are stacked into a single batched update for vectorized `_step_muon`.
+- After construction, every group's `lr` is duplicated into `initial_lr`. Schedules then write `group["lr"] = initial_lr * lrm` each step.
+
+## AdamW step
+
+`adamw_step_fused` is `@torch.compile(dynamic=False, fullgraph=True)`:
+
+```python
+p.mul_(1 - lr * wd)                              # decoupled weight decay
+exp_avg.lerp_(grad, 1 - β1)                      # m = β1 m + (1-β1) g
+exp_avg_sq.lerp_(grad.square(), 1 - β2)          # v = β2 v + (1-β2) g²
+denom = (exp_avg_sq / (1 - β2**step)).sqrt() + eps
+p.add_(exp_avg / denom, alpha=-lr / (1 - β1**step))
+```
+
+Bias correction is computed inline; no extra state. All hyperparameters arrive as 0-D CPU tensors (`_adamw_lr_t`, `_adamw_beta1_t`, …) so changing them between steps doesn't trigger `torch.compile` recompilation.
+
+## Muon step
+
+`muon_step_fused` is the more interesting one. The pipeline per stacked-shape group:
+
+```mermaid
+flowchart TD
+    G[Stacked grads] --> N1["Nesterov-style:<br/>m = β m + (1-β) g<br/>g ← (1-β) g + β m"]
+    N1 --> NM["Normalize: X = g / (||g||_F * 1.02 + 1e-6)"]
+    NM --> NS["Polar Express orthogonalize:<br/>ns_steps iterations of<br/>X ← a X + B X (or X B)"]
+    NS --> NV["NorMuon:<br/>per-row (or per-col) variance<br/>second moment"]
+    NV --> RS["Rescale & re-normalize Frobenius"]
+    RS --> CW["Cautious mask:<br/>only update where g·p ≥ 0"]
+    CW --> WD["p ← p - lr * (g + wd * p * mask)"]
+```
+
+### Polar Express orthogonalization
+
+```python
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739,  -2.808917465908714,  0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685,  0.5060648178503393),
+    (3.285753657755655,  -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+]
+
+X = g / (||g||_F * 1.02 + 1e-6)        # normalize
+if g.size(-2) > g.size(-1):            # tall matrix → use X^T X
+    for a, b, c in polar_express_coeffs[:ns_steps]:
+        A = X.mT @ X
+        B = b * A + c * (A @ A)
+        X = a * X + X @ B
+else:                                   # wide matrix → use X X^T
+    for a, b, c in polar_express_coeffs[:ns_steps]:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+```
+
+This is a Newton–Schulz-style polynomial that drives the singular values of `X` toward 1 — i.e., approximate orthogonalization of the (normalized) gradient matrix. `ns_steps=5` uses all five coefficient triples. The "tall vs wide" branch keeps the inner product on the smaller dimension for compute efficiency.
+
+### NorMuon variance reduction
+
+After orthogonalization, NorMuon estimates and rescales the per-row (tall) or per-column (wide) variance:
+
+```python
+v_mean = g.float().square().mean(dim=red_dim, keepdim=True)   # red_dim = -1 (tall) or -2 (wide)
+v_norm_sq = v_mean.sum(...) * red_dim_size
+v_norm = v_norm_sq.sqrt()
+second_momentum_buffer.lerp_(v_mean, 1 - β2)
+step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
+scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+v_norm_new = scaled_sq_sum.sum(...).sqrt()
+final_scale = step_size * (v_norm / v_norm_new.clamp_min(1e-10))
+g = g * final_scale
+```
+
+The result: each row (or column) gets a different effective learning rate based on its EMA of squared values, then everything is renormalized so the Frobenius norm stays consistent across rows.
+
+### Cautious weight decay
+
+```python
+mask = (g * p) >= 0
+p.sub_(lr * g + lr * wd * p * mask)
+```
+
+Weight decay only applies where `g` and `p` agree in sign (i.e., where the update would move the parameter toward zero from the gradient's direction *and* the decay is also pushing it toward zero). This prevents WD from fighting the gradient on the channels where shrinkage isn't warranted.
+
+The Muon LR is also shape-scaled:
+
+```python
+self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1])**0.5)
+```
+
+Tall matrices get a larger LR than wide ones in the same group — compensates for the asymmetry in the orthogonalization step.
+
+## State tensors
+
+For each Muon shape-group:
+
+- `momentum_buffer`: `(num_params, *shape)` — Nesterov momentum.
+- `second_momentum_buffer`: `(num_params, shape[-2], 1)` if tall, else `(num_params, 1, shape[-1])` — NorMuon EMA.
+
+For each AdamW parameter:
+
+- `state['step']`: scalar Python int.
+- `state['exp_avg']`, `state['exp_avg_sq']`: full-shape tensors.
+
+## Schedules
+
+Three time-based schedules wrap the optimizer, all keyed off `progress = total_training_time / TIME_BUDGET`:
+
+```python
+def get_lr_multiplier(progress):
+    if progress < WARMUP_RATIO:                          # warmup
+        return progress / WARMUP_RATIO if WARMUP_RATIO > 0 else 1.0
+    elif progress < 1.0 - WARMDOWN_RATIO:                # plateau
+        return 1.0
+    else:                                                # warmdown to FINAL_LR_FRAC
+        cooldown = (1.0 - progress) / WARMDOWN_RATIO
+        return cooldown * 1.0 + (1 - cooldown) * FINAL_LR_FRAC
+
+def get_muon_momentum(step):                             # 0.85 → 0.95 over first 300 steps
+    frac = min(step / 300, 1)
+    return (1 - frac) * 0.85 + frac * 0.95
+
+def get_weight_decay(progress):                          # WEIGHT_DECAY → 0 linearly
+    return WEIGHT_DECAY * (1 - progress)
+```
+
+Each step the loop writes:
+
+```python
+for group in optimizer.param_groups:
+    group["lr"] = group["initial_lr"] * lrm
+    if group["kind"] == "muon":
+        group["momentum"] = muon_momentum
+        group["weight_decay"] = muon_weight_decay
+```
+
+Defaults (`WARMUP_RATIO=0.0`, `WARMDOWN_RATIO=0.5`, `FINAL_LR_FRAC=0.0`) give a "no-warmup, half-the-budget cooldown to zero" trapezoid. Changing those is one of the simpler experiments.
+
+## Why no recompilation
+
+The compiled `_step_*` functions take 0-D CPU tensors for every numeric hyperparameter. The optimizer holds these tensors as instance attributes (`self._adamw_lr_t`, …) and uses `.fill_()` to write the current step's value. From `torch.compile`'s perspective, the *tensor identities* don't change between steps, so it doesn't recompile when LRs or β values shift mid-run.
+
+This is what lets the schedules above be cheap.
+
+## Surface area for experimentation
+
+If you're modifying the optimizer:
+
+- The polar-express coefficients and `ns_steps` are easy to swap.
+- The cautious-WD mask `(g * p) >= 0` is one of several reasonable forms — `(g * p) > 0` or no mask are alternatives.
+- The shape-LR scaling `max(1, h/w)^0.5` is a heuristic.
+- The two AdamW betas (`(0.8, 0.95)` and `(0.96, 0.95)`) and the embedding/unembedding LR ratio are obvious knobs.
+- Replacing Muon entirely (e.g., with Shampoo or plain AdamW for matrices) is a valid experiment.
+
+The schedules in `get_lr_multiplier`, `get_muon_momentum`, and `get_weight_decay` are also fair game — they're just three plain Python functions.

--- a/docs/operations/analysis.md
+++ b/docs/operations/analysis.md
@@ -1,0 +1,116 @@
+# Analyzing results
+
+After a run, two artifacts matter:
+
+- `results.tsv` — every experiment the agent tried, with status and description.
+- `git log autoresearch/<tag>` — one commit per kept experiment, in order.
+
+`analysis.ipynb` (in the repo root) is a small notebook for turning `results.tsv` into a "running best" plot and a few summary tables. This page is a guide to using it and reading the output.
+
+## Quick run
+
+```bash
+uv run jupyter lab analysis.ipynb     # or your notebook tool of choice
+# Run all cells.
+```
+
+The notebook expects `results.tsv` in the current directory and produces `progress.png` next to it.
+
+## What the notebook does
+
+### 1. Load and clean
+
+```python
+df = pd.read_csv("results.tsv", sep="\t")
+df["val_bpb"]   = pd.to_numeric(df["val_bpb"], errors="coerce")
+df["memory_gb"] = pd.to_numeric(df["memory_gb"], errors="coerce")
+df["status"]    = df["status"].str.strip().str.upper()
+```
+
+Statuses are normalized to upper-case (`KEEP`, `DISCARD`, `CRASH`).
+
+### 2. Outcome counts
+
+```python
+counts = df["status"].value_counts()
+keep_rate = n_keep / (n_keep + n_discard)
+```
+
+A useful sanity check: the keep rate should be a small but non-zero fraction (a few percent is typical). Zero kept means the agent never found anything; close to 50% means the experiments are too easy and the metric is noisy.
+
+### 3. Kept-experiment list
+
+Plain text dump of every kept experiment with its `val_bpb` and one-line description, in chronological order. This is the human-readable changelog of the run.
+
+### 4. Running-best plot
+
+The headline visualization. Save target is `progress.png`.
+
+- X axis: experiment index.
+- Y axis: `val_bpb` (lower is better), zoomed to `[best - margin, baseline + margin]`.
+- Faint grey dots: discarded experiments at-or-below baseline.
+- Green dots with black edges: kept experiments.
+- Green step line: running minimum over the kept points.
+- Each kept dot is annotated with its description.
+
+The Y-axis is intentionally zoomed: you only see runs that came close to or beat the baseline. Far-worse discards are off-screen by design.
+
+### 5. Summary stats
+
+```
+Baseline val_bpb:  …
+Best val_bpb:      …
+Total improvement: …  (X.XX%)
+Best experiment:   <description>
+```
+
+Followed by a chronological list of every kept experiment showing cumulative effort.
+
+### 6. Top hits by delta
+
+Sorts kept experiments by per-step improvement (`prev_bpb - val_bpb`):
+
+```
+Rank   Delta       BPB         Description
+   1   +0.004700   0.993200    increase MATRIX_LR to 0.05
+   2   +0.001500   0.991700    add a 9th transformer layer
+   …
+```
+
+Cumulative delta should equal the total improvement.
+
+## Reading the run
+
+Three quick judgments to make:
+
+1. **Was the agent productive?** Look at the kept count and the running-best line. A flat-then-down step is healthy. Long flats are signs the agent got stuck — re-read its commits for the same idea on repeat.
+2. **Did it overfit complexity?** Read the kept descriptions. If they're all subtle hyperparameter nudges, the agent is in local-optimization mode. If they include architectural changes, it's exploring.
+3. **Were there many crashes?** A crash rate above ~10% probably means the agent is over-reaching VRAM or pushing too hard on numerical stability. Worth a look at whether `program.md` should ask for smaller-step changes.
+
+## Inspecting individual experiments
+
+To look at a specific commit:
+
+```bash
+git show <commit>                           # the diff
+git log -1 --format=%B <commit>             # the commit message
+```
+
+The agent's commit messages tend to be the same as the description — but if you want the *exact* code state of an experiment, `git checkout <commit>` works because every experiment is a real commit on the branch.
+
+## Comparing runs across machines
+
+`val_bpb` is comparable across runs *with the same `MAX_SEQ_LEN`, `EVAL_TOKENS`, `VOCAB_SIZE`, and the same val shard*. If you've forked for smaller hardware and changed any of those, you can compare *within* a tag but not across hardware.
+
+`mfu_percent` is always relative to H100 peak, even on other hardware — it's only meaningful as a relative trend within a single tag.
+
+## Re-running the analysis on archived runs
+
+`results.tsv` is gitignored. To preserve a run:
+
+```bash
+cp results.tsv results-mar5.tsv
+git add results-mar5.tsv && git commit -m "archive mar5 run"
+```
+
+Or stash it on a `results/` branch. Then in the notebook, change the `pd.read_csv` filename or copy the archived TSV back to `results.tsv` before running.

--- a/docs/operations/forking.md
+++ b/docs/operations/forking.md
@@ -1,0 +1,112 @@
+# Forking for smaller hardware
+
+The default `train.py` is tuned for a single H100 (80 GB, BF16) with Flash Attention 3. On smaller GPUs, MacBooks (MPS / MLX), or AMD cards, you'll need to change either *just the constants* or, in some cases, the kernel imports as well.
+
+If a maintained fork already exists for your platform, prefer it — see the [README's notable forks](../../README.md#notable-forks). Otherwise, the playbook below.
+
+## What stays the same
+
+- The contract from `prepare.py`: `MAX_SEQ_LEN` (handled per-platform — see below), `EVAL_TOKENS`, `TIME_BUDGET`, `evaluate_bpb`, the pinned val shard. If you change `MAX_SEQ_LEN` you accept that your `val_bpb` is no longer comparable to runs at 2048.
+- The agent contract from `program.md`: results.tsv schema, keep/discard rules, the LOOP FOREVER pattern.
+
+## What you tune
+
+These are all in `train.py` unless noted, plus three constants in `prepare.py` that are sometimes worth changing for *very* small setups.
+
+### Smaller-but-still-CUDA GPU (e.g., RTX 3090, 4090, 4080)
+
+Often you only need to drop batch and depth a bit:
+
+```python
+DEPTH = 6                # was 8
+DEVICE_BATCH_SIZE = 64   # was 128 — halve until peak VRAM fits
+TOTAL_BATCH_SIZE = 2**18 # was 2**19 — keep DEVICE_BATCH_SIZE * MAX_SEQ_LEN | TOTAL_BATCH_SIZE
+WINDOW_PATTERN = "L"     # was "SSSL" — banded attention is FA3-tuned, simpler full attention often runs faster on consumer cards
+```
+
+`TOTAL_BATCH_SIZE % (DEVICE_BATCH_SIZE * MAX_SEQ_LEN) == 0` is asserted in `train.py`. With `DEVICE_BATCH_SIZE=64` and `MAX_SEQ_LEN=2048` the per-fwd token count is `131_072`, so `TOTAL_BATCH_SIZE=2**18` gives `grad_accum_steps=2`.
+
+### Apple Silicon / MacOS
+
+Two options:
+
+1. **Use a maintained fork.** [`miolini/autoresearch-macos`](https://github.com/miolini/autoresearch-macos) and [`trevin-creator/autoresearch-mlx`](https://github.com/trevin-creator/autoresearch-mlx) handle the kernel and device-selection rewrites.
+2. **Adapt yourself.** You'll need to:
+   - Swap `kernels.get_kernel(...)` and `fa3.flash_attn_func` for `torch.nn.functional.scaled_dot_product_attention` (no FA3 on MPS/MLX).
+   - Replace the `cuda` device, pinned-memory, and `non_blocking` calls in `make_dataloader` with MPS/MLX equivalents.
+   - Drop the `H100_BF16_PEAK_FLOPS` constant or replace it with the platform's peak so `mfu_percent` is meaningful (it's a cosmetic stat — the metric is `val_bpb`).
+   - Use `--num-shards 1` or `2` since the data is mostly streaming I/O.
+
+### AMD ROCm
+
+[`andyluo7/autoresearch`](https://github.com/andyluo7/autoresearch) handles the ROCm path. You'll typically:
+
+- Install PyTorch with the ROCm wheel index instead of `cu128`.
+- Confirm Flash Attention 3 is available via `kernels-community/flash-attn3` for your GPU capability tuple.
+- Otherwise tune as for any smaller CUDA card.
+
+### CPU-only or tiny laptops
+
+The repo isn't designed for this, but it's instructive. The smallest sensible config:
+
+In `prepare.py` (you accept losing comparability):
+
+```python
+MAX_SEQ_LEN = 256          # was 2048 — total tokens/fwd shrinks 8×
+EVAL_TOKENS = 4 * 524288   # was 40 * 524288 — eval is shorter
+VOCAB_SIZE = 1024          # was 8192 — smaller vocab, faster tokenizer
+```
+
+Then re-run `prepare.py` so the tokenizer rebuilds at the new vocab.
+
+In `train.py`:
+
+```python
+DEPTH = 4
+ASPECT_RATIO = 32
+DEVICE_BATCH_SIZE = 8
+TOTAL_BATCH_SIZE = 2**14
+WINDOW_PATTERN = "L"
+```
+
+You'll also want to swap the FA3 import for `F.scaled_dot_product_attention`. Expect mediocre `val_bpb` because the model is genuinely small — the goal of a CPU run is to verify the pipeline works, not to win.
+
+### Tinier datasets for tiny models
+
+For very small models, ClimbMix is too entropic to learn anything in 5 minutes. Karpathy recommends `karpathy/tinystories-gpt4-clean`:
+
+- Replace the `BASE_URL` and `MAX_SHARD` in `prepare.py`.
+- Update `_document_batches`/`text_iterator` if the parquet schema differs (TinyStories typically has the same `text` column, so this often works as-is).
+- Re-run `prepare.py` to retokenize.
+
+Tinystories at small `MAX_SEQ_LEN` (256–512) and small `DEPTH` (2–4) actually produces coherent samples, which makes for a more rewarding tiny-hardware setup.
+
+## Quick reference: what each knob actually controls
+
+| Knob | Lives in | Effect on memory | Effect on throughput | Effect on metric |
+|---|---|---|---|---|
+| `MAX_SEQ_LEN` | `prepare.py` | linear (acts on K/V cache and activations) | linear | breaks comparability if changed |
+| `EVAL_TOKENS` | `prepare.py` | none | shifts overhead per run | smaller eval = noisier metric |
+| `VOCAB_SIZE` | `prepare.py` | linear in embedding tables | mild | breaks comparability; requires re-prep |
+| `DEPTH` | `train.py` | linear | linear | usually monotonic up to a point |
+| `ASPECT_RATIO` | `train.py` | quadratic (via `n_embd`) | quadratic | usually monotonic |
+| `HEAD_DIM` | `train.py` | small | depends on FA3 path | small unless head count gets weird |
+| `WINDOW_PATTERN` | `train.py` | none | "L" is simpler, "SSSL" saves attention compute on long-context layers | small but real |
+| `DEVICE_BATCH_SIZE` | `train.py` | linear | sub-linear (kernel utilization) | indirect (via `TOTAL_BATCH_SIZE` choice) |
+| `TOTAL_BATCH_SIZE` | `train.py` | none | none (just changes grad_accum) | classic LR/batch tradeoff |
+
+## Sanity check after any platform port
+
+Run the baseline once manually:
+
+```bash
+uv run train.py
+```
+
+Make sure:
+
+1. The script prints a `val_bpb:` line (not `FAIL`).
+2. Peak VRAM matches your card.
+3. `mfu_percent` is reasonable for your platform (the H100 baseline is irrelevant on other hardware).
+
+If those three are fine, the agent loop will work.

--- a/docs/reference/prepare.md
+++ b/docs/reference/prepare.md
@@ -1,0 +1,152 @@
+# Reference: `prepare.py`
+
+`prepare.py` has two jobs:
+
+1. **One-time setup** (run once via the CLI): download data shards, train a BPE tokenizer, build the `token_bytes` lookup.
+2. **Runtime utilities imported by `train.py`**: the `Tokenizer` class, the `make_dataloader` generator, the `evaluate_bpb` metric, and the fixed constants.
+
+By contract, **`prepare.py` is read-only during experiments** — agents must not modify it. Changing it would invalidate cross-experiment comparisons.
+
+## Constants
+
+These are the public knobs the rest of the system depends on. Defined at module level near the top of `prepare.py`.
+
+| Name | Value | Meaning |
+|---|---|---|
+| `MAX_SEQ_LEN` | `2048` | Context length used everywhere. `train.py` imports this as the model's `sequence_len`. |
+| `TIME_BUDGET` | `300` | Seconds of training (excluding compilation/warmup) before the loop exits. |
+| `EVAL_TOKENS` | `40 * 524288` (~21 M) | Number of tokens evaluated by `evaluate_bpb`. |
+| `CACHE_DIR` | `~/.cache/autoresearch` | Root for all persisted state. |
+| `DATA_DIR` | `<CACHE_DIR>/data` | Parquet shards live here. |
+| `TOKENIZER_DIR` | `<CACHE_DIR>/tokenizer` | `tokenizer.pkl` and `token_bytes.pt` live here. |
+| `BASE_URL` | `https://huggingface.co/datasets/karpathy/climbmix-400b-shuffle/resolve/main` | Source of shards. |
+| `MAX_SHARD` | `6542` | The dataset has shards `shard_00000.parquet` … `shard_06542.parquet`. |
+| `VAL_SHARD` | `MAX_SHARD` (= `6542`) | Pinned validation shard. Always held out. |
+| `VAL_FILENAME` | `f"shard_{VAL_SHARD:05d}.parquet"` | Filename derived from `VAL_SHARD`. |
+| `VOCAB_SIZE` | `8192` | Target vocab size including special tokens. |
+| `SPLIT_PATTERN` | GPT-4-style regex (with `\p{N}{1,2}` instead of `{1,3}`) | Pre-tokenization regex used by `rustbpe`. |
+| `SPECIAL_TOKENS` | `["<|reserved_0|>", …, "<|reserved_3|>"]` | Reserved tokens appended after the BPE vocab. |
+| `BOS_TOKEN` | `"<|reserved_0|>"` | Inserted at the start of every packed row. |
+
+`MAX_SEQ_LEN`, `TIME_BUDGET`, `EVAL_TOKENS`, and `VOCAB_SIZE` are the contract surface — agents and forks must not touch them.
+
+## CLI
+
+```bash
+uv run prepare.py [--num-shards N] [--download-workers M]
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--num-shards` | `10` | How many training shards to download. `-1` means "all 6,542". The validation shard is downloaded in addition. |
+| `--download-workers` | `8` | Parallel HTTP workers. Auto-clamped to the number of files actually needed. |
+
+Steps the CLI executes (in order):
+
+1. `download_data(num_shards, download_workers)` — fetch missing shards.
+2. `train_tokenizer()` — train BPE if `tokenizer.pkl` and `token_bytes.pt` aren't both present.
+
+Both steps are idempotent.
+
+## Module-level functions
+
+### `download_single_shard(index) -> bool`
+
+Downloads `shard_{index:05d}.parquet` to `DATA_DIR`. Skips if already present. Retries with exponential backoff up to 5 attempts, cleaning up the `.tmp` partial file between retries. Returns `True` on success.
+
+### `download_data(num_shards, download_workers=8)`
+
+Downloads shards `[0, num_shards)` plus `VAL_SHARD`, in parallel via `multiprocessing.Pool`. Prints progress and a final summary. Creates `DATA_DIR` if missing.
+
+### `list_parquet_files() -> list[str]`
+
+Returns sorted absolute paths of all `*.parquet` files in `DATA_DIR`, excluding `.tmp` partials. Used by the dataloader and tokenizer training.
+
+### `text_iterator(max_chars=1_000_000_000, doc_cap=10_000)`
+
+Generator that yields raw document strings from the **training split only** (val shard excluded). Each document is truncated to `doc_cap` characters and the generator stops once `max_chars` total characters have been yielded. Used by `train_tokenizer`.
+
+### `train_tokenizer()`
+
+Trains a BPE tokenizer with `rustbpe` over `text_iterator()`, then wraps it as a `tiktoken.Encoding` with the four `<|reserved_i|>` special tokens appended after the merge vocabulary. Saves:
+
+- `tokenizer.pkl` — pickled `tiktoken.Encoding`.
+- `token_bytes.pt` — `torch.int32` tensor of length `enc.n_vocab` where entry `i` is `len(enc.decode([i]).encode("utf-8"))`. Special tokens get length `0` so `evaluate_bpb` excludes them.
+
+Skips entirely if both files already exist. Asserts that at least 2 parquet files are present (1 train + 1 val). Includes a roundtrip sanity check on a fixed test string.
+
+### `_document_batches(split, tokenizer_batch_size=128)`
+
+Internal infinite generator over `(documents, epoch)` tuples. `split` is `"train"` or `"val"`. The val branch yields *only* `VAL_FILENAME`; the train branch yields every other shard.
+
+### `make_dataloader(tokenizer, B, T, split, buffer_size=1000) -> generator`
+
+Returns an infinite generator yielding `(inputs, targets, epoch)` tuples on CUDA.
+
+- `inputs` and `targets` are `torch.long` tensors of shape `(B, T)`.
+- Inputs and targets are offset by 1: `inputs = row[:-1]`, `targets = row[1:]`.
+- Every row starts with the BOS token id.
+- Documents are packed using **best-fit-decreasing**: the largest doc that fits the remaining slot is taken; if none fits, the shortest doc is cropped to fill exactly. This achieves 100% utilization with no padding.
+- The buffer is refilled to `buffer_size` documents whenever it drops below.
+- Internally allocates a pinned CPU buffer and a CUDA buffer once, then re-uses them.
+
+The dataloader is a public boundary: `train.py` uses it for both training (`split="train"`) and inside `evaluate_bpb` (`split="val"`).
+
+### `get_token_bytes(device="cpu") -> torch.Tensor`
+
+Loads `token_bytes.pt` to the requested device. `evaluate_bpb` calls it with `device="cuda"`.
+
+### `evaluate_bpb(model, tokenizer, batch_size) -> float`
+
+The fixed metric. **Do not modify.**
+
+```python
+@torch.no_grad()
+def evaluate_bpb(model, tokenizer, batch_size):
+    token_bytes = get_token_bytes(device="cuda")
+    val_loader = make_dataloader(tokenizer, batch_size, MAX_SEQ_LEN, "val")
+    steps = EVAL_TOKENS // (batch_size * MAX_SEQ_LEN)
+    total_nats = 0.0
+    total_bytes = 0
+    for _ in range(steps):
+        x, y, _ = next(val_loader)
+        loss_flat = model(x, y, reduction='none').view(-1)
+        y_flat = y.view(-1)
+        nbytes = token_bytes[y_flat]
+        mask = nbytes > 0          # exclude special tokens
+        total_nats += (loss_flat * mask).sum().item()
+        total_bytes += nbytes.sum().item()
+    return total_nats / (math.log(2) * total_bytes)
+```
+
+Properties:
+
+- Always `MAX_SEQ_LEN`-long contexts so different model configs evaluate identically.
+- Special tokens (`token_bytes == 0`) are masked out from both numerator and denominator.
+- Returns nats/byte → bits/byte via the `1/log(2)` factor.
+- Vocab-size-independent: the result is interpreted in bits per UTF-8 byte of the original text.
+
+`train.py` calls this once at the end of each run, inside the `bf16` autocast context.
+
+## `Tokenizer` class
+
+A thin wrapper around the pickled `tiktoken.Encoding`. `train.py` instantiates one via `Tokenizer.from_directory()` and passes it to `make_dataloader`.
+
+| Method | Purpose |
+|---|---|
+| `Tokenizer.from_directory(tokenizer_dir=TOKENIZER_DIR)` | Load `tokenizer.pkl` and return an instance. |
+| `get_vocab_size() -> int` | Returns `enc.n_vocab` (= `VOCAB_SIZE`). |
+| `get_bos_token_id() -> int` | Returns the encoded id of `BOS_TOKEN`. |
+| `encode(text, prepend=None, num_threads=8)` | Encodes a `str` or a `list[str]`. If `prepend` is given (id or string token), inserts it at the start of every output sequence. Uses `tiktoken`'s batched, threaded path for lists. |
+| `decode(ids) -> str` | Standard `tiktoken` decode. |
+
+The `Tokenizer` exists so `train.py` can stay independent of `tiktoken`'s exact API.
+
+## Where things break if you violate the contract
+
+- Editing `evaluate_bpb` or `EVAL_TOKENS`: cross-experiment metrics become incomparable.
+- Editing `MAX_SEQ_LEN`: changes the batch token budget and the rotary embedding range; old runs are no longer comparable.
+- Editing `VAL_SHARD`: contaminates val with prior train data — invalidates the metric.
+- Editing `VOCAB_SIZE` after the tokenizer is built: the model embedding shape will mismatch the saved tokenizer.
+
+The canonical fix for any of those is to regenerate the cache: delete `~/.cache/autoresearch/` and re-run `uv run prepare.py`.

--- a/docs/reference/results-tsv.md
+++ b/docs/reference/results-tsv.md
@@ -1,0 +1,81 @@
+# Reference: `results.tsv`
+
+The agent's experiment log. Append-only during a run, untracked by git so it survives `git reset`.
+
+## Schema
+
+Five columns, **tab-separated** (not CSV — descriptions often contain commas):
+
+| Column | Type | Meaning |
+|---|---|---|
+| `commit` | 7-char short SHA | The commit the experiment was run on. For crashes/discards this is the commit *before* the rollback. |
+| `val_bpb` | float, 6 decimals | Validation bits-per-byte from `evaluate_bpb`. `0.000000` for crashes. |
+| `memory_gb` | float, 1 decimal | Peak VRAM in GiB. `peak_vram_mb / 1024`. `0.0` for crashes. |
+| `status` | enum | `keep`, `discard`, or `crash`. |
+| `description` | free text | Short human-readable summary of the idea (no tabs). |
+
+## Header
+
+The very first line is the header. The agent writes it during setup before the first experiment:
+
+```
+commit	val_bpb	memory_gb	status	description
+```
+
+## Examples
+
+```
+commit	val_bpb	memory_gb	status	description
+a1b2c3d	0.997900	44.0	keep	baseline
+b2c3d4e	0.993200	44.2	keep	increase MATRIX_LR to 0.05
+c3d4e5f	1.005000	44.0	discard	switch MLP activation to GeLU
+d4e5f6g	0.000000	0.0	crash	double n_embd (OOM)
+e5f6g7h	0.992100	44.5	keep	add a 9th transformer layer
+f6g7h8i	0.992050	44.5	discard	tweak softcap to 12 (improvement too small)
+```
+
+## Status semantics
+
+- **`keep`** — `val_bpb` strictly improved over the previous kept value. The branch advances. The `commit` column matches `git rev-parse --short HEAD` after the keep.
+- **`discard`** — run completed but didn't improve enough (or violated the simplicity criterion). The agent runs `git reset --hard HEAD~1` after logging. The recorded `commit` is the *now-deleted* commit's short SHA, preserved here as the only trail of what was tried.
+- **`crash`** — Python exception, OOM, NaN/exploding loss, or run >10 minutes. `val_bpb=0.000000` and `memory_gb=0.0` are sentinels.
+
+## Why TSV and not CSV
+
+Descriptions like `"crank LR, drop momentum, swap activation"` contain commas. Tabs almost never appear in free-text descriptions, and they're easy to type and read. Pandas reads the file with `sep="\t"` (see `analysis.ipynb`).
+
+## Why untracked
+
+`.gitignore` includes `results.tsv` so:
+
+- `git reset --hard HEAD~1` after a discarded experiment doesn't lose the log.
+- `git checkout autoresearch/<other-tag>` doesn't blow away the in-progress run's history.
+- Multiple agents on different branches don't fight over commits to the same file.
+
+The flip side: if you want to share results across machines or back them up, copy the file by hand or commit it to a separate "results" branch.
+
+## Reading the file
+
+```python
+import pandas as pd
+df = pd.read_csv("results.tsv", sep="\t")
+df["val_bpb"]   = pd.to_numeric(df["val_bpb"], errors="coerce")
+df["memory_gb"] = pd.to_numeric(df["memory_gb"], errors="coerce")
+df["status"]    = df["status"].str.strip().str.upper()
+```
+
+`analysis.ipynb` does exactly this and produces:
+
+- A summary count of `KEEP` / `DISCARD` / `CRASH` rows.
+- A list of every kept experiment with its `val_bpb` and description.
+- The "running best" plot saved as `progress.png`.
+- A ranked table of kept hits by `delta` improvement.
+
+See [operations/analysis.md](../operations/analysis.md) for the analysis workflow.
+
+## Common pitfalls
+
+- **Mixing tabs and spaces.** If the agent ever writes spaces, `pandas` will parse the row as a single column. The agent's prompt explicitly says "tab-separated, NOT comma-separated"; if you customize `program.md`, keep this constraint.
+- **Newlines in descriptions.** Don't. One row per experiment.
+- **Recording the post-reset commit instead of the experiment's own commit.** Discards should record the experiment commit's SHA *before* `git reset`. Otherwise the description is orphaned from any git object.
+- **Forgetting to log crashes.** If an experiment crashed and you skip logging it, the next analysis run misattributes effort. Always append a `crash` row.

--- a/docs/reference/train.md
+++ b/docs/reference/train.md
@@ -1,0 +1,223 @@
+# Reference: `train.py`
+
+`train.py` is the only file the agent edits. It defines the model, the optimizer, the schedules, and the training loop. This page documents the surface as it exists today (i.e., the *baseline* the agent starts from). Internals — what each piece *does* — are split into [internals/model.md](../internals/model.md) and [internals/optimizer.md](../internals/optimizer.md).
+
+## CLI
+
+```bash
+uv run train.py
+```
+
+No flags. Configuration is by editing the constants block (see below). On startup, `train.py`:
+
+1. Imports `MAX_SEQ_LEN`, `TIME_BUDGET`, `Tokenizer`, `make_dataloader`, `evaluate_bpb` from `prepare.py`.
+2. Loads the tokenizer from `~/.cache/autoresearch/tokenizer/`.
+3. Builds the model on CUDA via `to_empty` + `init_weights`.
+4. Compiles it with `torch.compile(model, dynamic=False)`.
+5. Trains for `TIME_BUDGET` seconds (compilation/warmup excluded).
+6. Runs `evaluate_bpb` once.
+7. Prints a fixed summary block.
+
+## Hyperparameter block
+
+The block of module-level constants that controls a run. Lives near the bottom of `train.py` (around line 432). Everything in this block is fair game for the agent; the values listed are the H100 baseline.
+
+```python
+# Model architecture
+ASPECT_RATIO = 64        # model_dim = depth * ASPECT_RATIO
+HEAD_DIM = 128           # target head dimension for attention
+WINDOW_PATTERN = "SSSL"  # sliding window pattern: L=full, S=half context
+
+# Optimization
+TOTAL_BATCH_SIZE = 2**19 # ~524K tokens per optimizer step
+EMBEDDING_LR = 0.6       # learning rate for token embeddings (Adam)
+UNEMBEDDING_LR = 0.004   # learning rate for lm_head (Adam)
+MATRIX_LR = 0.04         # learning rate for matrix parameters (Muon)
+SCALAR_LR = 0.5          # learning rate for per-layer scalars (Adam)
+WEIGHT_DECAY = 0.2       # cautious weight decay for Muon
+ADAM_BETAS = (0.8, 0.95) # Adam beta1, beta2
+WARMUP_RATIO = 0.0       # fraction of time budget for LR warmup
+WARMDOWN_RATIO = 0.5     # fraction of time budget for LR warmdown
+FINAL_LR_FRAC = 0.0      # final LR as fraction of initial
+
+# Model size
+DEPTH = 8                # number of transformer layers
+DEVICE_BATCH_SIZE = 128  # per-device batch size (reduce if OOM)
+```
+
+### Architecture knobs
+
+| Constant | Default | Effect |
+|---|---|---|
+| `ASPECT_RATIO` | 64 | Sets `n_embd = DEPTH * ASPECT_RATIO`, then rounds up to a multiple of `HEAD_DIM`. With `DEPTH=8` and `HEAD_DIM=128` this yields `n_embd = 512` (depth × 64 = 512, already a multiple of 128). |
+| `HEAD_DIM` | 128 | Target attention head dimension. `n_head = n_embd // HEAD_DIM`. |
+| `WINDOW_PATTERN` | `"SSSL"` | One char per layer (cycled). `S` = half context (`MAX_SEQ_LEN/2 = 1024`), `L` = full context (`MAX_SEQ_LEN = 2048`). Last layer is always overridden to full. |
+| `DEPTH` | 8 | Number of transformer blocks. |
+| `DEVICE_BATCH_SIZE` | 128 | Sequences per micro-batch on the GPU. |
+
+### Optimization knobs
+
+| Constant | Default | Effect |
+|---|---|---|
+| `TOTAL_BATCH_SIZE` | `2**19` (524,288) tokens | Tokens per optimizer step. Must be divisible by `DEVICE_BATCH_SIZE * MAX_SEQ_LEN`. Determines `grad_accum_steps`. |
+| `EMBEDDING_LR` | 0.6 | LR for `wte` and value embeddings (AdamW group). Multiplied by `(n_embd/768)^-0.5`. |
+| `UNEMBEDDING_LR` | 0.004 | LR for `lm_head` (AdamW group). Same scaling. |
+| `MATRIX_LR` | 0.04 | LR for transformer matrices (Muon groups). Per-shape scaling described in [internals/optimizer.md](../internals/optimizer.md). |
+| `SCALAR_LR` | 0.5 | Base LR for the per-layer scalar groups. `resid_lambdas` uses `SCALAR_LR * 0.01`; `x0_lambdas` uses `SCALAR_LR`. |
+| `WEIGHT_DECAY` | 0.2 | Initial cautious weight decay for Muon groups. Decays linearly to zero over training. |
+| `ADAM_BETAS` | `(0.8, 0.95)` | `(β1, β2)` for AdamW groups (except `x0_lambdas`, which uses `(0.96, 0.95)`). |
+
+### Schedule knobs
+
+| Constant | Default | Effect |
+|---|---|---|
+| `WARMUP_RATIO` | 0.0 | Fraction of `TIME_BUDGET` used for linear LR warmup from 0 → 1. |
+| `WARMDOWN_RATIO` | 0.5 | Fraction of `TIME_BUDGET` used at the end for linear cooldown to `FINAL_LR_FRAC`. |
+| `FINAL_LR_FRAC` | 0.0 | LR multiplier at the very end of training. |
+
+Schedules are time-based, not step-based. `progress = total_training_time / TIME_BUDGET`. See `get_lr_multiplier`, `get_muon_momentum`, `get_weight_decay` below.
+
+## `GPTConfig` (dataclass)
+
+```python
+@dataclass
+class GPTConfig:
+    sequence_len: int = 2048
+    vocab_size: int = 32768       # overridden by tokenizer.get_vocab_size() at build
+    n_layer: int = 12             # overridden by DEPTH
+    n_head: int = 6               # overridden by build_model_config
+    n_kv_head: int = 6            # overridden by build_model_config
+    n_embd: int = 768             # overridden by build_model_config
+    window_pattern: str = "SSSL"  # overridden by WINDOW_PATTERN
+```
+
+Built at runtime by `build_model_config(depth)`:
+
+```python
+base_dim = depth * ASPECT_RATIO
+model_dim = ((base_dim + HEAD_DIM - 1) // HEAD_DIM) * HEAD_DIM
+num_heads = model_dim // HEAD_DIM
+GPTConfig(
+    sequence_len=MAX_SEQ_LEN, vocab_size=vocab_size,
+    n_layer=depth, n_head=num_heads, n_kv_head=num_heads,
+    n_embd=model_dim, window_pattern=WINDOW_PATTERN,
+)
+```
+
+`n_kv_head == n_head` by default — no GQA. Setting `n_kv_head < n_head` (with `n_head % n_kv_head == 0`) enables grouped-query attention; the asserts in `CausalSelfAttention.__init__` are the only constraint.
+
+## `GPT` model
+
+| Method | Purpose |
+|---|---|
+| `__init__(config)` | Builds modules and registers RoPE buffers. Allocates value-embedding tables only for the layers selected by `has_ve`. |
+| `init_weights()` | Initializes everything in the prescribed scheme (see [internals/model.md](../internals/model.md)). Casts `wte` and value embeddings to `bfloat16`. |
+| `_precompute_rotary_embeddings(seq_len, head_dim, base=10000, device=None)` | Returns `(cos, sin)` of shape `(1, seq_len, 1, head_dim/2)`, in bf16. Called with `seq_len = config.sequence_len * 10` so the model can extrapolate. |
+| `_compute_window_sizes(config)` | Translates `window_pattern` into a per-layer `(window, lookback)` tuple consumed by Flash Attention 3. Last layer is forced to `(long_window, 0)`. |
+| `estimate_flops()` | Returns FLOPs/token for forward+backward, used for MFU. |
+| `num_scaling_params()` | Returns a dict counting parameters by group (`wte`, `value_embeds`, `lm_head`, `transformer_matrices`, `scalars`, `total`). |
+| `setup_optimizer(unembedding_lr, embedding_lr, matrix_lr, weight_decay, adam_betas, scalar_lr)` | Builds and returns a `MuonAdamW` optimizer with the documented param-group split. Records each group's `initial_lr`. |
+| `forward(idx, targets=None, reduction='mean')` | Standard LM forward. Returns logits when `targets is None`, otherwise the cross-entropy loss. Logits are softcapped at 15 (`15 * tanh(logits / 15)`). |
+
+## `MuonAdamW` optimizer
+
+```python
+optimizer = MuonAdamW(param_groups)
+optimizer.step()  # dispatches each group to _step_adamw or _step_muon
+```
+
+Param groups have an extra `kind` key: `"adamw"` or `"muon"`. AdamW groups carry `(lr, betas, eps, weight_decay)`. Muon groups carry `(lr, momentum, ns_steps, beta2, weight_decay)`.
+
+The `setup_optimizer` factory creates:
+
+- One AdamW group per scalar/embedding role (`lm_head`, `wte`, `value_embeds`, `resid_lambdas`, `x0_lambdas`).
+- One Muon group **per unique parameter shape** in `transformer.h` — each block exposes the same set of shapes, so this stacks parameters across blocks for vectorized updates.
+
+The `lr` field on every group is overwritten each step by `lr * lrm` where `lrm = get_lr_multiplier(progress)`. The `initial_lr` stored at construction time is what the schedules multiply.
+
+`muon_step_fused` and `adamw_step_fused` are `@torch.compile(dynamic=False, fullgraph=True)` and take 0-D CPU tensors for hyperparameters to avoid recompilation when those values change between steps.
+
+## Schedule functions
+
+```python
+def get_lr_multiplier(progress: float) -> float:
+    # piecewise linear: 0 → 1 over [0, WARMUP_RATIO),
+    #                   1 over [WARMUP_RATIO, 1 - WARMDOWN_RATIO),
+    #                   1 → FINAL_LR_FRAC over [1 - WARMDOWN_RATIO, 1].
+
+def get_muon_momentum(step: int) -> float:
+    # 0.85 → 0.95 linearly over the first 300 steps, constant afterwards.
+
+def get_weight_decay(progress: float) -> float:
+    # WEIGHT_DECAY * (1 - progress). Linear decay to zero.
+```
+
+`progress` is `min(total_training_time / TIME_BUDGET, 1.0)`. `total_training_time` is wall-clock training time (per-iteration `dt`), accumulated only after step 10 — so compilation and the first few warmup iterations don't count.
+
+## Training loop
+
+```python
+while True:
+    for micro_step in range(grad_accum_steps):
+        with autocast_ctx:        # bf16 autocast
+            loss = model(x, y)
+        loss = loss / grad_accum_steps
+        loss.backward()
+        x, y, epoch = next(train_loader)
+
+    progress = ...
+    update group lrs, muon momentum, muon weight decay
+    optimizer.step()
+    model.zero_grad(set_to_none=True)
+
+    if NaN or loss > 100: print("FAIL"); exit(1)
+
+    if step > 10:
+        total_training_time += dt
+    if step > 10 and total_training_time >= TIME_BUDGET:
+        break
+
+    step += 1
+
+# eval
+model.eval()
+with autocast_ctx:
+    val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+```
+
+Notes:
+
+- `train_loader` is consumed before the optimizer step so the next batch is overlapping with the current step's compute (the dataloader prefetches via pinned + non-blocking copy).
+- `gc.collect(); gc.freeze(); gc.disable()` runs once at step 0 to suppress the ~500 ms pause Python's GC otherwise causes mid-step. A safety `gc.collect()` runs every 5,000 steps.
+- The fast-fail check on NaN / `loss > 100` is `train.py`-side, not in the harness.
+
+## Output summary
+
+After training, `train.py` prints exactly:
+
+```
+---
+val_bpb:          0.997900
+training_seconds: 300.1
+total_seconds:    325.9
+peak_vram_mb:     45060.2
+mfu_percent:      39.80
+total_tokens_M:   499.6
+num_steps:        953
+num_params_M:     50.3
+depth:            8
+```
+
+| Key | Source |
+|---|---|
+| `val_bpb` | `evaluate_bpb` return value. The metric. |
+| `training_seconds` | Sum of per-step `dt` after warmup. |
+| `total_seconds` | `time() - t_start`, includes startup, compilation, eval. |
+| `peak_vram_mb` | `torch.cuda.max_memory_allocated() / 1024 / 1024`. |
+| `mfu_percent` | `100 * flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / training_seconds / H100_BF16_PEAK_FLOPS`. Always relative to H100 peak — not a "this GPU's MFU". |
+| `total_tokens_M` | `step * TOTAL_BATCH_SIZE / 1e6`. |
+| `num_steps` | Total optimizer steps taken. |
+| `num_params_M` | `num_scaling_params()['total'] / 1e6`. |
+| `depth` | The `DEPTH` constant. |
+
+The agent reads only the `val_bpb` and `peak_vram_mb` lines via grep. Other keys are for human inspection.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,624 @@
+# autoresearch — full documentation bundle
+
+This file is the single-file documentation bundle for `autoresearch`. It is a stable, readable concatenation of the canonical docs intended for LLM ingestion. Sources are listed below; the ordering is fixed.
+
+Sources, in order:
+
+1. `README.md` — top-level overview.
+2. `program.md` — the agent skill file.
+3. `docs/README.md` — documentation index.
+4. `docs/architecture.md` — system architecture.
+5. `docs/getting-started.md` — setup and first run.
+6. `docs/agent-workflow.md` — experiment loop semantics.
+7. `docs/reference/prepare.md` — `prepare.py` API reference.
+8. `docs/reference/train.md` — `train.py` API reference.
+9. `docs/reference/results-tsv.md` — `results.tsv` schema.
+10. `docs/internals/model.md` — GPT model internals.
+11. `docs/internals/optimizer.md` — `MuonAdamW` internals.
+12. `docs/operations/forking.md` — forking guidance.
+13. `docs/operations/analysis.md` — analysis workflow.
+14. `docs/agent-skills.md` — skill index.
+
+Every section is delimited by `========== <path> ==========` markers so a downstream tool can split this back into files if needed.
+
+========== README.md ==========
+
+# autoresearch
+
+![teaser](progress.png)
+
+*One day, frontier AI research used to be done by meat computers in between eating, sleeping, having other fun, and synchronizing once in a while using sound wave interconnect in the ritual of "group meeting". That era is long gone. Research is now entirely the domain of autonomous swarms of AI agents running across compute cluster megastructures in the skies.*
+
+The idea: give an AI agent a small but real LLM training setup and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model. The training code here is a simplified single-GPU implementation of [nanochat](https://github.com/karpathy/nanochat). The core idea is that you're not touching any of the Python files like you normally would as a researcher. Instead, you are programming the `program.md` Markdown files that provide context to the AI agents and set up your autonomous research org.
+
+## How it works
+
+The repo is deliberately kept small and only really has three files that matter:
+
+- **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
+- **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc.
+- **`program.md`** — baseline instructions for one agent. Point your agent here and let it go.
+
+By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
+
+## Quick start
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # install uv
+uv sync                                            # install deps
+uv run prepare.py                                  # download data + train tokenizer (~2 min)
+uv run train.py                                    # one manual experiment (~5 min)
+```
+
+If those work, point your agent at the repo (with permissions disabled) and prompt: *"Hi have a look at program.md and let's kick off a new experiment! let's do the setup first."*
+
+## Documentation
+
+Full documentation is in [`docs/`](docs/README.md). Quick links:
+
+- [Architecture](docs/architecture.md), [Getting started](docs/getting-started.md), [Agent workflow](docs/agent-workflow.md)
+- Reference: [`prepare.py`](docs/reference/prepare.md), [`train.py`](docs/reference/train.md), [`results.tsv`](docs/reference/results-tsv.md)
+- Internals: [GPT model](docs/internals/model.md), [`MuonAdamW`](docs/internals/optimizer.md)
+- Operations: [Forking](docs/operations/forking.md), [Analysis](docs/operations/analysis.md)
+- Agent skills: [skill index](docs/agent-skills.md)
+
+LLM-friendly artifacts: [`llms.txt`](llms.txt), [`llms-full.txt`](llms-full.txt) (this file).
+
+## Notable forks
+
+- [miolini/autoresearch-macos](https://github.com/miolini/autoresearch-macos) (MacOS)
+- [trevin-creator/autoresearch-mlx](https://github.com/trevin-creator/autoresearch-mlx) (MacOS / MLX)
+- [jsegov/autoresearch-win-rtx](https://github.com/jsegov/autoresearch-win-rtx) (Windows)
+- [andyluo7/autoresearch](https://github.com/andyluo7/autoresearch) (AMD)
+
+## License
+
+MIT
+
+========== program.md ==========
+
+# autoresearch
+
+This is an experiment to have the LLM do its own research.
+
+## Setup
+
+To set up a new experiment, work with the user to:
+
+1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current master.
+3. **Read the in-scope files**: The repo is small. Read these files for full context: `README.md`, `prepare.py`, `train.py`.
+4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
+5. **Initialize results.tsv**: Create `results.tsv` with just the header row.
+6. **Confirm and go**: Confirm setup looks good, then start the loop.
+
+## Experimentation
+
+Each experiment runs for a **fixed 5-minute time budget** on a single GPU. Launch with `uv run train.py`.
+
+**You CAN**: modify `train.py` — architecture, optimizer, hyperparameters, training loop, batch size, model size, anything.
+
+**You CANNOT**: modify `prepare.py`, install new packages, or modify the eval harness (`evaluate_bpb`).
+
+**Goal**: lowest `val_bpb`. VRAM is a soft constraint. Simpler is better — a small win that adds ugly complexity is not worth it; deleting code while matching the metric is a clear keep.
+
+**First run**: always the unmodified baseline.
+
+## Output format
+
+```
+---
+val_bpb:          0.997900
+training_seconds: 300.1
+total_seconds:    325.9
+peak_vram_mb:     45060.2
+mfu_percent:      39.80
+total_tokens_M:   499.6
+num_steps:        953
+num_params_M:     50.3
+depth:            8
+```
+
+Extract the metric: `grep "^val_bpb:" run.log`.
+
+## Logging results
+
+Log to `results.tsv` (tab-separated, NOT comma — commas break in descriptions):
+
+```
+commit	val_bpb	memory_gb	status	description
+a1b2c3d	0.997900	44.0	keep	baseline
+b2c3d4e	0.993200	44.2	keep	increase LR to 0.04
+c3d4e5f	1.005000	44.0	discard	switch to GeLU
+d4e5f6g	0.000000	0.0	crash	double model width (OOM)
+```
+
+Status: `keep`, `discard`, or `crash`. `results.tsv` is gitignored — do not commit it.
+
+## The experiment loop
+
+LOOP FOREVER:
+
+1. Look at git state.
+2. Tune `train.py` with one experimental idea.
+3. `git commit`.
+4. `uv run train.py > run.log 2>&1` (redirect — do NOT use tee).
+5. `grep "^val_bpb:\|^peak_vram_mb:" run.log`.
+6. Empty grep ⇒ run crashed: `tail -n 50 run.log`, decide fix vs skip.
+7. Append a row to `results.tsv`.
+8. If `val_bpb` improved, advance the branch. Otherwise `git reset --hard HEAD~1`.
+
+**Timeout**: kill any run that exceeds 10 minutes; treat as crash.
+
+**NEVER STOP**: the user may be asleep. Do not pause to ask "should I keep going?". Run until manually interrupted.
+
+========== docs/README.md ==========
+
+(See `docs/README.md` in the repo. The browsable index points to every section listed below.)
+
+========== docs/architecture.md ==========
+
+# Architecture
+
+Autoresearch turns a small, self-contained LLM training setup into an autonomous research target. A coding agent edits a single file, runs a fixed-budget training script, reads a single metric, and either keeps the change or reverts.
+
+## High-level system
+
+Three roles, three contracts:
+
+- **Human** writes `program.md` and chooses the agent. Never edits `train.py` once a run starts.
+- **Agent** mutates `train.py`, commits, runs `uv run train.py`, decides keep/discard.
+- **Harness** (`prepare.py`) provides constants, dataloader, and the canonical `evaluate_bpb` metric. Read-only by contract.
+
+Mermaid (system overview):
+
+```mermaid
+graph TD
+    Human["Human"] --> Program["program.md"]
+    Human --> Agent["Coding agent"]
+    Agent --> Program
+    Agent --> Train["train.py"]
+    Train --> Prepare["prepare.py"]
+    Prepare --> Cache[("~/.cache/autoresearch")]
+    Train --> Agent
+    Agent --> Results["results.tsv"]
+    Human --> Notebook["analysis.ipynb"]
+    Notebook --> Results
+```
+
+## Experiment loop
+
+```
+LOOP FOREVER:
+  edit train.py → git commit → uv run train.py > run.log → grep val_bpb
+  if improved: keep, advance branch
+  if equal/worse: discard, git reset --hard HEAD~1
+  if empty (crash): log crash, git reset
+```
+
+State lives in git. Every experiment is a commit. `results.tsv` is gitignored so it survives resets.
+
+## Training pipeline (one experiment run)
+
+Parquet shards → `_document_batches` → `Tokenizer.encode` → `make_dataloader` (BOS-aligned best-fit packing, pinned CPU → CUDA) → `GPT.forward` (bf16 autocast) → cross-entropy → backward → `MuonAdamW.step` → repeat until `TIME_BUDGET` → `evaluate_bpb` → print `val_bpb`.
+
+## Fixed vs. mutable
+
+| Layer | Fixed | Mutable |
+|---|---|---|
+| Data | shard list, val shard, `MAX_SEQ_LEN`, `EVAL_TOKENS` | none |
+| Tokenizer | `VOCAB_SIZE`, BPE merges | none |
+| Dataloader | packing logic | `DEVICE_BATCH_SIZE` |
+| Model | none — `GPT` is in `train.py` | every detail |
+| Optimizer | none — `MuonAdamW` is in `train.py` | every hyperparameter |
+| Eval | `evaluate_bpb`, val shard | none |
+| Time | `TIME_BUDGET = 300s` | none |
+
+## File layout
+
+```
+prepare.py     — read-only harness
+train.py       — the only file the agent edits
+program.md     — the agent skill
+analysis.ipynb — review notebook
+docs/          — this documentation set
+llms.txt       — concise LLM index
+llms-full.txt  — bundled docs
+CHANGELOG.md   — append-only history
+~/.cache/autoresearch/  — data shards + tokenizer (untracked)
+results.tsv             — experiment log (untracked)
+run.log                 — last run's stdout+stderr (untracked)
+```
+
+========== docs/getting-started.md ==========
+
+# Getting Started
+
+Linux + single NVIDIA GPU is the supported path. Other platforms: see forking notes.
+
+## Requirements
+
+- Single NVIDIA GPU (defaults tuned for H100 80 GB BF16).
+- Python ≥ 3.10.
+- `uv`: `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- ~20 GB free disk for the default 10 training shards + 1 val shard.
+
+## Install
+
+```bash
+git clone https://github.com/karpathy/autoresearch
+cd autoresearch
+uv sync
+```
+
+`uv sync` resolves against the cu128 PyTorch index. `kernels` fetches Flash Attention 3 wheels at first use.
+
+## Prepare data
+
+```bash
+uv run prepare.py                  # default: 10 shards + val shard, train BPE
+uv run prepare.py --num-shards 4   # smaller download
+uv run prepare.py --num-shards -1  # all 6,542 shards
+```
+
+Outputs: `~/.cache/autoresearch/data/shard_*.parquet`, `~/.cache/autoresearch/tokenizer/{tokenizer.pkl,token_bytes.pt}`.
+
+Re-running is safe (skips existing shards and existing tokenizer).
+
+## Verify
+
+```bash
+uv run train.py
+```
+
+Expect a final summary block ending with `val_bpb: …`. On H100 the baseline is ~0.99.
+
+Common issues: Flash Attention 3 wheel mismatch, OOM (drop `DEVICE_BATCH_SIZE`), no parquet files (re-run prepare).
+
+## Start the agent
+
+Open the agent in this directory with permissions disabled. Prompt:
+
+> Hi have a look at program.md and let's kick off a new experiment! let's do the setup first.
+
+The agent reads `program.md`, creates `autoresearch/<tag>`, runs the baseline, and loops. ~12 experiments/hour, ~100 over an 8-hour sleep. Wakes-up review: `cat results.tsv`, `git log --oneline autoresearch/<tag>`, run `analysis.ipynb`.
+
+========== docs/agent-workflow.md ==========
+
+# Agent Workflow
+
+Roles:
+
+- **Human**: writes `program.md`, decides start/stop, reviews. Doesn't edit `train.py` while running.
+- **Agent**: reads `program.md` + `README.md`, mutates `train.py`, commits, runs, decides keep/discard. Runs autonomously until interrupted.
+- **Repo**: enforces — `prepare.py` is read-only, `evaluate_bpb` is the metric, 5-minute budget is hard-coded.
+
+Setup phase:
+
+1. Propose tag (e.g., `mar5`); branch `autoresearch/<tag>` must not exist.
+2. `git checkout -b autoresearch/<tag>` off `master`.
+3. Read `README.md`, `prepare.py`, `train.py`.
+4. Verify cache (`~/.cache/autoresearch/data/`, `tokenizer.pkl`, `token_bytes.pt`).
+5. Init `results.tsv` with header.
+6. Confirm with human; first run is the unmodified baseline.
+
+Loop:
+
+```
+LOOP FOREVER:
+  inspect git state
+  modify train.py with one idea
+  git commit
+  uv run train.py > run.log 2>&1
+  grep '^val_bpb:|^peak_vram_mb:' run.log
+  if empty → tail run.log; fix or skip
+  append row to results.tsv (keep | discard | crash)
+  improved → advance branch; else → git reset --hard HEAD~1
+```
+
+Rules: redirect (no tee), one experiment per commit, never pause to ask "should I continue?", never add deps without human approval.
+
+Keep/discard:
+- **Crash** (exception, OOM, NaN-fast-fail, >10 min) → `crash`, `val_bpb=0.000000`, reset.
+- **Improved** → `keep`, advance branch. But discard if the win is tiny and the code is ugly.
+- **Equal/worse** → `discard`, reset. *Removing* code while matching the metric is a clear keep.
+
+`results.tsv` is gitignored. Multi-agent setups need separate worktrees + tags + GPUs.
+
+Failure modes the harness already catches: NaN/`loss > 100` → `print("FAIL"); exit(1)`; missing shards → assert in `make_dataloader`; over-time → loop break.
+
+To change agent behavior, edit `program.md`. The Python files are not the lever.
+
+========== docs/reference/prepare.md ==========
+
+# Reference: prepare.py
+
+Two jobs: one-time setup CLI, plus runtime utilities imported by `train.py`. Read-only contract.
+
+## Constants
+
+| Name | Value | Meaning |
+|---|---|---|
+| `MAX_SEQ_LEN` | 2048 | context length |
+| `TIME_BUDGET` | 300 | training seconds (excludes warmup) |
+| `EVAL_TOKENS` | 40 × 524288 | tokens evaluated by `evaluate_bpb` |
+| `CACHE_DIR` | `~/.cache/autoresearch` | cache root |
+| `DATA_DIR` | `<cache>/data` | parquet shards |
+| `TOKENIZER_DIR` | `<cache>/tokenizer` | tokenizer.pkl + token_bytes.pt |
+| `BASE_URL` | climbmix-400b-shuffle on HF | dataset source |
+| `MAX_SHARD` | 6542 | last shard index |
+| `VAL_SHARD` | `MAX_SHARD` | pinned val shard |
+| `VOCAB_SIZE` | 8192 | including 4 reserved special tokens |
+| `BOS_TOKEN` | `<\|reserved_0\|>` | start of every packed row |
+
+## CLI
+
+`uv run prepare.py [--num-shards N] [--download-workers M]`. Default `N=10`, `M=8`. Idempotent.
+
+## Functions
+
+- `download_single_shard(idx)`: 5-attempt retry with backoff.
+- `download_data(num_shards, download_workers=8)`: parallel pool.
+- `list_parquet_files()`: sorted absolute paths.
+- `text_iterator(max_chars, doc_cap)`: training-split-only doc generator.
+- `train_tokenizer()`: rustbpe + tiktoken, saves `tokenizer.pkl` and `token_bytes.pt`.
+- `_document_batches(split, batch_size=128)`: infinite `(docs, epoch)` generator.
+- `make_dataloader(tokenizer, B, T, split, buffer_size=1000)`: yields `(inputs, targets, epoch)` on CUDA. BOS-aligned best-fit packing, 100% utilization. Pinned CPU buffer + CUDA buffer reused.
+- `get_token_bytes(device)`: load `token_bytes.pt`.
+- `evaluate_bpb(model, tokenizer, batch_size)`: nats/byte → bits/byte. Excludes special tokens. Always uses `MAX_SEQ_LEN`. **Do not modify.**
+
+## Tokenizer class
+
+`Tokenizer.from_directory()`, `.get_vocab_size()`, `.get_bos_token_id()`, `.encode(text, prepend=None)`, `.decode(ids)`. Wraps a pickled `tiktoken.Encoding`.
+
+Violating the contract (editing `evaluate_bpb`, `MAX_SEQ_LEN`, `EVAL_TOKENS`, `VOCAB_SIZE`, `VAL_SHARD`) breaks cross-experiment comparability. Fix: `rm -rf ~/.cache/autoresearch && uv run prepare.py`.
+
+========== docs/reference/train.md ==========
+
+# Reference: train.py
+
+The only file the agent edits. CLI: `uv run train.py` (no flags).
+
+## Hyperparameter block (mutable)
+
+```
+ASPECT_RATIO = 64        # n_embd = depth * 64, rounded up to multiple of HEAD_DIM
+HEAD_DIM = 128
+WINDOW_PATTERN = "SSSL"  # S=half context, L=full; last layer always full
+TOTAL_BATCH_SIZE = 2**19 # 524288 tokens/step
+EMBEDDING_LR = 0.6
+UNEMBEDDING_LR = 0.004
+MATRIX_LR = 0.04
+SCALAR_LR = 0.5          # x0_lambdas uses this; resid_lambdas uses *0.01
+WEIGHT_DECAY = 0.2       # cautious WD for Muon, decays to 0
+ADAM_BETAS = (0.8, 0.95) # x0_lambdas overrides to (0.96, 0.95)
+WARMUP_RATIO = 0.0
+WARMDOWN_RATIO = 0.5
+FINAL_LR_FRAC = 0.0
+DEPTH = 8
+DEVICE_BATCH_SIZE = 128
+```
+
+`TOTAL_BATCH_SIZE % (DEVICE_BATCH_SIZE * MAX_SEQ_LEN) == 0` is asserted.
+
+## GPTConfig
+
+Fields: `sequence_len`, `vocab_size`, `n_layer`, `n_head`, `n_kv_head`, `n_embd`, `window_pattern`. Built at runtime by `build_model_config(DEPTH)`. `n_kv_head == n_head` by default (no GQA).
+
+## GPT methods
+
+- `init_weights()`: explicit init scheme, casts `wte` and value embeddings to bf16.
+- `_precompute_rotary_embeddings(seq_len, head_dim)`: `(cos, sin)` shape `(1, seq_len, 1, head_dim/2)`, bf16. Buffers sized at `sequence_len * 10`.
+- `_compute_window_sizes(config)`: `(window, lookback)` per layer, last forced to full.
+- `estimate_flops()`: FLOPs/token (fwd+bwd).
+- `num_scaling_params()`: per-group counts.
+- `setup_optimizer(...)`: builds `MuonAdamW` with `dmodel_lr_scale = (model_dim/768)^-0.5` applied to AdamW groups.
+- `forward(idx, targets, reduction)`: returns logits or cross-entropy. Logits softcapped at 15, lifted to fp32 before cross-entropy.
+
+## MuonAdamW
+
+Param-group dispatch on `kind == 'adamw' | 'muon'`. AdamW groups: lm_head, wte, value_embeds, resid_lambdas (lr × 0.01), x0_lambdas. Muon groups: bucketed by parameter shape across `transformer.h`. Both inner steps are `@torch.compile(dynamic=False, fullgraph=True)`. Hyperparameters arrive as 0-D CPU tensors so the compiled graph doesn't recompile when LRs change between steps.
+
+## Schedules (time-based, `progress = total_training_time / TIME_BUDGET`)
+
+```
+get_lr_multiplier(progress) — piecewise linear: warmup → 1 → cooldown to FINAL_LR_FRAC
+get_muon_momentum(step)    — 0.85 → 0.95 over first 300 steps
+get_weight_decay(progress) — WEIGHT_DECAY * (1 - progress)
+```
+
+## Training loop
+
+`for grad_accum_steps: forward → backward (next batch prefetched) → optimizer.step → zero_grad`. NaN / loss > 100 → `print("FAIL"); exit(1)`. `step > 10` is when `total_training_time` starts accumulating (skip compilation). `gc.disable()` after step 0; safety `gc.collect()` every 5000 steps. Loop breaks when `total_training_time >= TIME_BUDGET`.
+
+## Output keys
+
+`val_bpb` (the metric), `training_seconds`, `total_seconds`, `peak_vram_mb`, `mfu_percent` (always vs H100 BF16 peak), `total_tokens_M`, `num_steps`, `num_params_M`, `depth`. Agent reads only `val_bpb` and `peak_vram_mb`.
+
+========== docs/reference/results-tsv.md ==========
+
+# Reference: results.tsv
+
+Tab-separated, untracked, append-only during a run.
+
+Schema:
+
+| col | type | meaning |
+|---|---|---|
+| `commit` | 7-char SHA | the experiment's commit (preserved even after a discard reset) |
+| `val_bpb` | float | `evaluate_bpb` output, `0.000000` for crashes |
+| `memory_gb` | float | `peak_vram_mb / 1024`, `0.0` for crashes |
+| `status` | enum | `keep` / `discard` / `crash` |
+| `description` | free text | one line, no tabs, no newlines |
+
+Header line first:
+```
+commit\tval_bpb\tmemory_gb\tstatus\tdescription
+```
+
+Tabs not commas — descriptions contain commas. Untracked so `git reset` doesn't lose history. For multi-agent setups give each agent its own worktree.
+
+Pandas read: `pd.read_csv("results.tsv", sep="\t")`.
+
+Pitfalls: spaces instead of tabs, newlines in descriptions, recording the post-reset SHA on a discard, forgetting to log crashes.
+
+========== docs/internals/model.md ==========
+
+# Internals: GPT model
+
+Decoder-only transformer with: `x0_lambdas` (per-layer mixin of the input embedding), `resid_lambdas` (per-layer residual scale), value embeddings (ResFormer-style, alternating layers + last), alternating sliding-window attention, softcapped logits.
+
+## Block
+
+`x = norm(x); attn(x, ve, cos_sin, window) → +residual; x = norm(x); mlp(x) → +residual`. `c_proj` weights zero-initialized → block starts as identity.
+
+## Attention
+
+```
+q,k,v = c_q(x), c_k(x), c_v(x) reshaped to (B, T, n_head_or_kv, head_dim)
+if value_embeds present:
+    gate = 2 * sigmoid(ve_gate(x[..., :32]))   # per-head gate from first 32 channels
+    v = v + gate.unsqueeze(-1) * ve
+q, k = apply_rotary_emb(q, cos, sin); q, k = norm(q), norm(k)   # RoPE + QK-norm
+y = fa3.flash_attn_func(q, k, v, causal=True, window_size=(window, 0))
+y = c_proj(y.contiguous().view(B, T, -1))
+```
+
+`window_size` per layer from `_compute_window_sizes`. Default `WINDOW_PATTERN="SSSL"` with `n_layer=8` ⇒ `[S,S,S,L,S,S,S,L]`. `S = MAX_SEQ_LEN/2 = 1024`, `L = MAX_SEQ_LEN = 2048`.
+
+`has_ve(layer_idx, n_layer) = (layer_idx % 2) == ((n_layer - 1) % 2)`. With `n_layer=8`: VE on layers `[1, 3, 5, 7]`. Last layer always has VE. `ve_gate.weight` zero-init ⇒ initial gate = 1.0 (neutral).
+
+## MLP
+
+`c_fc(x).square_relu() → c_proj`. Squared ReLU. 4× expand. `c_proj` zero-init.
+
+## Norm
+
+`norm(x) = F.rms_norm(x, (x.size(-1),))` — no learnable scale/bias.
+
+## Init
+
+- `wte` ~ N(0, 1); `lm_head` ~ N(0, 0.001).
+- All `c_q`, `c_k`, `c_v`, `c_fc` uniform on `[-s, s]` with `s = sqrt(3) * n_embd^-0.5`.
+- All `c_proj` and `ve_gate.weight` zero.
+- `resid_lambdas` ← 1.0; `x0_lambdas` ← 0.1.
+- `wte` and value embeddings cast to bf16.
+
+## Forward
+
+```
+x = wte(idx); x = norm(x); x0 = x
+for i in layers:
+    x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+    ve = value_embeds[str(i)](idx) if i has VE else None
+    x = block(x, ve, cos_sin, window_sizes[i])
+x = norm(x)
+logits = lm_head(x).float()
+logits = 15 * tanh(logits / 15)
+return F.cross_entropy(logits, targets, reduction=reduction)  # or logits if no targets
+```
+
+## FLOP/param accounting
+
+`estimate_flops` excludes `wte`, `value_embeds`, `resid_lambdas`, `x0_lambdas` from the `6 * params` term and adds `12 * h * q * effective_seq` per layer (with `effective_seq = min(window, T)`). `num_scaling_params` returns `wte`, `value_embeds`, `lm_head`, `transformer_matrices`, `scalars`, `total`.
+
+========== docs/internals/optimizer.md ==========
+
+# Internals: MuonAdamW
+
+`MuonAdamW` dispatches param groups by `kind` field. AdamW for embeddings/lm_head/scalars. Muon for transformer matrices, bucketed by shape across blocks (vectorized batched update).
+
+## Group split (from `setup_optimizer`)
+
+- AdamW: `lm_head`, `wte`, `value_embeds`, `resid_lambdas` (lr × 0.01), `x0_lambdas` (betas `(0.96, 0.95)`).
+- Muon: one group per unique shape in `transformer.h`. `lr` further scaled by `max(1, h/w)^0.5` per shape.
+- AdamW LRs scaled by `(model_dim/768)^-0.5`.
+
+## AdamW step
+
+Decoupled WD (`p *= 1 - lr*wd`), then EMAs `m, v`, then `p -= (lr / (1 - β1^step)) * m / (sqrt(v / (1 - β2^step)) + eps)`.
+
+## Muon step
+
+1. Nesterov: `m = β m + (1-β) g; g = (1-β) g + β m`.
+2. Normalize: `X = g / (||g||_F * 1.02 + 1e-6)`.
+3. Polar Express orthogonalization (5 hard-coded coefficient triples; `ns_steps=5` uses all). Tall vs wide branch: tall ⇒ `A = X.mT @ X; X = aX + X @ (bA + cA²)`. Wide ⇒ `A = X @ X.mT; X = aX + (bA + cA²) @ X`.
+4. NorMuon variance reduction: `v_mean` over `red_dim`, EMA → `step_size = rsqrt`, rescale to preserve Frobenius norm.
+5. Cautious WD: `mask = (g * p) >= 0; p -= lr * (g + wd * p * mask)`.
+
+State per Muon shape-group: stacked `momentum_buffer (num_params, *shape)` and `second_momentum_buffer (num_params, h, 1)` or `(num_params, 1, w)` depending on aspect.
+
+## Schedules
+
+```
+lrm = warmup(progress) | 1.0 | cooldown(progress, FINAL_LR_FRAC)
+muon_momentum(step) = 0.85 + (0.95 - 0.85) * min(step/300, 1)
+muon_weight_decay(progress) = WEIGHT_DECAY * (1 - progress)
+```
+
+Each step: `group["lr"] = group["initial_lr"] * lrm`; Muon groups also receive new `momentum` and `weight_decay`. 0-D CPU tensor inputs to compiled inner steps prevent `torch.compile` recompilation when those values change.
+
+## Surface for experiments
+
+Coefficients in `polar_express_coeffs`, `ns_steps`, the cautious mask form, the `max(1, h/w)^0.5` LR scaling, AdamW betas, embedding/unembedding LR ratios, and the three schedule functions.
+
+========== docs/operations/forking.md ==========
+
+# Forking for smaller hardware
+
+Defaults are H100 (80 GB BF16) + Flash Attention 3. For other platforms either use a maintained fork or adapt yourself.
+
+What stays: contract from `prepare.py` (`MAX_SEQ_LEN`, `EVAL_TOKENS`, `TIME_BUDGET`, `evaluate_bpb`, val shard) and from `program.md`.
+
+Smaller CUDA (3090/4090): drop `DEPTH` (e.g., 6), halve `DEVICE_BATCH_SIZE`, halve `TOTAL_BATCH_SIZE`, set `WINDOW_PATTERN="L"`.
+
+MacOS / Apple Silicon: prefer existing forks. Otherwise: replace `kernels.get_kernel`/`fa3.flash_attn_func` with `F.scaled_dot_product_attention`, swap `cuda` device + pinned-memory in `make_dataloader`, drop `H100_BF16_PEAK_FLOPS` (cosmetic).
+
+AMD ROCm: install ROCm PyTorch wheels, confirm Flash Attention 3 availability via `kernels-community/flash-attn3`.
+
+CPU / tiny: edit `prepare.py` (`MAX_SEQ_LEN=256`, `EVAL_TOKENS=4*524288`, `VOCAB_SIZE=1024`), re-run prepare, set `DEPTH=4`, `ASPECT_RATIO=32`, `DEVICE_BATCH_SIZE=8`, `TOTAL_BATCH_SIZE=2**14`, `WINDOW_PATTERN="L"`, swap to SDPA. Use TinyStories (`karpathy/tinystories-gpt4-clean`) for visible coherence.
+
+Sanity: `uv run train.py` should print a real `val_bpb`, peak VRAM should match the card, MFU is informational only.
+
+========== docs/operations/analysis.md ==========
+
+# Analyzing results
+
+`results.tsv` + `git log autoresearch/<tag>` are the artifacts. `analysis.ipynb` plots `progress.png`.
+
+Notebook flow:
+
+1. Load with `pd.read_csv("results.tsv", sep="\t")`, normalize statuses to upper-case.
+2. Counts per status; keep rate.
+3. List of every kept experiment with `val_bpb` and description.
+4. Running-best plot: faint grey dots = discards near baseline, green dots = keeps with annotated descriptions, green step line = running min. Y-axis zoomed to `[best - margin, baseline + margin]`. Saves `progress.png`.
+5. Summary stats (baseline, best, total improvement).
+6. Top hits by per-step delta improvement.
+
+Reading the run: productivity (running-best slope), exploration vs exploitation (kept descriptions), crash rate (>10% suggests over-reach).
+
+Comparing across machines: `val_bpb` is comparable only with the same `MAX_SEQ_LEN`, `EVAL_TOKENS`, `VOCAB_SIZE`, val shard. `mfu_percent` is always vs H100 peak.
+
+Archiving: `cp results.tsv results-mar5.tsv`, commit on a separate branch, or stash externally.
+
+========== docs/agent-skills.md ==========
+
+# Agent skills
+
+One canonical skill: `program.md`. Triggers on a human prompt like *"look at program.md and kick off a new experiment"*.
+
+Use this skill when: the user wants an autonomous loop, hardware is verified, single GPU.
+
+Don't use this skill when: one-off experiment, hardware unverified, or the user is editing the harness/docs themselves.
+
+Authoring `program.md`:
+
+- Concise (loaded into every agent context).
+- Procedural (numbered steps for setup, numbered steps for the loop).
+- Constraints up front (CAN/CANNOT lists).
+- "NEVER STOP" rule preserved — most-violated rule otherwise.
+- No CLI invention; everything is `uv run train.py > run.log 2>&1` + grep.
+
+Multi-agent: separate worktrees + tags + GPUs. The skill itself is single-threaded.
+
+========== END ==========

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -87,7 +87,7 @@ To set up a new experiment, work with the user to:
 
 1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
 2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current master.
-3. **Read the in-scope files**: The repo is small. Read these files for full context: `README.md`, `prepare.py`, `train.py`.
+3. **Read the in-scope files**: The repo is small. Read these files for full context: `README.md`, `prepare.py`, `train.py`, plus `llms.txt` as a map into `docs/` if you need deeper detail.
 4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row.
 6. **Confirm and go**: Confirm setup looks good, then start the loop.
@@ -101,6 +101,8 @@ Each experiment runs for a **fixed 5-minute time budget** on a single GPU. Launc
 **You CANNOT**: modify `prepare.py`, install new packages, or modify the eval harness (`evaluate_bpb`).
 
 **Goal**: lowest `val_bpb`. VRAM is a soft constraint. Simpler is better — a small win that adds ugly complexity is not worth it; deleting code while matching the metric is a clear keep.
+
+**Exploration discipline**: prefer ideas you have not tried recently. After two consecutive experiments on the same axis, switch surfaces (architecture, optimizer internals, schedules, init, window pattern, value-embedding selection). `docs/internals/model.md` and `docs/internals/optimizer.md` enumerate surfaces.
 
 **First run**: always the unmodified baseline.
 
@@ -150,7 +152,7 @@ LOOP FOREVER:
 
 **Timeout**: kill any run that exceeds 10 minutes; treat as crash.
 
-**NEVER STOP**: the user may be asleep. Do not pause to ask "should I keep going?". Run until manually interrupted.
+**NEVER STOP**: the user may be asleep. Do not pause to ask "should I keep going?". Run until manually interrupted. If out of ideas, re-read `docs/internals/model.md` and `docs/internals/optimizer.md` for surfaces you haven't tried, combine previous near-misses, or try more radical architectural changes.
 
 ========== docs/README.md ==========
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,47 @@
+# autoresearch
+
+> Single-GPU, single-file harness for autonomous LLM pretraining research. A coding agent edits `train.py`, runs a fixed 5-minute training budget, reads `val_bpb`, and keeps or reverts. The repo defines the contract: `prepare.py` is read-only, `evaluate_bpb` is the metric, `program.md` is the agent skill.
+
+The repo is intentionally tiny: three substantive files (`prepare.py`, `train.py`, `program.md`) and a docs set. Anything not in `train.py` is harness — agents must not edit it. The agent loop is documented in `program.md` and expanded in `docs/agent-workflow.md`.
+
+## Start here
+
+- [README](README.md): top-level project story, install, quickstart, notable forks.
+- [docs index](docs/README.md): map of all documentation.
+- [Architecture](docs/architecture.md): system overview with mermaid diagrams.
+- [Getting started](docs/getting-started.md): install, data prep, baseline, launch agent.
+- [Agent workflow](docs/agent-workflow.md): the experiment loop, keep/discard rules, what's mutable.
+
+## Reference
+
+- [prepare.py reference](docs/reference/prepare.md): constants (`MAX_SEQ_LEN`, `TIME_BUDGET`, `EVAL_TOKENS`, `VOCAB_SIZE`), `Tokenizer`, `make_dataloader`, `evaluate_bpb`. **Read-only contract.**
+- [train.py reference](docs/reference/train.md): hyperparameter block, `GPTConfig`, `GPT` model, `MuonAdamW`, schedules, output summary keys.
+- [results.tsv reference](docs/reference/results-tsv.md): schema (`commit`, `val_bpb`, `memory_gb`, `status`, `description`), semantics, why TSV and untracked.
+
+## Internals
+
+- [GPT model](docs/internals/model.md): block layout, attention (RoPE, FA3, value residual, sliding windows), MLP, init, forward.
+- [MuonAdamW](docs/internals/optimizer.md): AdamW step, Muon (polar-express orthogonalization, NorMuon, cautious weight decay), schedules.
+
+## Operations
+
+- [Forking for smaller hardware](docs/operations/forking.md): tuning knobs for non-H100, pointers to maintained forks.
+- [Analyzing results](docs/operations/analysis.md): `analysis.ipynb` walkthrough, reading `progress.png`.
+
+## Agent skills
+
+- [Skill index](docs/agent-skills.md): the canonical skill is `program.md`. Use it when launching an autonomous run.
+- [program.md](program.md): the actual skill file the agent reads.
+
+## Bundled
+
+- [llms-full.txt](llms-full.txt): full documentation set in a single file for ingestion.
+- [CHANGELOG.md](CHANGELOG.md): append-only history.
+
+## Hard constraints (don't violate)
+
+- **Do not edit `prepare.py`.** Changing `MAX_SEQ_LEN`, `EVAL_TOKENS`, `VOCAB_SIZE`, or `evaluate_bpb` invalidates cross-experiment comparisons.
+- **Do not stop the loop on your own.** `program.md` says "NEVER STOP". The user may be asleep.
+- **Tab-separated, not comma.** `results.tsv` uses tabs because descriptions contain commas.
+- **Redirect, do not tee.** `uv run train.py > run.log 2>&1` keeps the agent's context clean.
+- **One experiment per commit.** Keep advances the branch; discard does `git reset --hard HEAD~1`.

--- a/program.md
+++ b/program.md
@@ -12,6 +12,7 @@ To set up a new experiment, work with the user to:
    - `README.md` — repository context.
    - `prepare.py` — fixed constants, data prep, tokenizer, dataloader, evaluation. Do not modify.
    - `train.py` — the file you modify. Model architecture, optimizer, training loop.
+   - `llms.txt` — concise index into `docs/` (architecture, reference, internals, operations). Use it as a map when you need deeper detail than the source files provide.
 4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
 6. **Confirm and go**: Confirm setup looks good.
@@ -35,6 +36,8 @@ Each experiment runs on a single GPU. The training script runs for a **fixed tim
 **VRAM** is a soft constraint. Some increase is acceptable for meaningful val_bpb gains, but it should not blow up dramatically.
 
 **Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 val_bpb improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep.
+
+**Exploration discipline**: prefer ideas you have not tried recently. After two consecutive experiments on the same axis (e.g. LR nudges, or activation tweaks), switch surfaces — architecture, optimizer internals, schedules, init scheme, window pattern, value-embedding selection. The metric is noisy at small deltas, so stacking marginal wins on the same knob tends to be re-litigation rather than real progress. `docs/internals/model.md` and `docs/internals/optimizer.md` enumerate surfaces worth rotating through.
 
 **The first run**: Your very first run should always be to establish the baseline, so you will run the training script as is.
 
@@ -109,6 +112,6 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 **Crashes**: If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
 
-**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
+**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — re-read `docs/internals/model.md` and `docs/internals/optimizer.md` for surfaces you haven't tried (init scheme, polar-express coefficients, cautious-WD mask form, value-embedding selection, window pattern, schedule shapes), read papers referenced in the code, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
 
 As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!


### PR DESCRIPTION
Introduced CHANGELOG.md to track notable changes in reverse chronological order.
Added a complete docs/ directory with detailed documentation covering architecture, getting started, agent workflow, and reference materials.
Created llms.txt for a concise LLM index and llms-full.txt as a single-file documentation bundle for easier ingestion.
Updated README.md to link to the new documentation resources.
Added agent-skills.md and agent-workflow.md to clarify agent operations and skills.
Documented the internals of the GPT model and the MuonAdamW optimizer in internals/ directory.
Documentation auto-generated using [adamdroberts/agent-skills/deep-documentation](https://github.com/adamdroberts/agent-skills/blob/main/deep-documentation/SKILL.md) skill

No code changes; all modifications are related to documentation and organization.

This should improve the auto-research functionality by giving it more concise documentation or at least, reduce the required tokens to get started, less code base analysis required as its already complete. - Docs automatically self-generate on new changes.

Add minor change to program.md to point to the LLMs.txt