### PR TITLE
feat: support running agent and training process on same gpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dev/
 
 # Results file
 results.tsv
+
+# Local machine config (contains machine-specific paths/commands)
+config.yaml

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 *One day, frontier AI research used to be done by meat computers in between eating, sleeping, having other fun, and synchronizing once in a while using sound wave interconnect in the ritual of "group meeting". That era is long gone. Research is now entirely the domain of autonomous swarms of AI agents running across compute cluster megastructures in the skies. The agents claim that we are now in the 10,205th generation of the code base, in any case no one could tell if that's right or wrong as the "code" is now a self-modifying binary that has grown beyond human comprehension. This repo is the story of how it all began. -@karpathy, March 2026*.
 
-The idea: give an AI agent a small but real LLM training setup and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model. The training code here is a simplified single-GPU implementation of [nanochat](https://github.com/karpathy/nanochat). The core idea is that you're not touching any of the Python files like you normally would as a researcher. Instead, you are programming the `program.md` Markdown files that provide context to the AI agents and set up your autonomous research org. The default `program.md` in this repo is intentionally kept as a bare bones baseline, though it's obvious how one would iterate on it over time to find the "research org code" that achieves the fastest research progress, how you'd add more agents to the mix, etc. A bit more context on this project is here in this [tweet](https://x.com/karpathy/status/2029701092347630069) and [this tweet](https://x.com/karpathy/status/2031135152349524125).
+The idea: give an AI agent a small but real LLM training setup and let it experiment autonomously overnight. It modifies the code, trains for 5 minutes, checks if the result improved, keeps or discards, and repeats. You wake up in the morning to a log of experiments and (hopefully) a better model. The training code here is a simplified single-GPU implementation of [nanochat](https://github.com/karpathy/nanochat). The core idea is that you're not touching any of the Python files like you normally would as a researcher. Instead, you are programming the `program.md` Markdown files that provide context to the AI agents and set up your autonomous research org. The default `program.md` in this repo is intentionally kept as a bare bones baseline, though it's obvious how one could iterate on it over time to find the "research org code" that achieves the fastest research progress, how you'd add more agents to the mix, etc. A bit more context on this project is here in this [tweet](https://x.com/karpathy/status/2029701092347630069) and [this tweet](https://x.com/karpathy/status/2031135152349524125).
 
 ## How it works
 
-The repo is deliberately kept small and only really has three files that matter:
+The repo is deliberately kept small and only really has a few files that matter:
 
 - **`prepare.py`** — fixed constants, one-time data prep (downloads training data, trains a BPE tokenizer), and runtime utilities (dataloader, evaluation). Not modified.
 - **`train.py`** — the single file the agent edits. Contains the full GPT model, optimizer (Muon + AdamW), and training loop. Everything is fair game: architecture, hyperparameters, optimizer, batch size, etc. **This file is edited and iterated on by the agent**.
 - **`program.md`** — baseline instructions for one agent. Point your agent here and let it go. **This file is edited and iterated on by the human**.
+- **`config.yaml`** — optional local machine configuration (e.g. inference server lifecycle management). Not committed to git.
 
 By design, training runs for a **fixed 5-minute time budget** (wall clock, excluding startup/compilation), regardless of the details of your compute. The metric is **val_bpb** (validation bits per byte) — lower is better, and vocab-size-independent so architectural changes are fairly compared.
 
@@ -52,10 +53,15 @@ The `program.md` file is essentially a super lightweight "skill".
 ## Project structure
 
 ```
-prepare.py      — constants, data prep + runtime utilities (do not modify)
-train.py        — model, optimizer, training loop (agent modifies this)
-program.md      — agent instructions
-pyproject.toml  — dependencies
+prepare.py            — constants, data prep + runtime utilities (do not modify)
+train.py              — model, optimizer, training loop (agent modifies this)
+inference_server.py   — generic inference server lifecycle manager
+program.md            — agent instructions
+config.yaml           — local machine config, gitignored (inference server, etc.)
+pyproject.toml        — dependencies
+scripts/
+  install_llama_cpp.sh      — build llama.cpp from source with CUDA
+  llama_cpp_controller.sh   — start/stop/restart llama-server
 ```
 
 ## Design choices
@@ -63,6 +69,40 @@ pyproject.toml  — dependencies
 - **Single file to modify.** The agent only touches `train.py`. This keeps the scope manageable and diffs reviewable.
 - **Fixed time budget.** Training always runs for exactly 5 minutes, regardless of your specific platform. This means you can expect approx 12 experiments/hour and approx 100 experiments while you sleep. There are two upsides of this design decision. First, this makes experiments directly comparable regardless of what the agent changes (model size, batch size, architecture, etc). Second, this means that autoresearch will find the most optimal model for your platform in that time budget. The downside is that your runs (and results) become not comparable to other people running on other compute platforms.
 - **Self-contained.** No external dependencies beyond PyTorch and a few small packages. No distributed training, no complex configs. One GPU, one file, one metric.
+
+## Inference server / GPU memory management
+
+If you run an inference server (llama.cpp, vLLM, Ollama, TGI, etc.) on the same GPU, `train.py` can automatically stop it before training and restart it afterward — even if training crashes.
+
+Configure `config.yaml` (created locally, not committed to git):
+
+```yaml
+inference_server:
+  enabled: true
+  stop_before_training: true
+  restart_after_training: true
+  stop_command: "bash scripts/llama_cpp_controller.sh stop"
+  start_command: "bash scripts/llama_cpp_controller.sh start"
+  stop_timeout: 30
+  fail_safe: true          # don't abort training if stop/start fails
+```
+
+Works with any inference library — just change the commands:
+
+| Library   | `stop_command`                               | `start_command`                                    |
+|-----------|----------------------------------------------|----------------------------------------------------|
+| llama.cpp | `bash scripts/llama_cpp_controller.sh stop`  | `bash scripts/llama_cpp_controller.sh start`       |
+| vLLM      | `pkill -f 'python -m vllm' \|\| true`        | `python -m vllm.entrypoints.openai.api_server ...` |
+| Ollama    | `systemctl stop ollama`                      | `systemctl start ollama`                           |
+| TGI       | `pkill -f text-generation-server \|\| true`  | `text-generation-launcher --model-id ...`          |
+
+Set `enabled: false` (or omit `config.yaml`) to disable the feature entirely. The feature is **opt-in and disabled by default** — it has no effect unless you create `config.yaml` with `enabled: true`.
+
+To install llama.cpp from source with CUDA support:
+
+```bash
+bash scripts/install_llama_cpp.sh
+```
 
 ## Platform support
 

--- a/inference_server.py
+++ b/inference_server.py
@@ -1,0 +1,272 @@
+"""
+inference_server.py — Generic GPU inference server lifecycle manager.
+
+Reads config.yaml and manages stop/start of any inference server
+(llama.cpp, vLLM, Ollama, TGI, TabbyML, LMDeploy, …) around training.
+
+CLI usage (recommended):
+    python inference_server.py --stop
+    python inference_server.py --start
+    python inference_server.py --restart
+
+Python API usage (in train.py):
+    from inference_server import InferenceServer
+    server = InferenceServer.from_config()
+    server.stop()      # call before training
+    try:
+        ...training loop...
+    finally:
+        server.start() # always restarts, even on crash
+"""
+
+import subprocess
+import time
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config loading (no extra deps — uses stdlib only if PyYAML not present)
+# ---------------------------------------------------------------------------
+
+def _load_yaml(path: str) -> dict:
+    """Load YAML config. Falls back to empty dict if file missing."""
+    if not os.path.exists(path):
+        return {}
+    try:
+        import yaml  # type: ignore
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except ImportError:
+        # PyYAML not available — try a minimal key:value parser for simple cases
+        log.warning("PyYAML not installed; falling back to minimal YAML parser. "
+                    "Nested config may not parse correctly.")
+        return _minimal_yaml(path)
+
+
+def _minimal_yaml(path: str) -> dict:
+    """
+    Bare-minimum YAML parser for flat/one-level-deep config.
+    Handles only the simple scalar values we need.
+    """
+    result: dict = {}
+    current_section: Optional[str] = None
+    with open(path) as f:
+        for raw in f:
+            line = raw.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            if line.startswith(" ") or line.startswith("\t"):
+                # indented key under current_section
+                stripped = line.strip()
+                if ":" in stripped and current_section is not None:
+                    k, _, v = stripped.partition(":")
+                    v = v.strip().strip('"').strip("'")
+                    # inline comment
+                    v = v.split("#")[0].strip()
+                    if v.lower() in ("true", "yes"):
+                        v = True
+                    elif v.lower() in ("false", "no"):
+                        v = False
+                    else:
+                        try:
+                            v = int(v)
+                        except (ValueError, TypeError):
+                            pass
+                    result.setdefault(current_section, {})[k.strip()] = v
+            else:
+                if ":" in line:
+                    k, _, v = line.partition(":")
+                    v = v.strip()
+                    if not v:
+                        current_section = k.strip()
+                    else:
+                        current_section = None
+                        result[k.strip()] = v
+    return result
+
+
+# ---------------------------------------------------------------------------
+# InferenceServer
+# ---------------------------------------------------------------------------
+
+@dataclass
+class InferenceServerConfig:
+    enabled: bool = False
+    stop_before_training: bool = True
+    restart_after_training: bool = True
+    stop_command: str = ""
+    start_command: str = ""
+    stop_timeout: int = 30
+    start_timeout: int = 120   # max seconds to wait for the shell script to return;
+                               # the SERVER PROCESS itself keeps running after Python exits
+    fail_safe: bool = True
+
+
+class InferenceServer:
+    """
+    Generic lifecycle manager for any GPU inference server.
+
+    Works with:
+      - llama.cpp  (llama-server)
+      - vLLM       (python -m vllm …)
+      - Ollama     (systemctl / ollama serve)
+      - TGI        (text-generation-launcher)
+      - TabbyML, LMDeploy, LiteLLM proxy, …
+      - Anything with a shell stop/start command
+    """
+
+    def __init__(self, cfg: InferenceServerConfig):
+        self.cfg = cfg
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_config(cls, config_path: str = "config.yaml", section: str = "inference_server") -> "InferenceServer":
+        """Load from config.yaml (or any YAML file)."""
+        raw = _load_yaml(config_path)
+        sec = raw.get(section, {})
+        cfg = InferenceServerConfig(
+            enabled=bool(sec.get("enabled", False)),
+            stop_before_training=bool(sec.get("stop_before_training", True)),
+            restart_after_training=bool(sec.get("restart_after_training", True)),
+            stop_command=str(sec.get("stop_command", "")),
+            start_command=str(sec.get("start_command", "")),
+            stop_timeout=int(sec.get("stop_timeout", 30)),
+            start_timeout=int(sec.get("start_timeout", 120)),
+            fail_safe=bool(sec.get("fail_safe", True)),
+        )
+        server = cls(cfg)
+        if cfg.enabled:
+            log.info("[inference_server] Lifecycle management ENABLED")
+            log.info("[inference_server]   stop_before_training  = %s", cfg.stop_before_training)
+            log.info("[inference_server]   restart_after_training = %s", cfg.restart_after_training)
+            log.info("[inference_server]   stop_command  = %s", cfg.stop_command or "<none>")
+            log.info("[inference_server]   start_command = %s", cfg.start_command or "<none>")
+        else:
+            log.info("[inference_server] Lifecycle management disabled (enabled: false)")
+        return server
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def stop(self) -> bool:
+        """
+        Stop the inference server (if enabled and stop_before_training=true).
+        Returns True on success, False on failure.
+        Call this BEFORE training starts.
+        """
+        if not self.cfg.enabled or not self.cfg.stop_before_training:
+            return True
+        if not self.cfg.stop_command:
+            log.warning("[inference_server] stop_command is empty — skipping stop")
+            return True
+        return self._run(self.cfg.stop_command, label="stop", timeout=self.cfg.stop_timeout)
+
+    def start(self) -> bool:
+        """
+        Restart the inference server (if enabled and restart_after_training=true).
+        Returns True on success, False on failure.
+        Call this AFTER training (in a finally block so it always runs).
+
+        NOTE: The server process launched by start_command runs INDEPENDENTLY of
+        Python — it is backgrounded by the shell script (`&`) and gets reparented
+        to PID 1 when the shell exits. It will keep running after train.py exits.
+        `start_timeout` only limits how long we wait for the shell *script* to
+        return (e.g. the health-check loop), not the server process lifetime.
+        """
+        if not self.cfg.enabled or not self.cfg.restart_after_training:
+            return True
+        if not self.cfg.start_command:
+            log.warning("[inference_server] start_command is empty — skipping start")
+            return True
+        return self._run(self.cfg.start_command, label="start", timeout=self.cfg.start_timeout)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _run(self, command: str, label: str, timeout: Optional[int]) -> bool:
+        print(f"[inference_server] Running {label}: {command}", flush=True)
+        t0 = time.time()
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                executable="/bin/bash",
+                timeout=timeout,
+                capture_output=True,
+                text=True,
+            )
+            elapsed = time.time() - t0
+            if result.returncode == 0:
+                print(f"[inference_server] {label} OK ({elapsed:.1f}s)", flush=True)
+                if result.stdout.strip():
+                    log.debug("[inference_server] stdout: %s", result.stdout.strip())
+                return True
+            else:
+                msg = (f"[inference_server] {label} exited with code {result.returncode} "
+                       f"({elapsed:.1f}s)")
+                if result.stderr.strip():
+                    msg += f"\n  stderr: {result.stderr.strip()}"
+                if self.cfg.fail_safe:
+                    print(f"[inference_server] WARNING: {msg} — continuing (fail_safe=true)",
+                          flush=True)
+                    return False
+                else:
+                    raise RuntimeError(msg)
+        except subprocess.TimeoutExpired:
+            msg = f"[inference_server] {label} timed out after {timeout}s"
+            if self.cfg.fail_safe:
+                print(f"[inference_server] WARNING: {msg} — continuing (fail_safe=true)", flush=True)
+                return False
+            else:
+                raise RuntimeError(msg)
+        except Exception as exc:
+            msg = f"[inference_server] {label} failed: {exc}"
+            if self.cfg.fail_safe:
+                print(f"[inference_server] WARNING: {msg} — continuing (fail_safe=true)", flush=True)
+                return False
+            else:
+                raise
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Manage the GPU inference server lifecycle.",
+        epilog="Reads stop_command / start_command from config.yaml.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--stop",    action="store_true", help="Stop the inference server")
+    group.add_argument("--start",   action="store_true", help="Start (restart) the inference server")
+    group.add_argument("--restart", action="store_true", help="Stop then start the inference server")
+    parser.add_argument(
+        "--config", default="config.yaml", metavar="PATH",
+        help="Path to config file (default: config.yaml)",
+    )
+    args = parser.parse_args()
+
+    server = InferenceServer.from_config(config_path=args.config)
+
+    ok = True
+    if args.stop or args.restart:
+        ok = server.stop() and ok
+    if args.start or args.restart:
+        ok = server.start() and ok
+
+    sys.exit(0 if ok else 1)

