### PR TITLE
fix(train): reduce rotary embedding sequence length to sequence_len

### DIFF
--- a/train.py
+++ b/train.py
@@ -141,7 +141,7 @@ class GPT(nn.Module):
             for i in range(config.n_layer) if has_ve(i, config.n_layer)
         })
         # Rotary embeddings
-        self.rotary_seq_len = config.sequence_len * 10
+        self.rotary_seq_len = config.sequence_len
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.register_buffer("cos", cos, persistent=False)
         self.register_buffer("sin", sin, persistent=False)


### PR DESCRIPTION
Resolves #6. Pre-allocating 10x more sequence length memory than needed for rotary embeddings in GPT.__init__() wastes GPU memory. This change sets self.rotary_seq_len to config.sequence_len, reducing rotary buffer memory by 90% with zero impact on training/evaluation (which are bounded by MAX_SEQ_LEN).