### PR TITLE
fix(train): save model checkpoint before evaluation to prevent losing results on eval crash

### DIFF
--- a/train.py
+++ b/train.py
@@ -609,8 +609,14 @@ total_tokens = step * TOTAL_BATCH_SIZE
 
 # Final eval
 model.eval()
+checkpoint_path = "checkpoint_preeval.pt"
+torch.save(model.state_dict(), checkpoint_path)
 with autocast_ctx:
     val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+
+# Clean up checkpoint if evaluation succeeded
+if os.path.exists(checkpoint_path):
+    os.remove(checkpoint_path)
 
 # Final summary
 t_end = time.time()


### PR DESCRIPTION
Saves model state dict to checkpoint_preeval.pt right after the training loop finishes and before evaluation begins. The checkpoint is deleted on successful evaluation, preserving it on evaluation crashes or OOMs for recovery/debugging (Fixes #7).