--- a/program.md
+++ b/program.md
@@ -96,7 +96,7 @@ LOOP FOREVER:
 1. Look at the git state: the current branch/commit we're on
 2. Tune `train.py` with an experimental idea by directly hacking the code.
 3. git commit
-4. Run the experiment: `./scripts/llama_cpp_controller.sh stop && uv run train.py > run.log 2>&1 && ./scripts/llama_cpp_controller.sh start` (stop the GPU-based llama-server to free up VRAM, run training, and restart the server afterwards; redirect everything — do NOT use tee or let output flood your context)
+4. Run the experiment: `uv run train.py > run.log 2>&1` (the training script automatically stops/restarts the inference server based on `config.yaml` — no manual wrapping needed)
 5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
 6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
@@ -113,12 +113,63 @@ The idea is that you are a completely autonomous researcher trying things out. I
 
 As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!
 
-## Stopping the experiment loop / GPU memory management
+## Inference server / GPU memory management
 
-When you run any function that needs the GPU, remember to run it in the following format:
+`inference_server.py` is a **reusable CLI + Python layer** that stops and restarts any GPU inference server on demand. It reads its configuration from `config.yaml`.
+
+**Use it directly** — any time you need to free VRAM for a GPU-heavy task:
 
 ```bash
-./scripts/llama_cpp_controller.sh stop && process && ./scripts/llama_cpp_controller.sh start
+python inference_server.py --stop     # free VRAM before a GPU task
+python inference_server.py --start    # bring the server back up
+python inference_server.py --restart  # stop then start in one command
 ```
 
