### PR TITLE
fix(pyproject): specify py-modules to fix setuptools editable install discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ torch = [
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
 explicit = true
+
+[tool.setuptools]
+py-modules = ["train", "prepare"]


### PR DESCRIPTION
Explicitly defines py-modules in pyproject.toml under [tool.setuptools] to resolve the setuptools flat-layout discovery error when installing in editable mode (Fixes #387).