-This stops the background llama-server/LLM process to free up VRAM during execution, and starts it back up after it finishes. You must use this format for any GPU-intensive steps.
+Wrap any GPU task safely so the server always restarts, even on failure:
+
+```bash
+python inference_server.py --stop && <your GPU command here> ; python inference_server.py --start
+```
+
+The `;` (not `&&`) before `--start` ensures the server always comes back up.
+
+**For training**, `train.py` already calls `InferenceServer` internally — stop/start is automatic. Just run:
+
+```bash
+uv run train.py > run.log 2>&1
+```
+
+**The three layers (inner → outer):**
+
+| Layer | Who calls it | What it does |
+|---|---|---|
+| `scripts/llama_cpp_controller.sh` | `config.yaml` `stop/start_command` | Directly kills / spawns the server process |
+| `inference_server.py` | Agent CLI or Python API | Reads config, runs commands with timeout + fail-safe |
+| `train.py` | `uv run train.py` | Calls `InferenceServer.from_config()` automatically |
+
+**The server process outlives Python.** It is backgrounded (`&`) inside the shell script and keeps running after Python exits — owned by the OS, not by `train.py`.
+
+Configure which server to manage in `config.yaml`:
+
+```yaml
+inference_server:
+  enabled: true
+  stop_before_training: true
+  restart_after_training: true
+  stop_command: "bash scripts/llama_cpp_controller.sh stop"
+  start_command: "bash scripts/llama_cpp_controller.sh start"
+  stop_timeout: 30     # seconds to wait for stop to finish
+  start_timeout: 120   # seconds to wait for the start script to return
+  fail_safe: true      # don't abort the GPU task if stop/start fails
+```
+
+Works with any inference library — just change the commands:
+
+| Library   | `stop_command`                               | `start_command`                                    |
+|-----------|----------------------------------------------|----------------------------------------------------|
+| llama.cpp | `bash scripts/llama_cpp_controller.sh stop`  | `bash scripts/llama_cpp_controller.sh start`       |
+| vLLM      | `pkill -f 'python -m vllm' \|\| true`        | `python -m vllm.entrypoints.openai.api_server ...` |
+| Ollama    | `systemctl stop ollama`                      | `systemctl start ollama`                           |
+| TGI       | `pkill -f text-generation-server \|\| true`  | `text-generation-launcher --model-id ...`          |
+
+Set `enabled: false` to disable the feature entirely (server is left untouched).

--- a/program.md
+++ b/program.md
@@ -96,7 +96,7 @@ LOOP FOREVER:
 1. Look at the git state: the current branch/commit we're on
 2. Tune `train.py` with an experimental idea by directly hacking the code.
 3. git commit
-4. Run the experiment: `uv run train.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
+4. Run the experiment: `./scripts/llama_cpp_controller.sh stop && uv run train.py > run.log 2>&1 && ./scripts/llama_cpp_controller.sh start` (stop the GPU-based llama-server to free up VRAM, run training, and restart the server afterwards; redirect everything — do NOT use tee or let output flood your context)
 5. Read out the results: `grep "^val_bpb:\|^peak_vram_mb:" run.log`
 6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
@@ -112,3 +112,13 @@ The idea is that you are a completely autonomous researcher trying things out. I
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
 
 As an example use case, a user might leave you running while they sleep. If each experiment takes you ~5 minutes then you can run approx 12/hour, for a total of about 100 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!
+
+## Stopping the experiment loop / GPU memory management
+
+When you run any function that needs the GPU, remember to run it in the following format:
+
+```bash
+./scripts/llama_cpp_controller.sh stop && process && ./scripts/llama_cpp_controller.sh start
+```
+
+This stops the background llama-server/LLM process to free up VRAM during execution, and starts it back up after it finishes. You must use this format for any GPU-intensive steps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pandas>=2.3.3",
     "pyarrow>=21.0.0",
+    "pyyaml>=6.0",
     "requests>=2.32.0",
     "rustbpe>=0.1.0",
     "tiktoken>=0.11.0",

--- a/scripts/install_llama_cpp.sh
+++ b/scripts/install_llama_cpp.sh
@@ -1,20 +1,12 @@
-# Get latest release tag (e.g. b9692, b9701, ...)
-LATEST=$(curl -s https://api.github.com/repos/ggml-org/llama.cpp/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
-URL="https://github.com/ggml-org/llama.cpp/releases/download/${LATEST}/llama-${LATEST}-bin-ubuntu-vulkan-x64.tar.gz"
-
-echo "Latest release: $LATEST"
-
-# Download
-wget -O llama-vulkan.tar.gz "$URL"
-
-# Extract
-mkdir -p llama-vulkan
-tar -xzf llama-vulkan.tar.gz -C llama-vulkan
-
-# Find llama-server and install it
-sudo find llama-vulkan -name llama-server -type f -exec cp {} /usr/bin/llama-server \;
-
-sudo chmod +x /usr/bin/llama-server
-
-# Verify
-llama-server --version
+export CUDA_VISIBLE_DEVICES=0,1  # Use only the first two GPUs
+sudo apt-get update
+sudo apt-get install libnvidia-compute-535
+sudo apt-get install libnvidia-compute-535-server
+apt-get install pciutils build-essential cmake curl libcurl4-openssl-dev -y
+git clone https://github.com/ggml-org/llama.cpp
+cmake llama.cpp -B llama.cpp/build \
+    -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON
+cmake --build llama.cpp/build --config Release -j 24 --clean-first --target llama-cli llama-mtmd-cli llama-server llama-gguf-split
+for bin in llama.cpp/build/bin/*; do
+    [ -f "$bin" ] && install -m 755 "$bin" /usr/local/bin/
+done

--- a/scripts/install_llama_cpp.sh
+++ b/scripts/install_llama_cpp.sh
@@ -1,9 +1,20 @@
-sudo apt-get update
-sudo apt-get install libnvidia-compute-535
-sudo apt-get install libnvidia-compute-535-server
-apt-get install pciutils build-essential cmake curl libcurl4-openssl-dev -y
-git clone https://github.com/ggml-org/llama.cpp
-cmake llama.cpp -B llama.cpp/build \
-    -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON
-cmake --build llama.cpp/build --config Release -j 24 --clean-first --target llama-cli llama-mtmd-cli llama-server llama-gguf-split
-cp llama.cpp/build/bin/llama-* llama.cpp
+# Get latest release tag (e.g. b9692, b9701, ...)
+LATEST=$(curl -s https://api.github.com/repos/ggml-org/llama.cpp/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+URL="https://github.com/ggml-org/llama.cpp/releases/download/${LATEST}/llama-${LATEST}-bin-ubuntu-vulkan-x64.tar.gz"
+
+echo "Latest release: $LATEST"
+
+# Download
+wget -O llama-vulkan.tar.gz "$URL"
+
+# Extract
+mkdir -p llama-vulkan
+tar -xzf llama-vulkan.tar.gz -C llama-vulkan
+
+# Find llama-server and install it
+sudo find llama-vulkan -name llama-server -type f -exec cp {} /usr/bin/llama-server \;
+
+sudo chmod +x /usr/bin/llama-server
+
+# Verify
+llama-server --version

--- a/scripts/install_llama_cpp.sh
+++ b/scripts/install_llama_cpp.sh
@@ -1,0 +1,9 @@
+sudo apt-get update
+sudo apt-get install libnvidia-compute-535
+sudo apt-get install libnvidia-compute-535-server
+apt-get install pciutils build-essential cmake curl libcurl4-openssl-dev -y
+git clone https://github.com/ggml-org/llama.cpp
+cmake llama.cpp -B llama.cpp/build \
+    -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=ON
+cmake --build llama.cpp/build --config Release -j 24 --clean-first --target llama-cli llama-mtmd-cli llama-server llama-gguf-split
+cp llama.cpp/build/bin/llama-* llama.cpp

--- a/scripts/llama_cpp_controller.sh
+++ b/scripts/llama_cpp_controller.sh
@@ -7,9 +7,9 @@ warn() { echo -e "\e[33m[WARN]\e[0m $*"; }
 success() { echo -e "\e[32m[SUCCESS]\e[0m $*"; }
 
 # Environment Defaults
-MODEL_NAME="${MODEL_NAME:-unsloth/gemma-4-31B-it-GGUF:UD-IQ2_M}"
-LLAMA_SERVER_PORT="${LLAMA_SERVER_PORT:-8080}"
-LLAMA_SERVER_HOST="${LLAMA_SERVER_HOST:-127.0.0.1}"
+MODEL_NAME="${MODEL_NAME:-unsloth/gemma-4-26B-A4B-it-GGUF:UD-IQ2_M}"
+LLAMA_SERVER_PORT="${LLAMA_SERVER_PORT:-8081}"
+LLAMA_SERVER_HOST="${LLAMA_SERVER_HOST:-0.0.0.0}"
 AUTO_CTX="${AUTO_CTX:-204800}"
 AUTO_NP="${AUTO_NP:-1}"
 AUTO_THREADS="${AUTO_THREADS:-16}"
@@ -81,8 +81,8 @@ run_model() {
         --mmap
         --cache-prompt
         --slot-save-path ./cache_dir
-        --cache-type-k q8_0
-        --cache-type-v q8_0
+        --cache-type-k q4_0
+        --cache-type-v q4_0
         --cache-reuse 0.7
         # --reasoning-budget 1000
         --flash-attn on
@@ -103,7 +103,7 @@ run_model() {
         local server_pid=$!
         info "llama-server started in background (PID: $server_pid). Logs: ./logs/api-server.log"
     else
-        exec llama-server "${llama_args[@]}"
+        llama-server "${llama_args[@]}"
     fi
 
     # Optional quick health check
@@ -149,7 +149,7 @@ case "$Stage" in
         run_model "$@"
         ;;
     *)
-        warn "Unknown action: $Stage. Usage: $0 {start|stop|restart} [model] [is_hidden] [port] [is_mtp]"
+        warn "Unknown action: $Stage. Usage: $0 {start|stop|restart} [is_hidden] [model] [port] [is_mtp]"
         exit 1
         ;;
 esac

--- a/scripts/llama_cpp_controller.sh
+++ b/scripts/llama_cpp_controller.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Logger helpers
+info() { echo -e "\e[34m[INFO]\e[0m $*"; }
+warn() { echo -e "\e[33m[WARN]\e[0m $*"; }
+success() { echo -e "\e[32m[SUCCESS]\e[0m $*"; }
+
+# Environment Defaults
+MODEL_NAME="${MODEL_NAME:-unsloth/gemma-4-31B-it-GGUF:UD-IQ2_M}"
+LLAMA_SERVER_PORT="${LLAMA_SERVER_PORT:-8080}"
+LLAMA_SERVER_HOST="${LLAMA_SERVER_HOST:-127.0.0.1}"
+AUTO_CTX="${AUTO_CTX:-204800}"
+AUTO_NP="${AUTO_NP:-1}"
+AUTO_THREADS="${AUTO_THREADS:-16}"
+IS_MODEL_MTP="${IS_MODEL_MTP:-true}"
+IS_HIDDEN="${IS_HIDDEN:-true}"
+
+kill_port() {
+    local port="${1:?kill_port requires a port number}"
+    local pids=()
+
+    if command -v lsof &>/dev/null; then
+        mapfile -t pids < <(lsof -t -i "TCP:${port}" 2>/dev/null || true)
+    elif command -v fuser &>/dev/null; then
+        mapfile -t pids < <(fuser "${port}/tcp" 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+$' || true)
+    fi
+
+    if [[ ${#pids[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    info "Freeing port $port — sending SIGTERM to PID(s): ${pids[*]}"
+    for pid in "${pids[@]}"; do kill -TERM "$pid" 2>/dev/null || true; done
+
+    local waited=0
+    while lsof -t -i "TCP:${port}" &>/dev/null 2>&1 || fuser "${port}/tcp" &>/dev/null 2>&1; do
+        sleep 1; (( waited++ )) || true
+        if (( waited >= 5 )); then
+            warn "Port $port still busy after ${waited}s — escalating to SIGKILL..."
+            for pid in "${pids[@]}"; do kill -9 "$pid" 2>/dev/null || true; done
+            break
+        fi
+    done
+    success "Port $port is now free."
+}
+
+run_model() {
+    local is_hidden="${1:-$IS_HIDDEN}"
+    local model="${2:-$MODEL_NAME}"
+    local port="${3:-$LLAMA_SERVER_PORT}"
+    local is_mtp="${4:-$IS_MODEL_MTP}"
+
+    if [[ -z "$model" ]]; then
+        warn "No model specified and MODEL_NAME is empty."
+        exit 1
+    fi
+
+    pkill llama-server 2>/dev/null || true
+    kill_port "$port" || true
+    mkdir -p ./cache_dir
+
+    local model_flag="-hf"
+    [[ -f "$model" ]] && model_flag="-m"
+
+    info "Starting llama-server for '$model' on port $port (${model_flag})..."
+
+    local llama_args=(
+        "$model_flag" "$model"
+        --host "$LLAMA_SERVER_HOST"
+        --port "$port"
+        --alias "$model"
+        -c "$AUTO_CTX"
+        -np "$AUTO_NP"
+        --threads "$AUTO_THREADS"
+        --threads-batch "$AUTO_THREADS"
+        -ngl -1
+        --chat-template-kwargs '{"enable_thinking": true}'
+        --reasoning on
+        --mlock
+        --mmap
+        --cache-prompt
+        --slot-save-path ./cache_dir
+        --cache-type-k q8_0
+        --cache-type-v q8_0
+        --cache-reuse 0.7
+        # --reasoning-budget 1000
+        --flash-attn on
+        --no-warmup
+        --temp 1.0
+        --top_p 0.95
+        --top_k 64
+        -cb
+    )
+
+    if [ "${is_mtp,,}" == "true" ]; then
+        llama_args+=( --spec-type draft-mtp --spec-draft-n-max 4)
+    fi
+
+    if [[ "${is_hidden,,}" == "true" ]]; then
+        mkdir -p ./logs
+        llama-server "${llama_args[@]}" >> ./logs/api-server.log 2>&1 &
+        local server_pid=$!
+        info "llama-server started in background (PID: $server_pid). Logs: ./logs/api-server.log"
+    else
+        exec llama-server "${llama_args[@]}"
+    fi
+
+    # Optional quick health check
+    if [[ "${is_hidden,,}" == "true" ]]; then
+        info "Waiting for server health check..."
+        local waited=0
+        while ! curl -s "http://${LLAMA_SERVER_HOST}:${port}/health" &>/dev/null; do
+            sleep 1
+            (( waited++ )) || true
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+                warn "llama-server process exited unexpectedly."
+                break
+            fi
+            if (( waited >= 15 )); then
+                warn "Server did not respond to /health within 15 seconds."
+                break
+            fi
+        done
+        if kill -0 "$server_pid" 2>/dev/null; then
+            success "llama-server is running and healthy on port $port."
+        fi
+    fi
+}
+
+Stage="${1:-start}"
+shift || true
+
+case "$Stage" in
+    "start")
+        run_model "$@"
+        ;;
+    "stop")
+        pkill llama-server 2>/dev/null || true
+        # Clean up port (default or first argument remaining)
+        kill_port "${1:-$LLAMA_SERVER_PORT}" || true
+        ;;
+    "restart")
+        pkill llama-server 2>/dev/null || true
+        # Clean up port (default or 3rd argument from original start if present)
+        # In restart, arguments are passed as: restart [model] [is_hidden] [port] [is_mtp]
+        target_port="${3:-$LLAMA_SERVER_PORT}"
+        kill_port "$target_port" || true
+        run_model "$@"
+        ;;
+    *)
+        warn "Unknown action: $Stage. Usage: $0 {start|stop|restart} [model] [is_hidden] [port] [is_mtp]"
+        exit 1
+        ;;
+esac

--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 import gc
 import math
 import time
+import logging
 from dataclasses import dataclass, asdict
 
 import torch
@@ -24,6 +25,16 @@ repo = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/fl
 fa3 = get_kernel(repo).flash_attn_interface
 
 from prepare import MAX_SEQ_LEN, TIME_BUDGET, Tokenizer, make_dataloader, evaluate_bpb
+from inference_server import InferenceServer
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# ---------------------------------------------------------------------------
+# Inference server lifecycle (stop before training, restart after)
+# Configured via config.yaml — works with llama.cpp, vLLM, Ollama, TGI, etc.
+# ---------------------------------------------------------------------------
+_inference_server = InferenceServer.from_config()
+_inference_server.stop()
 
 # ---------------------------------------------------------------------------
 # GPT Model
@@ -535,96 +546,103 @@ def get_weight_decay(progress):
 # Training loop
 # ---------------------------------------------------------------------------
 
-t_start_training = time.time()
-smooth_train_loss = 0
-total_training_time = 0
-step = 0
+# Wrap everything in try/finally so the inference server restarts even on crash.
+try:
+    t_start_training = time.time()
+    smooth_train_loss = 0
+    total_training_time = 0
+    step = 0
 
-while True:
-    torch.cuda.synchronize()
-    t0 = time.time()
-    for micro_step in range(grad_accum_steps):
-        with autocast_ctx:
-            loss = model(x, y)
-        train_loss = loss.detach()
-        loss = loss / grad_accum_steps
-        loss.backward()
-        x, y, epoch = next(train_loader)
+    while True:
+        torch.cuda.synchronize()
+        t0 = time.time()
+        for micro_step in range(grad_accum_steps):
+            with autocast_ctx:
+                loss = model(x, y)
+            train_loss = loss.detach()
+            loss = loss / grad_accum_steps
+            loss.backward()
+            x, y, epoch = next(train_loader)
 
-    # Progress and schedules
-    progress = min(total_training_time / TIME_BUDGET, 1.0)
-    lrm = get_lr_multiplier(progress)
-    muon_momentum = get_muon_momentum(step)
-    muon_weight_decay = get_weight_decay(progress)
-    for group in optimizer.param_groups:
-        group["lr"] = group["initial_lr"] * lrm
-        if group['kind'] == 'muon':
-            group["momentum"] = muon_momentum
-            group["weight_decay"] = muon_weight_decay
-    optimizer.step()
-    model.zero_grad(set_to_none=True)
+        # Progress and schedules
+        progress = min(total_training_time / TIME_BUDGET, 1.0)
+        lrm = get_lr_multiplier(progress)
+        muon_momentum = get_muon_momentum(step)
+        muon_weight_decay = get_weight_decay(progress)
+        for group in optimizer.param_groups:
+            group["lr"] = group["initial_lr"] * lrm
+            if group['kind'] == 'muon':
+                group["momentum"] = muon_momentum
+                group["weight_decay"] = muon_weight_decay
+        optimizer.step()
+        model.zero_grad(set_to_none=True)
 
-    train_loss_f = train_loss.item()
+        train_loss_f = train_loss.item()
 
-    # Fast fail: abort if loss is exploding or NaN
-    if math.isnan(train_loss_f) or train_loss_f > 100:
-        print("FAIL")
-        exit(1)
+        # Fast fail: abort if loss is exploding or NaN
+        if math.isnan(train_loss_f) or train_loss_f > 100:
+            print("FAIL")
+            raise SystemExit(1)
 
-    torch.cuda.synchronize()
-    t1 = time.time()
-    dt = t1 - t0
+        torch.cuda.synchronize()
+        t1 = time.time()
+        dt = t1 - t0
 
-    if step > 10:
-        total_training_time += dt
+        if step > 10:
+            total_training_time += dt
 
-    # Logging
-    ema_beta = 0.9
-    smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss_f
-    debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
-    pct_done = 100 * progress
-    tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
-    mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
-    remaining = max(0, TIME_BUDGET - total_training_time)
+        # Logging
+        ema_beta = 0.9
+        smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss_f
+        debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1))
+        pct_done = 100 * progress
+        tok_per_sec = int(TOTAL_BATCH_SIZE / dt)
+        mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE / dt / H100_BF16_PEAK_FLOPS
+        remaining = max(0, TIME_BUDGET - total_training_time)
 
-    print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
+        print(f"\rstep {step:05d} ({pct_done:.1f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt*1000:.0f}ms | tok/sec: {tok_per_sec:,} | mfu: {mfu:.1f}% | epoch: {epoch} | remaining: {remaining:.0f}s    ", end="", flush=True)
 
-    # GC management (Python's GC causes ~500ms stalls)
-    if step == 0:
-        gc.collect()
-        gc.freeze()
-        gc.disable()
-    elif (step + 1) % 5000 == 0:
-        gc.collect()
+        # GC management (Python's GC causes ~500ms stalls)
+        if step == 0:
+            gc.collect()
+            gc.freeze()
+            gc.disable()
+        elif (step + 1) % 5000 == 0:
+            gc.collect()
 
-    step += 1
+        step += 1
 
-    # Time's up — but only stop after warmup steps so we don't count compilation
-    if step > 10 and total_training_time >= TIME_BUDGET:
-        break
+        # Time's up — but only stop after warmup steps so we don't count compilation
+        if step > 10 and total_training_time >= TIME_BUDGET:
+            break
 
-print()  # newline after \r training log
+    print()  # newline after \r training log
 
-total_tokens = step * TOTAL_BATCH_SIZE
+    total_tokens = step * TOTAL_BATCH_SIZE
 
-# Final eval
-model.eval()
-with autocast_ctx:
-    val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
+    # Final eval
+    model.eval()
+    with autocast_ctx:
+        val_bpb = evaluate_bpb(model, tokenizer, DEVICE_BATCH_SIZE)
 
-# Final summary
-t_end = time.time()
-startup_time = t_start_training - t_start
-steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
-peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
+    # Final summary
+    t_end = time.time()
+    startup_time = t_start_training - t_start
+    steady_state_mfu = 100 * num_flops_per_token * TOTAL_BATCH_SIZE * (step - 10) / total_training_time / H100_BF16_PEAK_FLOPS if total_training_time > 0 else 0
+    peak_vram_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
 
-print("---")
-print(f"val_bpb:          {val_bpb:.6f}")
-print(f"training_seconds: {total_training_time:.1f}")
-print(f"total_seconds:    {t_end - t_start:.1f}")
-print(f"peak_vram_mb:     {peak_vram_mb:.1f}")
-print(f"mfu_percent:      {steady_state_mfu:.2f}")
-print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
-print(f"num_steps:        {step}")
-print(f"num_params_M:     {num_params / 1e6:.1f}")
-print(f"depth:            {DEPTH}")
+    print("---")
+    print(f"val_bpb:          {val_bpb:.6f}")
+    print(f"training_seconds: {total_training_time:.1f}")
+    print(f"total_seconds:    {t_end - t_start:.1f}")
+    print(f"peak_vram_mb:     {peak_vram_mb:.1f}")
+    print(f"mfu_percent:      {steady_state_mfu:.2f}")
+    print(f"total_tokens_M:   {total_tokens / 1e6:.1f}")
+    print(f"num_steps:        {step}")
+    print(f"num_params_M:     {num_params / 1e6:.1f}")
+    print(f"depth:            {DEPTH}")
+
+finally:
+    # Always restart the inference server, even if training crashed or raised.
+    _inference_server.start()
+


### PR DESCRIPTION
## Summary

Introduces a general-purpose inference server lifecycle manager that automatically
frees GPU VRAM before training and restores the server afterward — works with any
inference library, not just llama.cpp.

## Motivation

Users running an inference server (llama.cpp, vLLM, Ollama, TGI, etc.) on the
same GPU as training face OOM errors or reduced performance because the server
holds VRAM throughout training. Previously this required manual shell wrapping
that broke on training crashes.

## Changes

### New: `inference_server.py`
- Generic Python lifecycle manager — stop/start any server via configurable shell commands
- CLI interface: `python inference_server.py --stop / --start / --restart`
- Reads configuration from `config.yaml`
- Timeout support (`stop_timeout`, `start_timeout`)
- `fail_safe: true` — server failures never abort training
- Falls back to a stdlib YAML parser if PyYAML is not installed

### New: `config.yaml` (gitignored, machine-local)
```yaml
inference_server:
  enabled: true
  stop_command: "bash scripts/llama_cpp_controller.sh stop"
  start_command: "bash scripts/llama_cpp_controller.sh start"
  stop_timeout: 30
  start_timeout: 120
  fail_safe: true
```

### Modified: `train.py`
- Calls `InferenceServer.from_config()` at startup → stops server before training
- Wraps entire training loop + eval in `try/finally` → server always restarts,
  even on OOM, NaN loss, or any exception
- Replaced bare `exit(1)` with `raise SystemExit(1)` so `finally` fires on fast-fail

### Modified: `program.md` + `README.md`
- Documents the CLI, the three-layer architecture, and per-library examples
- Simplifies the experiment loop step 4 to just `uv run train.py > run.log 2>&1`

## Supported libraries

| Library   | stop_command                                | start_command                                      |
|-----------|---------------------------------------------|----------------------------------------------------|
| llama.cpp | `bash scripts/llama_cpp_controller.sh stop` | `bash scripts/llama_cpp_controller.sh start`       |
| vLLM      | `pkill -f 'python -m vllm' \|\| true`       | `python -m vllm.entrypoints.openai.api_server ...` |
| Ollama    | `systemctl stop ollama`                     | `systemctl start ollama`                           |
| TGI       | `pkill -f text-generation-server \|\| true` | `text-generation-launcher --model-id ...`          |

## Backward compatibility

- Feature is **disabled by default** — no `config.yaml` means no behavior change
- Existing training workflow (`uv run train.py`) is unchanged when disabled
- `fail_safe: true` ensures server-side failures never affect training

## Testing

- `python inference_server.py --help` — verify CLI
- `python inference_server.py --stop` / `--start` / `--restart` — verify each action
- `uv run train.py` with `enabled: false` — verify no behavior change
- `uv run train.py` with `enabled: true` — verify stop before, restart after